### PR TITLE
docs: add `Quick Start` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,81 @@ CeresMeta is the meta service for managing the CeresDB cluster.
 ## Status
 The project is in a very early stage.
 
+## Quick Start
+### Build ceresmeta binary
+```
+go build -o ceresmeta cmd/meta/main.go
+```
+
+### Start server(single node)
+```
+# Set correct HostIP here.
+export HostIP0="127.0.0.1"
+
+// ceresmeta0
+mkdir /tmp/ceresmeta0
+./ceresmeta -etcd-start-timeout-ms 1000000 \
+            -peer-urls "http://${HostIP0}:2380" \
+            -advertise-client-urls "http://${HostIP0}:2379" \
+            -advertise-peer-urls "http://${HostIP0}:2380" \
+            -client-urls "http://${HostIP0}:2379" \
+            -wal-dir /tmp/ceresmeta0/wal \
+            -data-dir /tmp/ceresmeta0/data \
+            -node-name "meta0" \
+            -etcd-log-file /tmp/ceresmeta0/etcd.log \
+            -initial-cluster "meta0=http://${HostIP0}:2380"
+```
+
+### Start server(multi nodes)
+```
+# Set correct HostIP here.
+export HostIP0="127.0.0.1"
+export HostIP1="127.0.0.2"
+export HostIP2="127.0.0.3"
+
+// ceresmeta0
+mkdir /tmp/ceresmeta0
+./ceresmeta -etcd-start-timeout-ms 1000000 \
+            -peer-urls "http://${HostIP0}:2380" \
+            -advertise-client-urls "http://${HostIP0}:2379" \
+            -advertise-peer-urls "http://${HostIP0}:2380" \
+            -client-urls "http://${HostIP0}:2379" \
+            -wal-dir /tmp/ceresmeta0/wal \
+            -data-dir /tmp/ceresmeta0/data \
+            -node-name "meta0" \
+            -etcd-log-file /tmp/ceresmeta0/etcd.log \
+            -initial-cluster "meta0=http://${HostIP0}:2380,meta1=http://${HostIP1}:12380,meta2=http://${HostIP2}:22380"
+
+// ceresmeta1
+mkdir /tmp/ceresmeta1
+./ceresmeta -etcd-start-timeout-ms 1000000 \
+            -peer-urls "http://${HostIP1}:12380" \
+            -advertise-client-urls "http://${HostIP1}:12379" \
+            -advertise-peer-urls "http://${HostIP1}:12380" \
+            -client-urls "http://${HostIP1}:12379" \
+            -wal-dir /tmp/ceresmeta1/wal \
+            -data-dir /tmp/ceresmeta1/data \
+            -node-name "meta1" \
+            -etcd-log-file /tmp/ceresmeta1/etcd.log \
+            -initial-cluster "meta0=http://${HostIP0}:2380,meta1=http://${HostIP1}:12380,meta2=http://${HostIP2}:22380"
+
+// ceresmeta2
+mkdir /tmp/ceresmeta2
+./ceresmeta -etcd-start-timeout-ms 1000000 \
+            -peer-urls "http://${HostIP2}:12380" \
+            -advertise-client-urls "http://${HostIP2}:12379" \
+            -advertise-peer-urls "http://${HostIP2}:12380" \
+            -client-urls "http://${HostIP2}:12379" \
+            -wal-dir /tmp/ceresmeta2/wal \
+            -data-dir /tmp/ceresmeta2/data \
+            -node-name "meta2" \
+            -etcd-log-file /tmp/ceresmeta2/etcd.log \
+            -initial-cluster "meta0=http://${HostIP0}:2380,meta1=http://${HostIP1}:12380,meta2=http://${HostIP2}:22380"
+```
+
+### Start server with docker
+TODO.
+
 ## Acknowledgment
 CeresMeta refers to the excellent project [pd](https://github.com/tikv/pd) in design and some module and codes are forked from [pd](https://github.com/tikv/pd), thanks to the TiKV team.
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ The project is in a very early stage.
 
 ## Quick Start
 ### Build ceresmeta binary
-```
-go build -o ceresmeta cmd/meta/main.go
+```bash
+make build
 ```
 
-### Start server(single node)
-```
+### Standalone Mode
+Although CeresMeta is designed to deployed as a cluster with three or more instances, it can also be started standalone:
+```bash
 # Set correct HostIP here.
 export HostIP0="127.0.0.1"
 
-// ceresmeta0
+# ceresmeta0
 mkdir /tmp/ceresmeta0
 ./ceresmeta -etcd-start-timeout-ms 1000000 \
             -peer-urls "http://${HostIP0}:2380" \
@@ -32,16 +33,17 @@ mkdir /tmp/ceresmeta0
             -initial-cluster "meta0=http://${HostIP0}:2380"
 ```
 
-### Start server(multi nodes)
-```
+### Cluster mode
+Here is an example for starting CeresMeta in cluster mode (three instances) on single machine by using different ports:
+```bash
 # Set correct HostIP here.
 export HostIP0="127.0.0.1"
-export HostIP1="127.0.0.2"
-export HostIP2="127.0.0.3"
+export HostIP1="127.0.0.1"
+export HostIP2="127.0.0.1"
 
-// ceresmeta0
+# ceresmeta0
 mkdir /tmp/ceresmeta0
-./ceresmeta -etcd-start-timeout-ms 1000000 \
+./ceresmeta -etcd-start-timeout-ms 30000 \
             -peer-urls "http://${HostIP0}:2380" \
             -advertise-client-urls "http://${HostIP0}:2379" \
             -advertise-peer-urls "http://${HostIP0}:2380" \
@@ -52,9 +54,9 @@ mkdir /tmp/ceresmeta0
             -etcd-log-file /tmp/ceresmeta0/etcd.log \
             -initial-cluster "meta0=http://${HostIP0}:2380,meta1=http://${HostIP1}:12380,meta2=http://${HostIP2}:22380"
 
-// ceresmeta1
+# ceresmeta1
 mkdir /tmp/ceresmeta1
-./ceresmeta -etcd-start-timeout-ms 1000000 \
+./ceresmeta -etcd-start-timeout-ms 30000 \
             -peer-urls "http://${HostIP1}:12380" \
             -advertise-client-urls "http://${HostIP1}:12379" \
             -advertise-peer-urls "http://${HostIP1}:12380" \
@@ -65,9 +67,9 @@ mkdir /tmp/ceresmeta1
             -etcd-log-file /tmp/ceresmeta1/etcd.log \
             -initial-cluster "meta0=http://${HostIP0}:2380,meta1=http://${HostIP1}:12380,meta2=http://${HostIP2}:22380"
 
-// ceresmeta2
+# ceresmeta2
 mkdir /tmp/ceresmeta2
-./ceresmeta -etcd-start-timeout-ms 1000000 \
+./ceresmeta -etcd-start-timeout-ms 30000 \
             -peer-urls "http://${HostIP2}:12380" \
             -advertise-client-urls "http://${HostIP2}:12379" \
             -advertise-peer-urls "http://${HostIP2}:12380" \
@@ -78,9 +80,6 @@ mkdir /tmp/ceresmeta2
             -etcd-log-file /tmp/ceresmeta2/etcd.log \
             -initial-cluster "meta0=http://${HostIP0}:2380,meta1=http://${HostIP1}:12380,meta2=http://${HostIP2}:22380"
 ```
-
-### Start server with docker
-TODO.
 
 ## Acknowledgment
 CeresMeta refers to the excellent project [pd](https://github.com/tikv/pd) in design and some module and codes are forked from [pd](https://github.com/tikv/pd), thanks to the TiKV team.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

CeresMeta is the meta service for managing the CeresDB cluster. 
Before starting CeresDB cluster, we need start ceresmeta service first.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->
Add `Quick Start` in README to help developers start ceresmeta.

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->