### PR TITLE
feat: add shard operations impl

### DIFF
--- a/server/cluster/balancer.go
+++ b/server/cluster/balancer.go
@@ -1,0 +1,40 @@
+package cluster
+
+import "math/rand"
+
+// clusterBalancer is used to collect cluster load, determine the node to select when migrating or splitting
+type clusterBalancer struct {
+	Cluster         Cluster
+	balanceStrategy balanceStrategy
+}
+
+type balanceStrategy int32
+
+const (
+	StrategyRandom       = 0 // Select node from cluster random, only used to test
+	StrategyShardBalance = 1
+	StrategyTableBalance = 2
+)
+
+func (balancer *clusterBalancer) selectNode() *Node {
+	// default impl is select a random node
+	switch balancer.balanceStrategy {
+	case StrategyRandom:
+		nodeCache := balancer.Cluster.nodesCache
+		k := rand.Intn(len(nodeCache))
+		i := 0
+		for _, x := range nodeCache {
+			if i == k {
+				return x
+			}
+			i++
+		}
+		break
+	case StrategyShardBalance:
+		break
+	case StrategyTableBalance:
+		break
+	}
+
+	return nil
+}

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -21,8 +21,9 @@ const DefaultHeartbeatInterval = time.Second * 3
 // coordinator is used to decide if the shards need to be scheduled.
 type coordinator struct {
 	// Mutex is to ensure only one coordinator can run at the same time.
-	lock    sync.Mutex
-	cluster *Cluster
+	lock            sync.Mutex
+	cluster         *Cluster
+	clusterBalancer *clusterBalancer
 
 	ctx          context.Context
 	cancel       context.CancelFunc
@@ -136,5 +137,273 @@ func (c *coordinator) scatterShard(ctx context.Context, nodeInfo *metaservicepb.
 			return errors.WithMessage(err, "coordinator scatterShard")
 		}
 	}
