### PR TITLE
feat: make ceresmeta runnable in cluster mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,3 @@ test: install-tools
 
 build: check
 	@ go build -o ceresmeta ./cmd/meta/...
-

--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,6 @@ test: install-tools
 	@ echo "go test ..."
 	@ go test -timeout 5m -race -cover $(PACKAGES)
 
-# TODO: support build rule
 build: check
+	@ go build -o ceresmeta ./cmd/meta/...
+

--- a/README.md
+++ b/README.md
@@ -7,23 +7,6 @@ CeresMeta is the meta service for managing the CeresDB cluster.
 ## Status
 The project is in a very early stage.
 
-## Run
-A simple cluster with three nodes can be run in the single machine.
-
-Prepare the data directories:
-```bash
-mkdir /tmp/ceresmeta0 /tmp/ceresmeta1 /tmp/ceresmeta2
-```
-
-Run the three commands in three terminals:
-```bash
-./ceresmeta -etcd-start-timeout-ms 1000000 -peer-urls "http://127.0.0.1:2380" -advertise-client-urls "http://127.0.0.1:2379" -advertise-peer-urls "http://127.0.0.1:2380" -client-urls "http://127.0.0.1:2379" -wal-dir /tmp/ceresmeta0/wal -data-dir /tmp/ceresmeta0/data -node-name "meta0"  -etcd-log-file /tmp/ceresmeta0/etcd.log -initial-cluster "meta0=http://127.0.0.1:2380,meta1=http://127.0.0.1:12380,meta2=http://127.0.0.1:22380
-
-./ceresmeta -etcd-start-timeout-ms 1000000 -peer-urls "http://127.0.0.1:12380" -advertise-client-urls "http://127.0.0.1:12379" -advertise-peer-urls "http://127.0.0.1:12380" -client-urls "http://127.0.0.1:12379" -wal-dir /tmp/ceresmeta1/wal -data-dir /tmp/ceresmeta1/data -node-name "meta1" -etcd-log-file /tmp/ceresmeta1/etcd.log -initial-cluster "meta0=http://127.0.0.1:2380,meta1=http://127.0.0.1:12380,meta2=http://127.0.0.1:22380
-
-./ceresmeta -etcd-start-timeout-ms 1000000 -peer-urls "http://127.0.0.1:22380" -advertise-client-urls "http://127.0.0.1:22379" -advertise-peer-urls "http://127.0.0.1:22380" -client-urls "http://127.0.0.1:22379" -wal-dir /tmp/ceresmeta2/wal -data-dir /tmp/ceresmeta2/data -node-name "meta2" -etcd-log-file /tmp/ceresmeta2/etcd.log -initial-cluster "meta0=http://127.0.0.1:2380,meta1=http://127.0.0.1:12380,meta2=http://127.0.0.1:22380
-```
-
 ## Acknowledgment
 CeresMeta refers to the excellent project [pd](https://github.com/tikv/pd) in design and some module and codes are forked from [pd](https://github.com/tikv/pd), thanks to the TiKV team.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ CeresMeta is the meta service for managing the CeresDB cluster.
 ## Status
 The project is in a very early stage.
 
+## Run
+A simple cluster with three nodes can be run in the single machine.
+
+Prepare the data directories:
+```bash
+mkdir /tmp/ceresmeta0 /tmp/ceresmeta1 /tmp/ceresmeta2
+```
+
+Run the three commands in three terminals:
+```bash
+./ceresmeta -etcd-start-timeout-ms 1000000 -peer-urls "http://127.0.0.1:2380" -advertise-client-urls "http://127.0.0.1:2379" -advertise-peer-urls "http://127.0.0.1:2380" -client-urls "http://127.0.0.1:2379" -wal-dir /tmp/ceresmeta0/wal -data-dir /tmp/ceresmeta0/data -node-name "meta0"  -etcd-log-file /tmp/ceresmeta0/etcd.log -initial-cluster "meta0=http://127.0.0.1:2380,meta1=http://127.0.0.1:12380,meta2=http://127.0.0.1:22380
+
+./ceresmeta -etcd-start-timeout-ms 1000000 -peer-urls "http://127.0.0.1:12380" -advertise-client-urls "http://127.0.0.1:12379" -advertise-peer-urls "http://127.0.0.1:12380" -client-urls "http://127.0.0.1:12379" -wal-dir /tmp/ceresmeta1/wal -data-dir /tmp/ceresmeta1/data -node-name "meta1" -etcd-log-file /tmp/ceresmeta1/etcd.log -initial-cluster "meta0=http://127.0.0.1:2380,meta1=http://127.0.0.1:12380,meta2=http://127.0.0.1:22380
+
+./ceresmeta -etcd-start-timeout-ms 1000000 -peer-urls "http://127.0.0.1:22380" -advertise-client-urls "http://127.0.0.1:22379" -advertise-peer-urls "http://127.0.0.1:22380" -client-urls "http://127.0.0.1:22379" -wal-dir /tmp/ceresmeta2/wal -data-dir /tmp/ceresmeta2/data -node-name "meta2" -etcd-log-file /tmp/ceresmeta2/etcd.log -initial-cluster "meta0=http://127.0.0.1:2380,meta1=http://127.0.0.1:12380,meta2=http://127.0.0.1:22380
+```
+
 ## Acknowledgment
 CeresMeta refers to the excellent project [pd](https://github.com/tikv/pd) in design and some module and codes are forked from [pd](https://github.com/tikv/pd), thanks to the TiKV team.
 

--- a/pkg/coderr/code.go
+++ b/pkg/coderr/code.go
@@ -11,6 +11,7 @@ const (
 	Internal           = http.StatusInternalServerError
 	// HTTPCodeUpperBound is a bound under which any Code should have the same meaning with the http status code.
 	HTTPCodeUpperBound = Code(1000)
+	PrintHelpUsage     = 1001
 )
 
 // ToHTTPCode converts the Code to http code.

--- a/pkg/coderr/error.go
+++ b/pkg/coderr/error.go
@@ -23,6 +23,10 @@ type CodeError interface {
 // Is checks whether the cause of `err` is the kind of error specified by the `expectCode`.
 // Returns false if the cause of `err` is not CodeError.
 func Is(err error, expectCode Code) bool {
+	if err == nil {
+		return false
+	}
+
 	cause := errors.Cause(err)
 	cerr, ok := cause.(CodeError)
 	if !ok {

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	DefaultLogLevel = "info"
-	DefaultLogFile  = "/tmp/ceresmeta/out.log"
+	DefaultLogFile  = "stdout"
 )
 
 type Config struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -177,10 +177,10 @@ func MakeConfigParser() (*Parser, error) {
 		cfg:     cfg,
 	}
 
-	fs.StringVar(&cfg.Log.Level, "log-level", log.DefaultLogLevel, "level of the log")
+	fs.StringVar(&cfg.Log.Level, "log-level", log.DefaultLogLevel, "log level")
 	fs.StringVar(&cfg.Log.File, "log-file", log.DefaultLogFile, "file for log output")
-	fs.StringVar(&cfg.EtcdLog.Level, "etcd-log-level", log.DefaultLogLevel, "level of the log")
-	fs.StringVar(&cfg.EtcdLog.File, "etcd-log-file", log.DefaultLogFile, "file for log output")
+	fs.StringVar(&cfg.EtcdLog.Level, "etcd-log-level", log.DefaultLogLevel, "log level of etcd")
+	fs.StringVar(&cfg.EtcdLog.File, "etcd-log-file", log.DefaultLogFile, "file for log output of etcd")
 
 	fs.Int64Var(&cfg.GrpcHandleTimeoutMs, "grpc-handle-timeout-ms", defaultGrpcHandleTimeoutMs, "timeout for handling grpc requests")
 	fs.Int64Var(&cfg.EtcdStartTimeoutMs, "etcd-start-timeout-ms", defaultEtcdStartTimeoutMs, "timeout for starting etcd server")

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -36,7 +36,8 @@ const (
 )
 
 type Config struct {
-	Log log.Config `toml:"log" json:"log"`
+	Log     log.Config `toml:"log" json:"log"`
+	EtcdLog log.Config `toml:"etcd-log" json:"etcd-log"`
 
 	GrpcHandleTimeoutMs int64 `toml:"grpc-handle-timeout-ms" json:"grpc-handle-timeout-ms"`
 	EtcdStartTimeoutMs  int64 `toml:"etcd-start-timeout-ms" json:"etcd-start-timeout-ms"`
@@ -129,7 +130,10 @@ func (c *Config) GenEtcdConfig() (*embed.Config, error) {
 		return nil, err
 	}
 
-	cfg.SetupGlobalLoggers()
+	cfg.Logger = "zap"
+	cfg.LogOutputs = []string{c.EtcdLog.File}
+	cfg.LogLevel = c.EtcdLog.Level
+
 	return cfg, nil
 }
 
@@ -175,6 +179,8 @@ func MakeConfigParser() (*Parser, error) {
 
 	fs.StringVar(&cfg.Log.Level, "log-level", log.DefaultLogLevel, "level of the log")
 	fs.StringVar(&cfg.Log.File, "log-file", log.DefaultLogFile, "file for log output")
+	fs.StringVar(&cfg.EtcdLog.Level, "etcd-log-level", log.DefaultLogLevel, "level of the log")
+	fs.StringVar(&cfg.EtcdLog.File, "etcd-log-file", log.DefaultLogFile, "file for log output")
 
 	fs.Int64Var(&cfg.GrpcHandleTimeoutMs, "grpc-handle-timeout-ms", defaultGrpcHandleTimeoutMs, "timeout for handling grpc requests")
 	fs.Int64Var(&cfg.EtcdStartTimeoutMs, "etcd-start-timeout-ms", defaultEtcdStartTimeoutMs, "timeout for starting etcd server")

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -141,7 +141,11 @@ type Parser struct {
 
 func (p *Parser) Parse(arguments []string) (*Config, error) {
 	if err := p.flagSet.Parse(arguments); err != nil {
-		return nil, ErrInvalidCommandArgs.WithCausef("original arguments:%v, parse err:%v", arguments, err)
+		if err == flag.ErrHelp {
+			return nil, ErrHelpRequested.WithCause(err)
+		}
+
+		return nil, ErrInvalidCommandArgs.WithCausef("fail to parse flag arguments:%v, err:%v", arguments, err)
 	}
 
 	// TODO: support loading config from file.

--- a/server/config/error.go
+++ b/server/config/error.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	ErrHelpRequested      = coderr.NewCodeError(coderr.PrintHelpUsage, "help requested")
 	ErrInvalidPeerURL     = coderr.NewCodeError(coderr.InvalidParams, "invalid peers url")
 	ErrInvalidCommandArgs = coderr.NewCodeError(coderr.InvalidParams, "invalid command arguments")
 	ErrRetrieveHostname   = coderr.NewCodeError(coderr.Internal, "retrieve local hostname")

--- a/server/server.go
+++ b/server/server.go
@@ -121,7 +121,7 @@ func (srv *Server) startEtcd(ctx context.Context) error {
 
 	srv.etcdCli = client
 	etcdLeaderGetter := &etcdutil.LeaderGetterWrapper{Server: etcdSrv.Server}
-	srv.member = member.NewMember("", uint64(etcdSrv.Server.ID()), "", client, etcdLeaderGetter, srv.cfg.EtcdCallTimeout())
+	srv.member = member.NewMember("", uint64(etcdSrv.Server.ID()), srv.cfg.NodeName, client, etcdLeaderGetter, srv.cfg.EtcdCallTimeout())
 	srv.etcdSrv = etcdSrv
 	return nil
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #13

# Rationale for this change
Now the ceresmeta is actaully not runnable. Make it runnable before the following work comes.
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Fix the problem the process can't exit after receive interupt signal.
- Make the etcd log level and file configurable.
- Set name for `Member`.
<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->