### PR TITLE
refactor: attach call stack to coderr

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,14 +5,14 @@ Closes #
 # Rationale for this change
  
  <!---
- Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
+ Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
  Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
 -->
 
 # What changes are included in this PR?
 
 <!---
-There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
+There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
 -->
 
 # Are there any user-facing changes?
@@ -20,7 +20,7 @@ There is no need to duplicate the description in the issue here but it is someti
 <!---
 Please mention if:
 
-- there are user-facing changes that needs to update the documentation or configuration.
+- there are user-facing changes that need to update the documentation or configuration.
 - this is a breaking change to public APIs
 -->
 

--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -12,7 +12,7 @@ Besides the [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewCom
   - An error code can be used by multiple different errors,
   - The error codes are defined in the single global package [coderr](https://github.com/CeresDB/ceresmeta/tree/main/pkg/coderr).
 - Construct: define leaf errors on package level (often in a separate `error.go` file) by package [coderr](https://github.com/CeresDB/ceresmeta/tree/main/pkg/coderr).
-- Wrap: wrap errors by `errors.Wrap` or `errors.Wrapf`.
+- Wrap: wrap errors by `errors.WithMessage` or `errors.WithMessagef`.
 - Check: test the error identity by calling `coderr.Is`.
 - Log: only log the error on the top level package.
 - Respond: respond the `CodeError`(defined in package [coderr](https://github.com/CeresDB/ceresmeta/tree/main/pkg/coderr)) unwrapped by `errors.Cause` to client on service level.

--- a/pkg/coderr/error.go
+++ b/pkg/coderr/error.go
@@ -69,7 +69,8 @@ func (e *codeError) Code() Code {
 }
 
 func (e *codeError) WithCausef(format string, a ...any) CodeError {
-	causeWithStack := errors.WithStack(errors.New(fmt.Sprintf(format, a...)))
+	errMsg := fmt.Sprintf(format, a...)
+	causeWithStack := errors.WithStack(errors.New(errMsg))
 	return &codeError{
 		code:  e.code,
 		desc:  e.desc,

--- a/pkg/coderr/error.go
+++ b/pkg/coderr/error.go
@@ -57,11 +57,11 @@ func NewCodeError(code Code, desc string) CodeError {
 type codeError struct {
 	code  Code
 	desc  string
-	cause string
+	cause error
 }
 
 func (e *codeError) Error() string {
-	return fmt.Sprintf("(#%d)%s, cause:%s", e.code, e.desc, e.cause)
+	return fmt.Sprintf("(#%d)%s, cause:%+v", e.code, e.desc, e.cause)
 }
 
 func (e *codeError) Code() Code {
@@ -69,17 +69,19 @@ func (e *codeError) Code() Code {
 }
 
 func (e *codeError) WithCausef(format string, a ...any) CodeError {
+	causeWithStack := errors.WithStack(errors.New(fmt.Sprintf(format, a...)))
 	return &codeError{
 		code:  e.code,
 		desc:  e.desc,
-		cause: fmt.Sprintf(format, a...),
+		cause: causeWithStack,
 	}
 }
 
 func (e *codeError) WithCause(cause error) CodeError {
+	causeWithStack := errors.WithStack(cause)
 	return &codeError{
 		code:  e.code,
 		desc:  e.desc,
-		cause: cause.Error(),
+		cause: causeWithStack,
 	}
 }

--- a/pkg/coderr/error_test.go
+++ b/pkg/coderr/error_test.go
@@ -1,0 +1,20 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package coderr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorStack(t *testing.T) {
+	r := require.New(t)
+	cerr := NewCodeError(Internal, "test internal error")
+	err := cerr.WithCausef("failed reason:%s", "for test")
+	errDesc := fmt.Sprintf("%v", err)
+	expectErrDesc := "(#500)test internal error, cause:failed reason:for test\ngithub.com/CeresDB/ceresmeta/pkg/coderr.(*codeError).WithCausef\n\t/Users/xkwei/Code/github/ceresmeta/pkg/coderr/error.go:72\ngithub.com/CeresDB/ceresmeta/pkg/coderr.TestErrorStack\n\t/Users/xkwei/Code/github/ceresmeta/pkg/coderr/error_test.go:15\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1446\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1594\ngithub.com/CeresDB/ceresmeta/pkg/coderr.(*codeError).WithCausef\n\t/Users/xkwei/Code/github/ceresmeta/pkg/coderr/error.go:72\ngithub.com/CeresDB/ceresmeta/pkg/coderr.TestErrorStack\n\t/Users/xkwei/Code/github/ceresmeta/pkg/coderr/error_test.go:15\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1446\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1594"
+
+	r.Equal(expectErrDesc, errDesc)
+}

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -82,11 +82,11 @@ func (c *coordinator) scatterShard(ctx context.Context, nodeInfo *metaservicepb.
 	if c.cluster.metaData.clusterTopology.State == clusterpb.ClusterTopology_STABLE {
 		shardIDs, err := c.cluster.GetShardIDs(nodeInfo.GetEndpoint())
 		if err != nil {
-			return errors.Wrap(err, "coordinator scatterShard")
+			return errors.WithMessage(err, "coordinator scatterShard")
 		}
 		if len(nodeInfo.GetShardInfos()) == 0 {
 			if err := c.eventHandler.Dispatch(ctx, nodeInfo.GetEndpoint(), &schedule.OpenEvent{ShardIDs: shardIDs}); err != nil {
-				return errors.Wrap(err, "coordinator scatterShard")
+				return errors.WithMessage(err, "coordinator scatterShard")
 			}
 		}
 	}
@@ -124,16 +124,16 @@ func (c *coordinator) scatterShard(ctx context.Context, nodeInfo *metaservicepb.
 	c.cluster.metaData.clusterTopology.ShardView = shards
 	c.cluster.metaData.clusterTopology.State = clusterpb.ClusterTopology_STABLE
 	if err := c.cluster.storage.PutClusterTopology(ctx, c.cluster.clusterID, c.cluster.metaData.clusterTopology.Version, c.cluster.metaData.clusterTopology); err != nil {
-		return errors.Wrap(err, "coordinator scatterShard")
+		return errors.WithMessage(err, "coordinator scatterShard")
 	}
 
 	if err := c.cluster.Load(ctx); err != nil {
-		return errors.Wrap(err, "coordinator scatterShard")
+		return errors.WithMessage(err, "coordinator scatterShard")
 	}
 
 	for nodeName, node := range c.cluster.nodesCache {
 		if err := c.eventHandler.Dispatch(ctx, nodeName, &schedule.OpenEvent{ShardIDs: node.shardIDs}); err != nil {
-			return errors.Wrap(err, "coordinator scatterShard")
+			return errors.WithMessage(err, "coordinator scatterShard")
 		}
 	}
 	return nil

--- a/server/etcdutil/config.go
+++ b/server/etcdutil/config.go
@@ -60,9 +60,9 @@ func PrepareEtcdServerAndClient(t *testing.T) (*embed.Etcd, *clientv3.Client, Cl
 	})
 	assert.NoError(t, err)
 
-	close := func() {
+	closeSrv := func() {
 		etcd.Close()
 		CleanConfig(cfg)
 	}
-	return etcd, client, close
+	return etcd, client, closeSrv
 }

--- a/server/etcdutil/util_test.go
+++ b/server/etcdutil/util_test.go
@@ -23,8 +23,8 @@ func makeTestKeys(num int) []string {
 func TestScanNormal(t *testing.T) {
 	r := require.New(t)
 
-	_, client, close := PrepareEtcdServerAndClient(t)
-	defer close()
+	_, client, closeSrv := PrepareEtcdServerAndClient(t)
+	defer closeSrv()
 
 	keys := makeTestKeys(51)
 	lastKey := keys[len(keys)-1]
@@ -63,8 +63,8 @@ func TestScanNormal(t *testing.T) {
 func TestScanFailed(t *testing.T) {
 	r := require.New(t)
 
-	_, client, close := PrepareEtcdServerAndClient(t)
-	defer close()
+	_, client, closeSrv := PrepareEtcdServerAndClient(t)
+	defer closeSrv()
 
 	keys := makeTestKeys(50)
 	ctx := context.Background()

--- a/server/grpcservice/forward.go
+++ b/server/grpcservice/forward.go
@@ -16,14 +16,14 @@ import (
 func (s *Service) getForwardedCeresmetaClient(ctx context.Context) (metaservicepb.CeresmetaRpcServiceClient, error) {
 	forwardedAddr, _, err := s.getForwardedAddr(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "get forwarded ceresmeta client")
+		return nil, errors.WithMessage(err, "get forwarded ceresmeta client")
 	}
 
 	if forwardedAddr != "" {
 		log.Info("try to create ceresmeta client", zap.String("addr", forwardedAddr))
 		ceresmetaClient, err := s.getCeresmetaClient(ctx, forwardedAddr)
 		if err != nil {
-			return nil, errors.Wrapf(err, "get forwarded ceresmeta client, addr:%s", forwardedAddr)
+			return nil, errors.WithMessagef(err, "get forwarded ceresmeta client, addr:%s", forwardedAddr)
 		}
 		return ceresmetaClient, nil
 	}
@@ -33,7 +33,7 @@ func (s *Service) getForwardedCeresmetaClient(ctx context.Context) (metaservicep
 func (s *Service) getCeresmetaClient(ctx context.Context, addr string) (metaservicepb.CeresmetaRpcServiceClient, error) {
 	client, err := s.getForwardedGrpcClient(ctx, addr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "get ceresmeta client, addr:%s", addr)
+		return nil, errors.WithMessagef(err, "get ceresmeta client, addr:%s", addr)
 	}
 	return metaservicepb.NewCeresmetaRpcServiceClient(client), nil
 }
@@ -54,7 +54,7 @@ func (s *Service) getForwardedGrpcClient(ctx context.Context, forwardedAddr stri
 func (s *Service) getForwardedAddr(ctx context.Context) (string, bool, error) {
 	member, err := s.h.GetLeader(ctx)
 	if err != nil {
-		return "", false, errors.Wrap(err, "get forwarded addr")
+		return "", false, errors.WithMessage(err, "get forwarded addr")
 	}
 	if member.IsLocal {
 		return "", true, nil

--- a/server/grpcservice/service.go
+++ b/server/grpcservice/service.go
@@ -124,12 +124,12 @@ func (s *Service) NodeHeartbeat(heartbeatSrv metaservicepb.CeresmetaRpcService_N
 		{
 			err = f.maybeInitForwardedStream(ctx)
 			if err != nil {
-				return errors.Wrap(err, "node heartbeat")
+				return errors.WithMessage(err, "node heartbeat")
 			}
 
 			if f.stream != nil {
 				if err = f.stream.Send(req); err != nil {
-					return errors.Wrap(err, "node heartbeat")
+					return errors.WithMessage(err, "node heartbeat")
 				}
 
 				select {
@@ -332,7 +332,7 @@ func (f *forwarder) reconnect(addr string) error {
 
 	ceresmetaClient, err := f.s.getCeresmetaClient(dialCtx, addr)
 	if err != nil {
-		return errors.Wrap(err, "forwarder reconnect")
+		return errors.WithMessage(err, "forwarder reconnect")
 	}
 
 	if ceresmetaClient != nil {
@@ -341,7 +341,7 @@ func (f *forwarder) reconnect(addr string) error {
 		f.stream, err = f.s.createHeartbeatForwardedStream(ctx, ceresmetaClient)
 		if err != nil {
 			cancel()
-			return errors.Wrap(err, "forwarder reconnect")
+			return errors.WithMessage(err, "forwarder reconnect")
 		}
 
 		// Forward the leader's response to the client.

--- a/server/id/id_impl.go
+++ b/server/id/id_impl.go
@@ -42,7 +42,7 @@ func (a *AllocatorImpl) Alloc(ctx context.Context) (uint64, error) {
 
 	if !a.isInitialized {
 		if err := a.slowRebaseLocked(ctx); err != nil {
-			return 0, errors.Wrap(err, "alloc id")
+			return 0, errors.WithMessage(err, "alloc id")
 		}
 		a.isInitialized = true
 	}
@@ -52,7 +52,7 @@ func (a *AllocatorImpl) Alloc(ctx context.Context) (uint64, error) {
 			log.Warn("fast rebase failed", zap.Error(err))
 
 			if err = a.slowRebaseLocked(ctx); err != nil {
-				return 0, errors.Wrap(err, "alloc id")
+				return 0, errors.WithMessage(err, "alloc id")
 			}
 		}
 	}
@@ -65,7 +65,7 @@ func (a *AllocatorImpl) Alloc(ctx context.Context) (uint64, error) {
 func (a *AllocatorImpl) slowRebaseLocked(ctx context.Context) error {
 	resp, err := a.kv.Get(ctx, a.key)
 	if err != nil {
-		return errors.Wrapf(err, "get end id failed, key:%s", a.key)
+		return errors.WithMessagef(err, "get end id failed, key:%s", a.key)
 	}
 
 	if n := len(resp.Kvs); n > 1 {
@@ -96,7 +96,7 @@ func (a *AllocatorImpl) firstDoRebaseLocked(ctx context.Context) error {
 		Then(opPutEnd).
 		Commit()
 	if err != nil {
-		return errors.Wrapf(err, "put end id failed, key:%s", a.key)
+		return errors.WithMessagef(err, "put end id failed, key:%s", a.key)
 	} else if !resp.Succeeded {
 		return ErrTxnPutEndID.WithCausef("txn put end id failed, key is exist, key:%s, resp:%v", a.key, resp)
 	}
@@ -122,7 +122,7 @@ func (a *AllocatorImpl) doRebaseLocked(ctx context.Context, currEnd uint64) erro
 		Then(opPutEnd).
 		Commit()
 	if err != nil {
-		return errors.Wrapf(err, "put end id failed, key:%s, old value:%d, new value:%d", a.key, currEnd, newEnd)
+		return errors.WithMessagef(err, "put end id failed, key:%s, old value:%d, new value:%d", a.key, currEnd, newEnd)
 	} else if !resp.Succeeded {
 		return ErrTxnPutEndID.WithCausef("txn put end id failed, endEquals failed, key:%s, value:%d, resp:%v", a.key, currEnd, resp)
 	}

--- a/server/id/id_test.go
+++ b/server/id/id_test.go
@@ -22,8 +22,8 @@ const (
 func TestMultipleAllocBasedOnKV(t *testing.T) {
 	start := 0
 	size := 201
-	_, kv, close := etcdutil.PrepareEtcdServerAndClient(t)
-	defer close()
+	_, kv, closeSrv := etcdutil.PrepareEtcdServerAndClient(t)
+	defer closeSrv()
 
 	testAllocIDValue(t, kv, start, size)
 	testAllocIDValue(t, kv, ((start+size)/defaultStep+1)*defaultStep, size)

--- a/server/member/watch_leader_test.go
+++ b/server/member/watch_leader_test.go
@@ -28,8 +28,8 @@ func (ctx *mockWatchCtx) EtcdLeaderID() uint64 {
 }
 
 func TestWatchLeaderSingle(t *testing.T) {
-	etcd, client, close := etcdutil.PrepareEtcdServerAndClient(t)
-	defer close()
+	etcd, client, closeSrv := etcdutil.PrepareEtcdServerAndClient(t)
+	defer closeSrv()
 
 	watchCtx := &mockWatchCtx{
 		stopped: false,

--- a/server/schedule/event_handler.go
+++ b/server/schedule/event_handler.go
@@ -47,7 +47,7 @@ func NewEventHandler(hbstream *HeartbeatStreams) *EventHandler {
 
 func (e *EventHandler) Dispatch(ctx context.Context, nodeName string, event Event) error {
 	if err := e.hbstreams.SendMsgAsync(ctx, nodeName, event.ToHeartbeatResp()); err != nil {
-		return errors.Wrap(err, "event handler dispatch")
+		return errors.WithMessage(err, "event handler dispatch")
 	}
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -151,7 +151,7 @@ func (srv *Server) startServer(ctx context.Context) error {
 
 	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.hbStreams, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep)
 	if err != nil {
-		return errors.Wrap(err, "start server")
+		return errors.WithMessage(err, "start server")
 	}
 	srv.clusterManager = manager
 

--- a/server/storage/storage_impl.go
+++ b/server/storage/storage_impl.go
@@ -58,7 +58,7 @@ func (s *metaStorageImpl) ListClusters(ctx context.Context) ([]*clusterpb.Cluste
 
 	err := etcdutil.Scan(ctx, s.client, startKey, endKey, rangeLimit, do)
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to list clusters, start key:%s, end key:%s, range limit:%d", startKey, endKey, rangeLimit)
+		return nil, errors.WithMessagef(err, "fail to list clusters, start key:%s, end key:%s, range limit:%d", startKey, endKey, rangeLimit)
 	}
 
 	return clusters, nil
@@ -85,7 +85,7 @@ func (s *metaStorageImpl) CreateCluster(ctx context.Context, cluster *clusterpb.
 		Then(opCreateCluster).
 		Commit()
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to create cluster, clusterID:%d, key:%s", cluster.Id, key)
+		return nil, errors.WithMessagef(err, "fail to create cluster, clusterID:%d, key:%s", cluster.Id, key)
 	}
 	if !resp.Succeeded {
 		return nil, ErrCreateClusterAgain.WithCausef("cluster may already exist, clusterID:%d, key:%s, resp:%v", cluster.Id, key, resp)
@@ -117,7 +117,7 @@ func (s *metaStorageImpl) CreateClusterTopology(ctx context.Context, clusterTopo
 		Then(opCreateClusterTopology, opCreateClusterTopologyLatestVersion).
 		Commit()
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to create cluster topology, clusterID:%d, key:%s", clusterTopology.ClusterId, key)
+		return nil, errors.WithMessagef(err, "fail to create cluster topology, clusterID:%d, key:%s", clusterTopology.ClusterId, key)
 	}
 	if !resp.Succeeded {
 		return nil, ErrCreateClusterTopologyAgain.WithCausef("cluster topology may already exist, clusterID:%d, key:%s, resp:%v", clusterTopology.ClusterId, key, resp)
@@ -129,13 +129,13 @@ func (s *metaStorageImpl) GetClusterTopology(ctx context.Context, clusterID uint
 	key := makeClusterTopologyLatestVersionKey(s.rootPath, clusterID)
 	version, err := etcdutil.Get(ctx, s.client, key)
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to get cluster topology latest version, clusterID:%d, key:%s", clusterID, key)
+		return nil, errors.WithMessagef(err, "fail to get cluster topology latest version, clusterID:%d, key:%s", clusterID, key)
 	}
 
 	key = makeClusterTopologyKey(s.rootPath, clusterID, version)
 	value, err := etcdutil.Get(ctx, s.client, key)
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to get cluster topology, clusterID:%d, key:%s", clusterID, key)
+		return nil, errors.WithMessagef(err, "fail to get cluster topology, clusterID:%d, key:%s", clusterID, key)
 	}
 
 	clusterTopology := &clusterpb.ClusterTopology{}
@@ -164,7 +164,7 @@ func (s *metaStorageImpl) PutClusterTopology(ctx context.Context, clusterID uint
 		Then(opPutClusterTopology, opPutLatestVersion).
 		Commit()
 	if err != nil {
-		return errors.Wrapf(err, "fail to put cluster topology, clusterID:%d, key:%s", clusterID, key)
+		return errors.WithMessagef(err, "fail to put cluster topology, clusterID:%d, key:%s", clusterID, key)
 	}
 	if !resp.Succeeded {
 		return ErrPutClusterTopologyConflict.WithCausef("cluster topology may have been modified, clusterID:%d, key:%s, resp:%v", clusterID, key, resp)
@@ -191,7 +191,7 @@ func (s *metaStorageImpl) ListSchemas(ctx context.Context, clusterID uint32) ([]
 
 	err := etcdutil.Scan(ctx, s.client, startKey, endKey, rangeLimit, do)
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to list schemas, clusterID:%d, start key:%s, end key:%s, range limit:%d", clusterID, startKey, endKey, rangeLimit)
+		return nil, errors.WithMessagef(err, "fail to list schemas, clusterID:%d, start key:%s, end key:%s, range limit:%d", clusterID, startKey, endKey, rangeLimit)
 	}
 
 	return schemas, nil
@@ -218,7 +218,7 @@ func (s *metaStorageImpl) CreateSchema(ctx context.Context, clusterID uint32, sc
 		Then(opCreateSchema).
 		Commit()
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to create schema, clusterID:%d, schemaID:%d, key:%s", clusterID, schema.Id, key)
+		return nil, errors.WithMessagef(err, "fail to create schema, clusterID:%d, schemaID:%d, key:%s", clusterID, schema.Id, key)
 	}
 	if !resp.Succeeded {
 		return nil, ErrCreateSchemaAgain.WithCausef("schema may already exist, clusterID:%d, schemaID:%d, key:%s, resp:%v", clusterID, schema.Id, key, resp)
@@ -250,7 +250,7 @@ func (s *metaStorageImpl) CreateTable(ctx context.Context, clusterID uint32, sch
 		Then(opCreateTable, opCreateNameToID).
 		Commit()
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to create table, clusterID:%d, schemaID:%d, tableID:%d, key:%s", clusterID, schemaID, table.Id, key)
+		return nil, errors.WithMessagef(err, "fail to create table, clusterID:%d, schemaID:%d, tableID:%d, key:%s", clusterID, schemaID, table.Id, key)
 	}
 	if !resp.Succeeded {
 		return nil, ErrCreateTableAgain.WithCausef("table may already exist, clusterID:%d, schemaID:%d, tableID:%d, key:%s, resp:%v", clusterID, schemaID, table.Id, key, resp)
@@ -261,18 +261,18 @@ func (s *metaStorageImpl) CreateTable(ctx context.Context, clusterID uint32, sch
 func (s *metaStorageImpl) GetTable(ctx context.Context, clusterID uint32, schemaID uint32, tableName string) (*clusterpb.Table, bool, error) {
 	value, err := etcdutil.Get(ctx, s.client, makeNameToIDKey(s.rootPath, clusterID, schemaID, tableName))
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "fail to get table id, clusterID:%d, schemaID:%d, table name:%s", clusterID, schemaID, tableName)
+		return nil, false, errors.WithMessagef(err, "fail to get table id, clusterID:%d, schemaID:%d, table name:%s", clusterID, schemaID, tableName)
 	}
 
 	tableID, err := strconv.ParseUint(value, 10, 64)
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "string to int failed")
+		return nil, false, errors.WithMessagef(err, "string to int failed")
 	}
 
 	key := makeTableKey(s.rootPath, clusterID, schemaID, tableID)
 	value, err = etcdutil.Get(ctx, s.client, key)
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "fail to get table, clusterID:%d, schemaID:%d, tableID:%d, key:%s", clusterID, schemaID, tableID, key)
+		return nil, false, errors.WithMessagef(err, "fail to get table, clusterID:%d, schemaID:%d, tableID:%d, key:%s", clusterID, schemaID, tableID, key)
 	}
 
 	table := &clusterpb.Table{}
@@ -300,7 +300,7 @@ func (s *metaStorageImpl) ListTables(ctx context.Context, clusterID uint32, sche
 	}
 	err := etcdutil.Scan(ctx, s.client, startKey, endKey, rangeLimit, do)
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to list tables, clusterID:%d, schemaID:%d, start key:%s, end key:%s, range limit:%d", clusterID, schemaID, startKey, endKey, rangeLimit)
+		return nil, errors.WithMessagef(err, "fail to list tables, clusterID:%d, schemaID:%d, start key:%s, end key:%s, range limit:%d", clusterID, schemaID, startKey, endKey, rangeLimit)
 	}
 
 	return tables, nil
@@ -311,12 +311,12 @@ func (s *metaStorageImpl) DeleteTable(ctx context.Context, clusterID uint32, sch
 
 	value, err := etcdutil.Get(ctx, s.client, nameKey)
 	if err != nil {
-		return errors.Wrapf(err, "fail to get table id, clusterID:%d, schemaID:%d, table name:%s", clusterID, schemaID, tableName)
+		return errors.WithMessagef(err, "fail to get table id, clusterID:%d, schemaID:%d, table name:%s", clusterID, schemaID, tableName)
 	}
 
 	tableID, err := strconv.ParseUint(value, 10, 64)
 	if err != nil {
-		return errors.Wrapf(err, "string to int failed")
+		return errors.WithMessagef(err, "string to int failed")
 	}
 
 	key := makeTableKey(s.rootPath, clusterID, schemaID, tableID)
@@ -332,7 +332,7 @@ func (s *metaStorageImpl) DeleteTable(ctx context.Context, clusterID uint32, sch
 		Then(opDeleteNameToID, opDeleteTable).
 		Commit()
 	if err != nil {
-		return errors.Wrapf(err, "fail to delete table, clusterID:%d, schemaID:%d, tableID:%d, tableName:%s", clusterID, schemaID, tableID, tableName)
+		return errors.WithMessagef(err, "fail to delete table, clusterID:%d, schemaID:%d, tableID:%d, tableName:%s", clusterID, schemaID, tableID, tableName)
 	}
 	if !resp.Succeeded {
 		return ErrDeleteTableAgain.WithCausef("table may already delete, clusterID:%d, schemaID:%d, tableID:%d, tableName:%s", clusterID, schemaID, tableID, tableName)
@@ -368,7 +368,7 @@ func (s *metaStorageImpl) CreateShardTopologies(ctx context.Context, clusterID u
 		Then(opCreateShardTopologiesAndLatestVersion...).
 		Commit()
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to create shard topology, clusterID:%d", clusterID)
+		return nil, errors.WithMessagef(err, "fail to create shard topology, clusterID:%d", clusterID)
 	}
 	if !resp.Succeeded {
 		return nil, ErrCreateShardTopologyAgain.WithCausef("shard topology may already exist, clusterID:%d, resp:%v", clusterID, resp)
@@ -383,13 +383,13 @@ func (s *metaStorageImpl) ListShardTopologies(ctx context.Context, clusterID uin
 		key := makeShardLatestVersionKey(s.rootPath, clusterID, shardID)
 		version, err := etcdutil.Get(ctx, s.client, key)
 		if err != nil {
-			return nil, errors.Wrapf(err, "fail to list shard topology latest version, clusterID:%d, shardID:%d, key:%s", clusterID, shardID, key)
+			return nil, errors.WithMessagef(err, "fail to list shard topology latest version, clusterID:%d, shardID:%d, key:%s", clusterID, shardID, key)
 		}
 
 		key = makeShardTopologyKey(s.rootPath, clusterID, shardID, version)
 		value, err := etcdutil.Get(ctx, s.client, key)
 		if err != nil {
-			return nil, errors.Wrapf(err, "fail to list shard topology, clusterID:%d, shardID:%d, key:%s", clusterID, shardID, key)
+			return nil, errors.WithMessagef(err, "fail to list shard topology, clusterID:%d, shardID:%d, key:%s", clusterID, shardID, key)
 		}
 
 		shardTopology := &clusterpb.ShardTopology{}
@@ -420,7 +420,7 @@ func (s *metaStorageImpl) PutShardTopology(ctx context.Context, clusterID uint32
 		Then(opPutLatestVersion, opPutShardTopology).
 		Commit()
 	if err != nil {
-		return errors.Wrapf(err, "fail to put shard topology, clusterID:%d, shardID:%d, key:%s", clusterID, shardTopology.ShardId, key)
+		return errors.WithMessagef(err, "fail to put shard topology, clusterID:%d, shardID:%d, key:%s", clusterID, shardTopology.ShardId, key)
 	}
 	if !resp.Succeeded {
 		return ErrPutShardTopologyConflict.WithCausef("shard topology may have been modified, clusterID:%d, shardID:%d, key:%s, resp:%v", clusterID, shardTopology.ShardId, key, resp)
@@ -447,7 +447,7 @@ func (s *metaStorageImpl) ListNodes(ctx context.Context, clusterID uint32) ([]*c
 
 	err := etcdutil.Scan(ctx, s.client, startKey, endKey, rangeLimit, do)
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to list nodes, clusterID:%d, start key:%s, end key:%s, range limit:%d", clusterID, startKey, endKey, rangeLimit)
+		return nil, errors.WithMessagef(err, "fail to list nodes, clusterID:%d, start key:%s, end key:%s, range limit:%d", clusterID, startKey, endKey, rangeLimit)
 	}
 
 	return nodes, nil
@@ -484,7 +484,7 @@ func (s *metaStorageImpl) CreateOrUpdateNode(ctx context.Context, clusterID uint
 		Else(opUpdateNode).
 		Commit()
 	if err != nil {
-		return nil, errors.Wrapf(err, "fail to create or update node, clusterID:%d, node name:%s, key:%s", clusterID, node.Name, key)
+		return nil, errors.WithMessagef(err, "fail to create or update node, clusterID:%d, node name:%s, key:%s", clusterID, node.Name, key)
 	}
 
 	return node, nil


### PR DESCRIPTION
# Which issue does this PR close?

Closes #20 

# Rationale for this change
 The call stack should be attached to the error cause, which helps a lot when troubleshooting problems.
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Replace `errors.Wrap(f)` with `errors.WithMessage(f)`;
- Attach call stack to `coderr` cause;
- Some fixes for docs;
<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
New ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->