+	return nil
+}
+
+/*
+*
+Only Leader Shard(`Replication_Factor` == 1)
+ 1. Same as `Multi Follower Shard` leader shard.
+
+Multi Follower Shard(`Replication_Factor` >= 2)
+- Leader Shard：
+ 1. First, CeresMeta adjusts the routing relationship and create a new follower shard on the node.
+ 2. Follower shard notifies CeresMeta after initialization.
+ 3. CeresMeta started the process of leader switch, switched the leader to the newly created follower shard.
+ 4. Close the original leader shard after the leader switch is completed.
+
+- Follower Shard：
+ 1. Adjust shard node mapping to directly assign this shard to another node.
+*/
+func (c *coordinator) migrateShard(shard *clusterpb.Shard, targetNode *Node) error {
+	// create new follower shard, reduce unavailable time
+	shardId, err := c.cluster.allocShardID(c.ctx)
+	if err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+
+	clusterTopology := c.cluster.metaData.clusterTopology
+	newFollowerShard := &clusterpb.Shard{
+		Id:        shardId,
+		ShardRole: clusterpb.ShardRole_FOLLOWER,
+		Node:      targetNode.meta.Name,
+	}
+	clusterTopology.ShardView = append(clusterTopology.ShardView, newFollowerShard)
+
+	// Update tables on new Shard
+	shardTopologies, err := c.cluster.storage.ListShardTopologies(c.ctx, c.cluster.clusterID, []uint32{shard.GetId()})
+	for i := 0; i < len(shardTopologies); i++ {
+		if shardTopologies[i].ShardId == shard.Id {
+			tables := shardTopologies[i].GetTableIds()
+			shardTopology := &clusterpb.ShardTopology{
+				ShardId:  shardId,
+				TableIds: tables,
+				Version:  0,
+			}
+
+			if err := c.cluster.storage.PutShardTopology(c.ctx, c.cluster.clusterID, shardTopology.GetVersion(), shardTopology); err != nil {
+				return errors.WithMessage(err, "coordinator migrateShard")
+			}
+		}
+	}
+
+	if err := c.cluster.storage.PutClusterTopology(c.ctx, c.cluster.clusterID, c.cluster.metaData.clusterTopology.Version, c.cluster.metaData.clusterTopology); err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+
+	if err := c.cluster.Load(c.ctx); err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+
+	// New follower shard create finish, migrate shard by transfer leader
+	if err := c.transferLeaderShard(c.ctx, shard, newFollowerShard); err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+
+	// Migrate shard finish, delete origin leader shard
+	if err := c.eventHandler.Dispatch(c.ctx, targetNode.meta.GetName(), &schedule.CloseEvent{ShardIDs: []uint32{shard.Id}}); err != nil {
+		return errors.WithMessage(err, "coordinator scatterShard")
+	}
+	for i := 0; i < len(clusterTopology.ShardView); i++ {
+		if clusterTopology.ShardView[i] == shard {
+			clusterTopology.ShardView = append(clusterTopology.ShardView[:i], clusterTopology.ShardView[i+1:]...)
+		}
+	}
+	return nil
+}
+
+/*
+*
+Only Leader Shard(`Replication_Factor` == 1)
+ 1. When there is only one leader shard, there is no need to switch leader, CeresMeta only need to migrate shard to another node.
+
+Multi Follower Shard(`Replication_Factor` >= 2)
+ 1. First, set the original leader shard and the follower to be switched to PENDING_FOLLOWER and PENDING_LEADER.
+ 2. Wait for the leader shard to complete the preparatory action before the leader switch, and notify the CeresMeta after the completion. In this process, the new leader cannot process the write request.
+ 3. After receiving this request, CeresMeta will update the status of the two shards, and the leader switch is completed.
+*/
+func (c *coordinator) transferLeaderShard(ctx context.Context, oldLeader *clusterpb.Shard, newLeader *clusterpb.Shard) error {
+	// When `Replication_Factor` == 1, newLeader is nil, find a suitable node and migrate shard to this node
+	if newLeader == nil {
+		targetNode := c.clusterBalancer.selectNode()
+		return c.migrateShard(oldLeader, targetNode)
+	}
+
+	leaderFsm := NewFSM(clusterpb.ShardRole_LEADER)
+	followerFsm := NewFSM(clusterpb.ShardRole_FOLLOWER)
+
+	if err := leaderFsm.Event(EventPrepareTransferFollower); err != nil {
+		return errors.WithMessage(err, "coordinator transferLeaderShard")
+	}
+	if err := followerFsm.Event(EventPrepareTransferLeader); err != nil {
+		return errors.WithMessage(err, "coordinator transferLeaderShard")
+	}
+
+	// Leader transfer first, follower wait until leader transfer finish
+	if err := leaderFsm.Event(EventTransferFollower); err != nil {
+		leaderFsm.Event(EventTransferFollowerFailed)
+		return errors.WithMessage(err, "coordinator transferLeaderShard")
+	}
+	if err := followerFsm.Event(EventTransferLeader); err != nil {
+		followerFsm.Event(EventTransferLeaderFailed)
+		return errors.WithMessage(err, "coordinator transferLeaderShard")
+	}
+
+	// Update cluster topology
+	currentTopology := c.cluster.metaData.clusterTopology
+	for i := 0; i < len(currentTopology.ShardView); i++ {
+		shardId := currentTopology.ShardView[i].Id
+		if shardId == oldLeader.Id {
+			currentTopology.ShardView[i].ShardRole = clusterpb.ShardRole_FOLLOWER
+		}
+		if shardId == newLeader.Id {
+			currentTopology.ShardView[i].ShardRole = clusterpb.ShardRole_LEADER
+		}
+	}
+	if err := c.cluster.storage.PutClusterTopology(ctx, c.cluster.clusterID, c.cluster.metaData.clusterTopology.Version, c.cluster.metaData.clusterTopology); err != nil {
+		return errors.WithMessage(err, "coordinator scatterShard")
+	}
+
+	if err := c.cluster.Load(ctx); err != nil {
+		return errors.WithMessage(err, "coordinator scatterShard")
+	}
+	return nil
+}
+
+// Just supported split to 2 shards, if target split size >2, repeat shard split
+func (c *coordinator) splitShard(shard *clusterpb.Shard, targetNode *Node) error {
+	shardTablesWithRole, err := c.cluster.GetTables(c.ctx, []uint32{shard.Id}, shard.Node)
+	if err != nil {
+		return errors.WithMessage(err, "coordinator splitShard")
+	}
+
+	tables := shardTablesWithRole[shard.Id].tables
+	if len(tables) <= 1 {
+		return ErrSplitShard.WithCausef("the number of tables in the shard is less than 2, cannot be split, shardID:%d", shard.Id)
+	}
+
+	// TODO: Consider better split strategy
+	originNodeTables := tables[0 : len(tables)/2]
+	targetNodeTables := tables[len(tables)/2+1 : len(tables)]
+
+	originNodeTablesID := make([]uint64, 0, len(originNodeTables))
+	for i := 0; i < len(originNodeTables); i++ {
+		originNodeTablesID = append(originNodeTablesID, originNodeTables[i].meta.Id)
+	}
+	targetNodeTablesID := make([]uint64, 0, len(targetNodeTables))
+	for i := 0; i < len(targetNodeTables); i++ {
+		targetNodeTablesID = append(targetNodeTablesID, targetNodeTables[i].meta.Id)
+	}
+
+	// Create new shard on same node
+	newShardId, err := c.cluster.allocShardID(c.ctx)
+	if err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+
+	clusterTopology := c.cluster.metaData.clusterTopology
+	newShard := &clusterpb.Shard{
+		Id:        newShardId,
+		ShardRole: clusterpb.ShardRole_LEADER,
+		Node:      targetNode.meta.Name,
+	}
+	clusterTopology.ShardView = append(clusterTopology.ShardView, newShard)
+
+	// Update origin shard topologies
+	shardTopologies, err := c.cluster.storage.ListShardTopologies(c.ctx, c.cluster.clusterID, []uint32{shard.Id})
+	if err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+	for i := 0; i < len(shardTopologies); i++ {
+		if shardTopologies[i].ShardId == shard.Id {
+			shardTopologies = append(shardTopologies, &clusterpb.ShardTopology{
+				ShardId:  shard.Id,
+				TableIds: originNodeTablesID,
+				Version:  0,
+			})
+		}
+	}
+
+	// Create new shard topologies
+	shardTopology := &clusterpb.ShardTopology{
+		ShardId:  newShardId,
+		TableIds: targetNodeTablesID,
+		Version:  0,
+	}
+
+	if err := c.cluster.storage.PutShardTopology(c.ctx, c.cluster.clusterID, shardTopology.GetVersion(), shardTopology); err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+
+	if err := c.cluster.storage.PutClusterTopology(c.ctx, c.cluster.clusterID, c.cluster.metaData.clusterTopology.Version, c.cluster.metaData.clusterTopology); err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+
+	if err := c.cluster.Load(c.ctx); err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+
+	// New shard created finish, migrate new shard to another node
+	return c.migrateShard(newShard, targetNode)
+}
+
+func (c *coordinator) mergeShard(shards []*clusterpb.Shard, targetNode *Node) error {
+	if len(shards) < 2 {
+		return ErrMergeShard.WithCausef("The number of shards to be merged is at least 2")
+	}
+
+	// Check whether the shard is in the targetNode, migrate if shard is not in the targetNode
+	shardIds := make([]uint32, 0)
+	for i := 0; i < len(shards); i++ {
+		if shards[i].Node != targetNode.meta.Name {
+			shardIds = append(shardIds, shards[i].Id)
+			if err := c.migrateShard(shards[i], targetNode); err != nil {
+				return errors.WithMessage(err, "coordinator mergeShard")
+			}
+		}
+	}
+
+	// Now merge shards in the same node
+	// Create a new shardTopology contains all tables in shards
+	shardTopologies, err := c.cluster.storage.ListShardTopologies(c.ctx, c.cluster.clusterID, shardIds)
+	if err != nil {
+		return errors.Wrap(err, "coordinator migrateShard")
+	}
+	tableIds := make([]uint64, 0)
+	for i := 0; i < len(shardTopologies); i++ {
+		tableIds = append(tableIds, shardTopologies[i].TableIds...)
+	}
+
+	shardTopology := &clusterpb.ShardTopology{
+		ShardId:  shards[0].Id,
+		TableIds: tableIds,
+		Version:  0,
+	}
+
+	if err := c.cluster.storage.PutShardTopology(c.ctx, c.cluster.clusterID, shardTopology.GetVersion(), shardTopology); err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+
+	// Close merged shards
+	if err := c.eventHandler.Dispatch(c.ctx, targetNode.meta.GetName(), &schedule.CloseEvent{ShardIDs: shardIds[1:]}); err != nil {
+		return errors.WithMessage(err, "coordinator scatterShard")
+	}
+
+	// Update cluster topology shardView, delete closed shards
+	closedShardMap := make(map[uint32]*clusterpb.Shard)
+	for _, shard := range shards[1:] {
+		closedShardMap[shard.Id] = shard
+	}
+	shardView := c.cluster.metaData.clusterTopology.ShardView
+	for i := 0; i < len(shardView); i++ {
+		if _, isPresent := closedShardMap[shardView[i].Id]; isPresent {
+			shardView = append(shardView[:i], shardView[i+1:]...)
+		}
+	}
+
+	if err := c.cluster.storage.PutClusterTopology(c.ctx, c.cluster.clusterID, c.cluster.metaData.clusterTopology.Version, c.cluster.metaData.clusterTopology); err != nil {
+		return errors.WithMessage(err, "coordinator migrateShard")
+	}
+
 	return nil
 }

