### PR TITLE
feat: add shardID allocator

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -89,7 +89,8 @@ func NewCluster(meta *clusterpb.Cluster, storage storage.Storage, kv clientv3.KV
 		nodesCache:    make(map[string]*Node),
 		schemaIDAlloc: id.NewAllocatorImpl(kv, path.Join(rootPath, meta.Name, AllocSchemaIDPrefix), idAllocatorStep),
 		tableIDAlloc:  id.NewAllocatorImpl(kv, path.Join(rootPath, meta.Name, AllocTableIDPrefix), idAllocatorStep),
-		shardIDAlloc:  id.NewReusableAllocatorImpl(uint64(meta.ShardTotal)),
+		// TODO: Load ShardTopology when cluster create, pass exist shardID to allocator
+		shardIDAlloc: id.NewReusableAllocatorImpl(make([]uint64, 0), MinShardID),
 
 		storage:  storage,
 		kv:       kv,
@@ -574,6 +575,7 @@ func (c *Cluster) allocTableID(ctx context.Context) (uint64, error) {
 	return id, nil
 }
 
+// nolint
 func (c *Cluster) allocShardID(ctx context.Context) (uint32, error) {
 	id, err := c.shardIDAlloc.Alloc(ctx)
 	if err != nil {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -89,7 +89,7 @@ func NewCluster(meta *clusterpb.Cluster, storage storage.Storage, kv clientv3.KV
 		nodesCache:    make(map[string]*Node),
 		schemaIDAlloc: id.NewAllocatorImpl(kv, path.Join(rootPath, meta.Name, AllocSchemaIDPrefix), idAllocatorStep),
 		tableIDAlloc:  id.NewAllocatorImpl(kv, path.Join(rootPath, meta.Name, AllocTableIDPrefix), idAllocatorStep),
-		shardIDAlloc:  id.NewAllocatorImpl(kv, path.Join(rootPath, meta.Name, AllocShardIDPrefix), idAllocatorStep),
+		shardIDAlloc:  id.NewReusableAllocatorImpl(uint64(meta.ShardTotal)),
 
 		storage:  storage,
 		kv:       kv,
@@ -577,7 +577,7 @@ func (c *Cluster) allocTableID(ctx context.Context) (uint64, error) {
 func (c *Cluster) allocShardID(ctx context.Context) (uint32, error) {
 	id, err := c.shardIDAlloc.Alloc(ctx)
 	if err != nil {
-		return 0, errors.Wrap(err, "cluster alloc shard id failed")
+		return 0, errors.WithMessage(err, "cluster alloc shard id failed")
 	}
 	return uint32(id), nil
 }

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -22,6 +22,7 @@ const (
 	AllocClusterIDPrefix = "ClusterID"
 	AllocSchemaIDPrefix  = "SchemaID"
 	AllocTableIDPrefix   = "TableID"
+	AllocShardIDPrefix   = "ShardID"
 )
 
 type TableInfo struct {

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -22,7 +22,6 @@ const (
 	AllocClusterIDPrefix = "ClusterID"
 	AllocSchemaIDPrefix  = "SchemaID"
 	AllocTableIDPrefix   = "TableID"
-	AllocShardIDPrefix   = "ShardID"
 )
 
 type TableInfo struct {

--- a/server/cluster/shard.go
+++ b/server/cluster/shard.go
@@ -6,6 +6,10 @@ import (
 	"github.com/CeresDB/ceresdbproto/pkg/clusterpb"
 )
 
+const (
+	MinShardID = 1
+)
+
 type Shard struct {
 	meta    []*clusterpb.Shard
 	nodes   []*clusterpb.Node

--- a/server/id/error.go
+++ b/server/id/error.go
@@ -5,7 +5,8 @@ package id
 import "github.com/CeresDB/ceresmeta/pkg/coderr"
 
 var (
-	ErrTxnPutEndID = coderr.NewCodeError(coderr.Internal, "put end id in txn")
-	ErrAllocID     = coderr.NewCodeError(coderr.Internal, "alloc id")
-	ErrCollectID   = coderr.NewCodeError(coderr.Internal, "collect invalid id")
+	ErrTxnPutEndID         = coderr.NewCodeError(coderr.Internal, "put end id in txn")
+	ErrAllocID             = coderr.NewCodeError(coderr.Internal, "alloc id")
+	ErrCollectID           = coderr.NewCodeError(coderr.Internal, "collect invalid id")
+	ErrCollectNotSupported = coderr.NewCodeError(coderr.Internal, "collect is not supported")
 )

--- a/server/id/error.go
+++ b/server/id/error.go
@@ -7,4 +7,5 @@ import "github.com/CeresDB/ceresmeta/pkg/coderr"
 var (
 	ErrTxnPutEndID = coderr.NewCodeError(coderr.Internal, "put end id in txn")
 	ErrAllocID     = coderr.NewCodeError(coderr.Internal, "alloc id")
+	ErrCollectID   = coderr.NewCodeError(coderr.Internal, "collect invalid id")
 )

--- a/server/id/id.go
+++ b/server/id/id.go
@@ -9,5 +9,6 @@ type Allocator interface {
 	// Alloc allocs a unique id.
 	Alloc(ctx context.Context) (uint64, error)
 
+	// Collect collect unused id to reused in alloc
 	Collect(ctx context.Context, id uint64) error
 }

--- a/server/id/id.go
+++ b/server/id/id.go
@@ -8,4 +8,6 @@ import "context"
 type Allocator interface {
 	// Alloc allocs a unique id.
 	Alloc(ctx context.Context) (uint64, error)
+
+	Collect(ctx context.Context, id uint64) error
 }

--- a/server/id/id_impl.go
+++ b/server/id/id_impl.go
@@ -28,7 +28,7 @@ type AllocatorImpl struct {
 	isInitialized bool
 }
 
-func NewAllocatorImpl(kv clientv3.KV, key string, allocStep uint) *AllocatorImpl {
+func NewAllocatorImpl(kv clientv3.KV, key string, allocStep uint) Allocator {
 	return &AllocatorImpl{kv: kv, key: key, allocStep: allocStep}
 }
 
@@ -60,6 +60,10 @@ func (a *AllocatorImpl) Alloc(ctx context.Context) (uint64, error) {
 	ret := a.base
 	a.base++
 	return ret, nil
+}
+
+func (a *AllocatorImpl) Collect(_ context.Context, _ uint64) error {
+	return ErrCollectNotSupported
 }
 
 func (a *AllocatorImpl) slowRebaseLocked(ctx context.Context) error {

--- a/server/id/reusable_id_impl.go
+++ b/server/id/reusable_id_impl.go
@@ -21,7 +21,7 @@ type OrderedList struct {
 }
 
 // FindMinHoleValueAndIndex Find the minimum hole value and its index.
-// If the list is empty, then return invalid value and 0 as index;
+// If the list is empty, then return min value and 0 as index;
 // If no hole is found, then return the `last_value + 1` in the list and l.Len() as the index;
 func (l *OrderedList) FindMinHoleValueAndIndex(min uint64) (uint64, int) {
 	if len(l.sorted) == 0 {

--- a/server/id/reusable_id_impl.go
+++ b/server/id/reusable_id_impl.go
@@ -1,0 +1,55 @@
+package id
+
+import (
+	"context"
+	"sync"
+)
+
+type ReusableAllocatorImpl struct {
+	// RWMutex is used to protect following fields.
+	lock sync.Mutex
+
+	idQueue     []uint64
+	maxShardNum uint64
+}
+
+func NewReusableAllocatorImpl(maxShardNum uint64) *ReusableAllocatorImpl {
+	// Init id queue
+	var queue []uint64
+	for i := uint64(0); i < maxShardNum; i++ {
+		queue = append(queue, i)
+	}
+
+	return &ReusableAllocatorImpl{
+		idQueue:     queue,
+		maxShardNum: maxShardNum,
+	}
+}
+
+func (a *ReusableAllocatorImpl) isExhausted() bool {
+	return len(a.idQueue) == 0
+}
+
+func (a *ReusableAllocatorImpl) Collect(id uint64) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	if id >= a.maxShardNum {
+		return ErrCollectID.WithCausef("ID is invalid, id:%d can not greater than maxShardNum:%d", id, a.maxShardNum)
+	}
+	a.idQueue = append(a.idQueue, id)
+	return nil
+}
+
+func (a *ReusableAllocatorImpl) Alloc(ctx context.Context) (uint64, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if a.isExhausted() {
+		return 0, ErrAllocID.WithCausef("ID is exhausted, maxShardNum:%d", a.maxShardNum)
+	}
+
+	ret := a.idQueue[0]
+	a.idQueue = a.idQueue[1:]
+
+	return ret, nil
+}

--- a/server/id/reusable_id_impl.go
+++ b/server/id/reusable_id_impl.go
@@ -20,15 +20,9 @@ type OrderedList struct {
 	sorted []uint64
 }
 
-func (l *OrderedList) IndexOfValue(v uint64) int {
-	for i, value := range l.sorted {
-		if value == v {
-			return i
-		}
-	}
-	return -1
-}
-
+// FindFirstHoleValueAndIndex Find the minimum hole value and its index.
+// If the list is empty, then return invalid value and 0 as index;
+// If no hole is found, then return the `last_value + 1` in the list and l.Len() as the index;
 func (l *OrderedList) FindFirstHoleValueAndIndex(min uint64) (uint64, int) {
 	if len(l.sorted) == 0 {
 		return min, 0
@@ -50,6 +44,7 @@ func (l *OrderedList) FindFirstHoleValueAndIndex(min uint64) (uint64, int) {
 	return s[len(s)-1] + 1, len(s)
 }
 
+// Insert the value at the idx whose correctness should be ensured by the caller.
 func (l *OrderedList) Insert(v uint64, i int) {
 	if len(l.sorted) == i {
 		l.sorted = append(l.sorted, v)

--- a/server/id/reusable_id_impl.go
+++ b/server/id/reusable_id_impl.go
@@ -17,11 +17,11 @@ type ReusableAllocatorImpl struct {
 }
 
 type OrderedList struct {
-	sortedArray []uint64
+	sorted []uint64
 }
 
 func (l *OrderedList) IndexOfValue(v uint64) int {
-	for i, value := range l.sortedArray {
+	for i, value := range l.sorted {
 		if value == v {
 			return i
 		}
@@ -30,18 +30,18 @@ func (l *OrderedList) IndexOfValue(v uint64) int {
 }
 
 func (l *OrderedList) FindFirstHoleValueAndIndex(min uint64) (uint64, int) {
-	if len(l.sortedArray) == 0 {
+	if len(l.sorted) == 0 {
 		return min, 0
 	}
-	if len(l.sortedArray) == 1 {
-		return l.sortedArray[0] + 1, 1
+	if len(l.sorted) == 1 {
+		return l.sorted[0] + 1, 1
 	}
-	if l.sortedArray[0] > min {
+	if l.sorted[0] > min {
 		return min, 0
 	}
 
-	s := l.sortedArray
-	for i := 0; i < len(l.sortedArray)-1; i++ {
+	s := l.sorted
+	for i := 0; i < len(l.sorted)-1; i++ {
 		if s[i]+1 != s[i+1] {
 			return s[i] + 1, i + 1
 		}
@@ -51,42 +51,30 @@ func (l *OrderedList) FindFirstHoleValueAndIndex(min uint64) (uint64, int) {
 }
 
 func (l *OrderedList) Insert(v uint64, i int) {
-	if len(l.sortedArray) == i {
-		l.sortedArray = append(l.sortedArray, v)
+	if len(l.sorted) == i {
+		l.sorted = append(l.sorted, v)
 	} else {
-		l.sortedArray = append(l.sortedArray[:i+1], l.sortedArray[i:]...)
-		l.sortedArray[i] = v
+		l.sorted = append(l.sorted[:i+1], l.sorted[i:]...)
+		l.sorted[i] = v
 	}
-}
-
-func (l *OrderedList) Get(i int) uint64 {
-	return l.sortedArray[i]
 }
 
 func (l *OrderedList) Remove(v uint64) int {
 	removeIndex := -1
-	for i, value := range l.sortedArray {
+	for i, value := range l.sorted {
 		if value == v {
 			removeIndex = i
 		}
 	}
-	l.sortedArray = append(l.sortedArray[:removeIndex], l.sortedArray[removeIndex+1:]...)
+	l.sorted = append(l.sorted[:removeIndex], l.sorted[removeIndex+1:]...)
 	return removeIndex
-}
-
-func (l *OrderedList) Length() int {
-	return len(l.sortedArray)
-}
-
-func (l *OrderedList) Min() uint64 {
-	return l.sortedArray[0]
 }
 
 func NewReusableAllocatorImpl(existIDs []uint64, minID uint64) Allocator {
 	sort.Slice(existIDs, func(i, j int) bool {
 		return existIDs[i] < existIDs[j]
 	})
-	return &ReusableAllocatorImpl{minID: minID, existIDs: &OrderedList{sortedArray: existIDs}}
+	return &ReusableAllocatorImpl{minID: minID, existIDs: &OrderedList{sorted: existIDs}}
 }
 
 func (a *ReusableAllocatorImpl) Alloc(_ context.Context) (uint64, error) {

--- a/server/id/reusable_id_impl.go
+++ b/server/id/reusable_id_impl.go
@@ -20,18 +20,18 @@ type OrderedList struct {
 	sorted []uint64
 }
 
-// FindFirstHoleValueAndIndex Find the minimum hole value and its index.
+// FindMinHoleValueAndIndex Find the minimum hole value and its index.
 // If the list is empty, then return invalid value and 0 as index;
 // If no hole is found, then return the `last_value + 1` in the list and l.Len() as the index;
-func (l *OrderedList) FindFirstHoleValueAndIndex(min uint64) (uint64, int) {
+func (l *OrderedList) FindMinHoleValueAndIndex(min uint64) (uint64, int) {
 	if len(l.sorted) == 0 {
+		return min, 0
+	}
+	if l.sorted[0] > min {
 		return min, 0
 	}
 	if len(l.sorted) == 1 {
 		return l.sorted[0] + 1, 1
-	}
-	if l.sorted[0] > min {
-		return min, 0
 	}
 
 	s := l.sorted
@@ -76,7 +76,7 @@ func (a *ReusableAllocatorImpl) Alloc(_ context.Context) (uint64, error) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	// Find minimum unused ID bigger than minID
-	v, i := a.existIDs.FindFirstHoleValueAndIndex(a.minID)
+	v, i := a.existIDs.FindMinHoleValueAndIndex(a.minID)
 	a.existIDs.Insert(v, i)
 	return v, nil
 }

--- a/server/id/reusable_id_test.go
+++ b/server/id/reusable_id_test.go
@@ -11,33 +11,33 @@ import (
 
 func TestAlloc(t *testing.T) {
 	re := require.New(t)
-	cxt := context.Background()
+	ctx := context.Background()
 
 	allocor := NewReusableAllocatorImpl([]uint64{}, uint64(1))
 	// IDs: []
 	// Alloc: 1
 	// IDs: [1]
-	id, err := allocor.Alloc(cxt)
+	id, err := allocor.Alloc(ctx)
 	re.NoError(err)
 	re.Equal(uint64(1), id)
 
 	// IDs: [1]
 	// Alloc: 2
 	// IDs: [1,2]
-	id, err = allocor.Alloc(cxt)
+	id, err = allocor.Alloc(ctx)
 	re.NoError(err)
 	re.Equal(uint64(2), id)
 
 	// IDs: [1,2]
 	// Collect: 2
 	// IDs: [1]
-	err = allocor.Collect(cxt, uint64(2))
+	err = allocor.Collect(ctx, uint64(2))
 	re.NoError(err)
 
 	// IDs: [1]
 	// Alloc: 2
 	// IDs: [1,2]
-	id, err = allocor.Alloc(cxt)
+	id, err = allocor.Alloc(ctx)
 	re.NoError(err)
 	re.Equal(uint64(2), id)
 
@@ -47,27 +47,27 @@ func TestAlloc(t *testing.T) {
 	// IDs: [1,2,3,5,6]
 	// Alloc: 4
 	// IDs: [1,2,3,4,5,6]
-	id, err = allocor.Alloc(cxt)
+	id, err = allocor.Alloc(ctx)
 	re.NoError(err)
 	re.Equal(uint64(4), id)
 
 	// IDs: [1,2,3,4,5,6]
 	// Alloc: 7
 	// IDs: [1,2,3,4,5,6,7]
-	id, err = allocor.Alloc(cxt)
+	id, err = allocor.Alloc(ctx)
 	re.NoError(err)
 	re.Equal(uint64(7), id)
 
 	// IDs: [1,2,3,4,5,6,7]
 	// Collect: 1
 	// IDs: [2,3,4,5,6,7]
-	err = allocor.Collect(cxt, uint64(1))
+	err = allocor.Collect(ctx, uint64(1))
 	re.NoError(err)
 
 	// IDs: [2,3,4,5,6,7]
 	// Alloc: 1
 	// IDs: [1,2,3,4,5,6,7]
-	id, err = allocor.Alloc(cxt)
+	id, err = allocor.Alloc(ctx)
 	re.NoError(err)
 	re.Equal(uint64(1), id)
 }

--- a/server/id/reusable_id_test.go
+++ b/server/id/reusable_id_test.go
@@ -1,0 +1,37 @@
+package id
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	maxShardNum = 64
+)
+
+func TestAlloc(t *testing.T) {
+	re := require.New(t)
+	cxt := context.Background()
+	alloc := NewReusableAllocatorImpl(maxShardNum)
+
+	for i := 0; i < maxShardNum; i++ {
+		id, err := alloc.Alloc(cxt)
+		re.NoError(err)
+		re.Equal(uint64(i), id)
+	}
+
+	_, err := alloc.Alloc(cxt)
+	re.Error(err)
+
+	err = alloc.Collect(100)
+	re.Error(err)
+
+	err = alloc.Collect(0)
+	re.NoError(err)
+
+	id, err := alloc.Alloc(cxt)
+	re.NoError(err)
+	re.Equal(uint64(0), id)
+}

--- a/server/id/reusable_id_test.go
+++ b/server/id/reusable_id_test.go
@@ -1,3 +1,5 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 package id
 
 import (
@@ -10,33 +12,62 @@ import (
 func TestAlloc(t *testing.T) {
 	re := require.New(t)
 	cxt := context.Background()
+
+	allocor := NewReusableAllocatorImpl([]uint64{}, uint64(1))
+	// IDs: []
+	// Alloc: 1
+	// IDs: [1]
+	id, err := allocor.Alloc(cxt)
+	re.NoError(err)
+	re.Equal(uint64(1), id)
+
+	// IDs: [1]
+	// Alloc: 2
+	// IDs: [1,2]
+	id, err = allocor.Alloc(cxt)
+	re.NoError(err)
+	re.Equal(uint64(2), id)
+
+	// IDs: [1,2]
+	// Collect: 2
+	// IDs: [1]
+	err = allocor.Collect(cxt, uint64(2))
+	re.NoError(err)
+
+	// IDs: [1]
+	// Alloc: 2
+	// IDs: [1,2]
+	id, err = allocor.Alloc(cxt)
+	re.NoError(err)
+	re.Equal(uint64(2), id)
+
 	// IDs: [1,2,3,5,6]
-	alloc := NewReusableAllocatorImpl([]uint64{1, 2, 3, 5, 6}, uint64(1))
+	allocor = NewReusableAllocatorImpl([]uint64{1, 2, 3, 5, 6}, uint64(1))
 
 	// IDs: [1,2,3,5,6]
 	// Alloc: 4
 	// IDs: [1,2,3,4,5,6]
-	id, err := alloc.Alloc(cxt)
+	id, err = allocor.Alloc(cxt)
 	re.NoError(err)
 	re.Equal(uint64(4), id)
 
-	// IDs: [1,2,3,5,6]
+	// IDs: [1,2,3,4,5,6]
 	// Alloc: 7
 	// IDs: [1,2,3,4,5,6,7]
-	id, err = alloc.Alloc(cxt)
+	id, err = allocor.Alloc(cxt)
 	re.NoError(err)
 	re.Equal(uint64(7), id)
 
-	// IDs: [1,2,3,5,6]
+	// IDs: [1,2,3,4,5,6,7]
 	// Collect: 1
 	// IDs: [2,3,4,5,6,7]
-	err = alloc.Collect(cxt, uint64(1))
+	err = allocor.Collect(cxt, uint64(1))
 	re.NoError(err)
 
 	// IDs: [2,3,4,5,6,7]
 	// Alloc: 1
 	// IDs: [1,2,3,4,5,6,7]
-	id, err = alloc.Alloc(cxt)
+	id, err = allocor.Alloc(cxt)
 	re.NoError(err)
 	re.Equal(uint64(1), id)
 }

--- a/server/id/reusable_id_test.go
+++ b/server/id/reusable_id_test.go
@@ -7,31 +7,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	maxShardNum = 64
-)
-
 func TestAlloc(t *testing.T) {
 	re := require.New(t)
 	cxt := context.Background()
-	alloc := NewReusableAllocatorImpl(maxShardNum)
+	// IDs: [1,2,3,5,6]
+	alloc := NewReusableAllocatorImpl([]uint64{1, 2, 3, 5, 6}, uint64(1))
 
-	for i := 0; i < maxShardNum; i++ {
-		id, err := alloc.Alloc(cxt)
-		re.NoError(err)
-		re.Equal(uint64(i), id)
-	}
-
-	_, err := alloc.Alloc(cxt)
-	re.Error(err)
-
-	err = alloc.Collect(100)
-	re.Error(err)
-
-	err = alloc.Collect(0)
-	re.NoError(err)
-
+	// IDs: [1,2,3,5,6]
+	// Alloc: 4
+	// IDs: [1,2,3,4,5,6]
 	id, err := alloc.Alloc(cxt)
 	re.NoError(err)
-	re.Equal(uint64(0), id)
+	re.Equal(uint64(4), id)
+
+	// IDs: [1,2,3,5,6]
+	// Alloc: 7
+	// IDs: [1,2,3,4,5,6,7]
+	id, err = alloc.Alloc(cxt)
+	re.NoError(err)
+	re.Equal(uint64(7), id)
+
+	// IDs: [1,2,3,5,6]
+	// Collect: 1
+	// IDs: [2,3,4,5,6,7]
+	err = alloc.Collect(cxt, uint64(1))
+	re.NoError(err)
+
+	// IDs: [2,3,4,5,6,7]
+	// Alloc: 1
+	// IDs: [1,2,3,4,5,6,7]
+	id, err = alloc.Alloc(cxt)
+	re.NoError(err)
+	re.Equal(uint64(1), id)
 }


### PR DESCRIPTION
# Which issue does this PR close?
Closes #

# Rationale for this change
To manage the scheduling of shards, we need to generate and manage the ID of shards just like Table.

# What changes are included in this PR?
Add ShardID allocator for every cluster instance

# Are there any user-facing changes?
None

# How does this change test
Reuse the existing allocator implementation, and unit tests already exist.