### PR TITLE
feat: support leadership event callback mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 ceresmeta
 .tools
+.vscode

--- a/server/member/lease.go
+++ b/server/member/lease.go
@@ -73,12 +73,12 @@ func (l *lease) Grant(ctx context.Context) error {
 }
 
 func (l *lease) Close(ctx context.Context) error {
-	// check whether the lease was granted.
+	// Check whether the lease was granted.
 	if l.ID == 0 {
 		return nil
 	}
 
-	// release and reset all the resources.
+	// Release and reset all the resources.
 	l.setExpireTime(time.Time{})
 	ctx, cancel := context.WithTimeout(ctx, l.timeout)
 	defer cancel()
@@ -94,10 +94,10 @@ func (l *lease) Close(ctx context.Context) error {
 
 // KeepAlive renews the lease until timeout for renewing lease.
 func (l *lease) KeepAlive(ctx context.Context) {
-	// used to receive the renewed event.
+	// Used to receive the renewed event.
 	renewed := make(chan bool, 1)
 	ctx1, cancelRenewBg := context.WithCancel(ctx)
-	// used to join with the renew goroutine in the background.
+	// Used to join with the renew goroutine in the background.
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -139,7 +139,7 @@ func (l *lease) setExpireTime(newExpireTime time.Time) {
 	l.expireTime = newExpireTime
 }
 
-// setExpireTimeIfNewer updates the l.expireTime only if the newExpireTime is after l.expireTime.
+// `setExpireTimeIfNewer` updates the l.expireTime only if the newExpireTime is after l.expireTime.
 // Returns true if l.expireTime is updated.
 func (l *lease) setExpireTimeIfNewer(newExpireTime time.Time) bool {
 	l.expireTimeL.Lock()
@@ -160,7 +160,7 @@ func (l *lease) getExpireTime() time.Time {
 	return l.expireTime
 }
 
-// renewLeaseBg keeps the lease alive by periodically call `lease.KeepAliveOnce`.
+// `renewLeaseBg` keeps the lease alive by periodically call `lease.KeepAliveOnce`.
 // The l.expireTime will be updated during renewing and the renew lease result (whether alive) will be told to caller by `renewed` channel.
 func (l *lease) renewLeaseBg(ctx context.Context, interval time.Duration, renewed chan<- bool) {
 	l.logger.Info("start renewing lease background", zap.Duration("interval", interval))
@@ -190,11 +190,11 @@ L:
 
 		renewRes := renewOnce()
 
-		// init the timer for next keep alive action.
+		// Init the timer for next keep alive action.
 		t := time.After(interval)
 
 		if !renewRes.failed() {
-			// notify result of the renew.
+			// Notify result of the renew.
 			select {
 			case renewed <- renewRes.alive():
 			case <-ctx.Done():
@@ -202,7 +202,7 @@ L:
 			}
 		}
 
-		// wait for next keep alive action.
+		// Wait for next keep alive action.
 		select {
 		case <-t:
 		case <-ctx.Done():

--- a/server/member/member.go
+++ b/server/member/member.go
@@ -100,7 +100,7 @@ func (m *Member) WaitForLeaderChange(ctx context.Context, revision int64) {
 	for {
 		wch := watcher.Watch(ctx, m.leaderKey, clientv3.WithRev(revision))
 		for resp := range wch {
-			// meet compacted error, use the compact revision.
+			// Meet compacted error, use the compact revision.
 			if resp.CompactRevision != 0 {
 				m.logger.Warn("required revision has been compacted, use the compact revision",
 					zap.Int64("required-revision", revision),
@@ -182,7 +182,7 @@ func (m *Member) CampaignAndKeepLeader(ctx context.Context, leaseTTLSec int64, c
 		}()
 	}
 
-	// keep the leadership by renewing the lease periodically after success in campaigning leader.
+	// Keep the leadership by renewing the lease periodically after success in campaigning leader.
 	closeLeaseWg.Add(1)
 	go func() {
 		newLease.KeepAlive(ctx)
@@ -190,7 +190,7 @@ func (m *Member) CampaignAndKeepLeader(ctx context.Context, leaseTTLSec int64, c
 		closeLeaseOnce.Do(closeLease)
 	}()
 
-	// check the leadership periodically and exit if it changes.
+	// Check the leadership periodically and exit if it changes.
 	leaderCheckTicker := time.NewTicker(leaderCheckInterval)
 	defer leaderCheckTicker.Stop()
 

--- a/server/member/member.go
+++ b/server/member/member.go
@@ -130,7 +130,7 @@ func (m *Member) WaitForLeaderChange(ctx context.Context, revision int64) {
 	}
 }
 
-func (m *Member) CampaignAndKeepLeader(ctx context.Context, leaseTTLSec int64, callback LeadershipEventCallback) error {
+func (m *Member) CampaignAndKeepLeader(ctx context.Context, leaseTTLSec int64, callbacks LeadershipEventCallbacks) error {
 	leaderVal, err := m.Marshal()
 	if err != nil {
 		return err
@@ -173,12 +173,12 @@ func (m *Member) CampaignAndKeepLeader(ctx context.Context, leaseTTLSec int64, c
 
 	m.logger.Info("succeed to set leader", zap.String("leader-key", m.leaderKey), zap.String("leader", m.Name))
 
-	if callback != nil {
-		// The leader has been elected and trigger the callback.
-		callback.AfterElected(ctx)
+	if callbacks != nil {
+		// The leader has been elected and trigger the callbacks.
+		callbacks.AfterElected(ctx)
 		// The leader will be transferred after exit this method.
 		defer func() {
-			callback.BeforeTransfer(ctx)
+			callbacks.BeforeTransfer(ctx)
 		}()
 	}
 

--- a/server/member/watch_leader.go
+++ b/server/member/watch_leader.go
@@ -31,7 +31,7 @@ type LeaderWatcher struct {
 	leaseTTLSec int64
 }
 
-type LeadershipEventCallback interface {
+type LeadershipEventCallbacks interface {
 	AfterElected(ctx context.Context)
 	BeforeTransfer(ctx context.Context)
 }
@@ -53,8 +53,8 @@ func NewLeaderWatcher(ctx WatchContext, self *Member, leaseTTLSec int64) *Leader
 //	 - The leader keeps the leadership lease alive.
 //   - The other members keeps waiting for the leader changes.
 //
-// The LeadershipCallback callback will be triggered when specific events occur.
-func (l *LeaderWatcher) Watch(ctx context.Context, callback LeadershipEventCallback) {
+// The LeadershipCallbacks callback will be triggered when specific events occur.
+func (l *LeaderWatcher) Watch(ctx context.Context, callbacks LeadershipEventCallbacks) {
 	var wait string
 	logger := log.With(zap.String("self", l.self.Name))
 
@@ -91,7 +91,7 @@ func (l *LeaderWatcher) Watch(ctx context.Context, callback LeadershipEventCallb
 			// A new leader should be elected and the etcd leader should be elected as the new leader.
 			if l.self.ID == etcdLeaderID {
 				// campaign the leader and block until leader changes.
-				if err := l.self.CampaignAndKeepLeader(ctx, l.leaseTTLSec, callback); err != nil {
+				if err := l.self.CampaignAndKeepLeader(ctx, l.leaseTTLSec, callbacks); err != nil {
 					logger.Error("fail to campaign and keep leader", zap.Error(err))
 					wait = waitReasonFailEtcd
 				} else {

--- a/server/member/watch_leader.go
+++ b/server/member/watch_leader.go
@@ -53,7 +53,7 @@ func NewLeaderWatcher(ctx WatchContext, self *Member, leaseTTLSec int64) *Leader
 //	 - The leader keeps the leadership lease alive.
 //   - The other members keeps waiting for the leader changes.
 //
-// The LeadershipCallbacks callback will be triggered when specific events occur.
+// The LeadershipCallbacks `callbacks` will be triggered when specific events occur.
 func (l *LeaderWatcher) Watch(ctx context.Context, callbacks LeadershipEventCallbacks) {
 	var wait string
 	logger := log.With(zap.String("self", l.self.Name))
@@ -77,7 +77,7 @@ func (l *LeaderWatcher) Watch(ctx context.Context, callbacks LeadershipEventCall
 			wait = waitReasonNoWait
 		}
 
-		// check whether leader exists.
+		// Check whether leader exists.
 		leaderResp, err := l.self.GetLeader(ctx)
 		if err != nil {
 			logger.Error("fail to get leader", zap.Error(err))
@@ -90,7 +90,7 @@ func (l *LeaderWatcher) Watch(ctx context.Context, callbacks LeadershipEventCall
 			// Leader does not exist.
 			// A new leader should be elected and the etcd leader should be elected as the new leader.
 			if l.self.ID == etcdLeaderID {
-				// campaign the leader and block until leader changes.
+				// Campaign the leader and block until leader changes.
 				if err := l.self.CampaignAndKeepLeader(ctx, l.leaseTTLSec, callbacks); err != nil {
 					logger.Error("fail to campaign and keep leader", zap.Error(err))
 					wait = waitReasonFailEtcd
@@ -100,7 +100,7 @@ func (l *LeaderWatcher) Watch(ctx context.Context, callbacks LeadershipEventCall
 				continue
 			}
 
-			// for other nodes that is not etcd leader, just wait for the new leader elected.
+			// For other nodes that is not etcd leader, just wait for the new leader elected.
 			wait = waitReasonElectLeader
 		} else {
 			// Leader does exist.
@@ -113,7 +113,7 @@ func (l *LeaderWatcher) Watch(ctx context.Context, callbacks LeadershipEventCall
 				continue
 			}
 
-			// the leader is not etcd leader and this node is leader so reset it.
+			// The leader is not etcd leader and this node is leader so reset it.
 			if leaderResp.Leader.Id == l.self.ID {
 				if err := l.self.ResetLeader(ctx); err != nil {
 					logger.Error("fail to reset leader", zap.Error(err))
@@ -122,7 +122,7 @@ func (l *LeaderWatcher) Watch(ctx context.Context, callbacks LeadershipEventCall
 				continue
 			}
 
-			// the leader is not etcd leader and this node is not the leader so just wait a moment and check leader again.
+			// The leader is not etcd leader and this node is not the leader so just wait a moment and check leader again.
 			wait = waitReasonResetLeader
 		}
 	}

--- a/server/member/watch_leader_test.go
+++ b/server/member/watch_leader_test.go
@@ -66,7 +66,7 @@ func TestWatchLeaderSingle(t *testing.T) {
 	ctx, cancelWatch := context.WithCancel(context.Background())
 	watchedDone := make(chan struct{}, 1)
 	go func() {
-		leaderWatcher.Watch(ctx)
+		leaderWatcher.Watch(ctx, nil)
 		watchedDone <- struct{}{}
 	}()
 

--- a/server/server.go
+++ b/server/server.go
@@ -182,7 +182,7 @@ func (srv *Server) watchLeader(ctx context.Context) {
 	}
 	watcher := member.NewLeaderWatcher(watchCtx, srv.member, srv.cfg.LeaseTTLSec)
 
-	watcher.Watch(ctx)
+	watcher.Watch(ctx, nil)
 }
 
 func (srv *Server) watchEtcdLeaderPriority(_ context.Context) {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Some data is exclusive and can only be kept by the leader, that is to say, these data can't be accessed by followers and leaders at the same time. Such a requirement is a little difficult to be met when the leadership is being transferred.

What we need is actually is a mechanism to enforce then order of the leadership transference between the old leader and the new leader so that we can disallow the old leader access to the exclusive data before the old leader transfers the leadership and allow the new leader access to the data before the new leader takes the leadership.

 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Introduce the `LeadershipEventCallbacks` to the `Leadership.Watch` method and the callbacks will be called before the leader hands over the leadership and after the leader takes up the leadership.
<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
There is no test yet, but it can be tested actually. Some tests should be supplemented afterwards.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->