--- a/server/cluster/error.go
+++ b/server/cluster/error.go
@@ -15,4 +15,7 @@ var (
 	ErrNodeNotFound            = coderr.NewCodeError(coderr.NotFound, "node not found")
 	ErrNodeShardsIsEmpty       = coderr.NewCodeError(coderr.Internal, "node's shard list is empty")
 	ErrGetShardTopology        = coderr.NewCodeError(coderr.Internal, "get shard topology")
+
+	ErrSplitShard = coderr.NewCodeError(coderr.Internal, "split shard")
+	ErrMergeShard = coderr.NewCodeError(coderr.Internal, "merge shard")
 )

--- a/server/schedule/event_handler.go
+++ b/server/schedule/event_handler.go
@@ -35,6 +35,54 @@ func (open *OpenEvent) ToHeartbeatResp() *metaservicepb.NodeHeartbeatResponse {
 	}
 }
 
+type CloseEvent struct {
+	ShardIDs []uint32
+}
+
+func (open *CloseEvent) ToHeartbeatResp() *metaservicepb.NodeHeartbeatResponse {
+	return &metaservicepb.NodeHeartbeatResponse{
+		Timestamp: uint64(time.Now().UnixMilli()),
+		Cmd: &metaservicepb.NodeHeartbeatResponse_CloseCmd{
+			CloseCmd: &metaservicepb.CloseCmd{
+				ShardIds: open.ShardIDs,
+			},
+		},
+	}
+}
+
+type TransferLeaderEvent struct {
+	OldLeaderShardID uint32
+	NewLeaderShardID uint32
+}
+
+func (open *TransferLeaderEvent) ToHeartbeatResp() *metaservicepb.NodeHeartbeatResponse {
+	return &metaservicepb.NodeHeartbeatResponse{
+		Timestamp: uint64(time.Now().UnixMilli()),
+		Cmd: &metaservicepb.NodeHeartbeatResponse_ChangeRoleCmd{
+			ChangeRoleCmd: &metaservicepb.ChangeRoleCmd{
+				// TODO: fix params
+			},
+		},
+	}
+}
+
+type TransferLeaderFailedEvent struct {
+	OldLeaderShardID uint32
+	NewLeaderShardID uint32
+}
+
+func (open *TransferLeaderFailedEvent) ToHeartbeatResp() *metaservicepb.NodeHeartbeatResponse {
+	// TODO : Use the correct call
+	return &metaservicepb.NodeHeartbeatResponse{
+		Timestamp: uint64(time.Now().UnixMilli()),
+		Cmd: &metaservicepb.NodeHeartbeatResponse_ChangeRoleCmd{
+			ChangeRoleCmd: &metaservicepb.ChangeRoleCmd{
+				// TODO: fix params
+			},
+		},
+	}
+}
+
 type EventHandler struct {
 	hbstreams *HeartbeatStreams
 }


### PR DESCRIPTION
# Which issue does this PR close?
Closes #

# Rationale for this change
Add shard operations implementation, support shard `transferLeader`、`migrate`、`split`、`merge`

# What changes are included in this PR?
* Add shard fsm `callback` implementation.
* Add `transferLeaderShard`、`migrateShard`、`splitShard`、`mergeShard` implementation in `coordinator` .
* Add `balancer` to select the best node when temporary shards need to be created.

# Are there any user-facing changes?
None.

# How does this change test
Pass unit test.