### PR TITLE
feat: define procedure interface

### DIFF
--- a/server/coordinator/procedure/procedure.go
+++ b/server/coordinator/procedure/procedure.go
@@ -1,0 +1,45 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package procedure
+
+import "context"
+
+type State string
+
+const (
+	StateRunning   = "running"
+	StateFinished  = "finished"
+	StateFailed    = "failed"
+	StateCancelled = "cancelled"
+)
+
+type procedureType = uint
+
+const (
+	switchLeader procedureType = iota
+	mergeShard
+)
+
+// Procedure is used to describe how to execute a set of operations from the scheduler, e.g. SwitchLeaderProcedure, MergeShardProcedure.
+type Procedure interface {
+	// ID of the procedure.
+	ID() uint64
+
+	// Type of the procedure.
+	Type() procedureType
+
+	// Start the procedure.
+	Start(ctx context.Context) error
+
+	// Cancel the procedure.
+	Cancel(ctx context.Context) error
+
+	// State of the procedure. Retrieve the state of this procedure.
+	State() State
+}
+
+// nolint
+type Manager struct {
+	storage    *Storage
+	procedures []Procedure
+}

--- a/server/coordinator/procedure/procedure.go
+++ b/server/coordinator/procedure/procedure.go
@@ -13,10 +13,10 @@ const (
 	StateCancelled = "cancelled"
 )
 
-type procedureType = uint
+type Typ = uint
 
 const (
-	switchLeader procedureType = iota
+	switchLeader Typ = iota
 	mergeShard
 )
 
@@ -26,7 +26,7 @@ type Procedure interface {
 	ID() uint64
 
 	// Type of the procedure.
-	Type() procedureType
+	Type() Typ
 
 	// Start the procedure.
 	Start(ctx context.Context) error

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -11,7 +11,8 @@ type Write interface {
 // nolint
 type Meta struct {
 	id      uint64
-	typ     uint8
+	typ     procedureType
+	state   State
 	rawData []byte
 }
 

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -1,3 +1,5 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 package procedure
 
 import (
@@ -10,13 +12,13 @@ type Write interface {
 
 // nolint
 type Meta struct {
-	id      uint64
-	typ     procedureType
-	state   State
-	rawData []byte
+	ID      uint64
+	Typ     Typ
+	State   State
+	RawData []byte
 }
 
 type Storage interface {
 	Write
-	List(ctx context.Context, state State) (*Meta, error)
+	Scan(ctx context.Context, batchSize uint, state State, meta []*Meta) error
 }

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -1,0 +1,21 @@
+package procedure
+
+import (
+	"context"
+)
+
+type Write interface {
+	CreateOrUpdate(ctx context.Context, meta *Meta) error
+}
+
+// nolint
+type Meta struct {
+	id      uint64
+	typ     uint8
+	rawData []byte
+}
+
+type Storage interface {
+	Write
+	List(ctx context.Context, state State) (*Meta, error)
+}

--- a/server/coordinator/procedure/switch_leader.go
+++ b/server/coordinator/procedure/switch_leader.go
@@ -1,3 +1,5 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 package procedure
 
 import (
@@ -21,7 +23,7 @@ func (s *SwitchLeaderProcedure) ID() uint64 {
 	return 0
 }
 
-func (s *SwitchLeaderProcedure) Type() procedureType {
+func (s *SwitchLeaderProcedure) Type() Typ {
 	return switchLeader
 }
 

--- a/server/coordinator/procedure/switch_leader.go
+++ b/server/coordinator/procedure/switch_leader.go
@@ -1,0 +1,38 @@
+package procedure
+
+import (
+	"context"
+)
+
+func NewSwitchLeaderProcedure() *SwitchLeaderProcedure {
+	return nil
+}
+
+func LoadSwitchLeaderProcedure(_ []byte) *SwitchLeaderProcedure {
+	return nil
+}
+
+// nolint
+type SwitchLeaderProcedure struct {
+	writer Write
+}
+
+func (s *SwitchLeaderProcedure) ID() uint64 {
+	return 0
+}
+
+func (s *SwitchLeaderProcedure) Type() procedureType {
+	return switchLeader
+}
+
+func (s *SwitchLeaderProcedure) Start(_ context.Context) error {
+	return nil
+}
+
+func (s *SwitchLeaderProcedure) Cancel(_ context.Context) error {
+	return nil
+}
+
+func (s *SwitchLeaderProcedure) State() State {
+	return ""
+}

--- a/server/coordinator/procedure/switch_leader.go
+++ b/server/coordinator/procedure/switch_leader.go
@@ -8,7 +8,7 @@ func NewSwitchLeaderProcedure() *SwitchLeaderProcedure {
 	return nil
 }
 
-func LoadSwitchLeaderProcedure(_ []byte) *SwitchLeaderProcedure {
+func LoadSwitchLeaderProcedure(_ *Meta) *SwitchLeaderProcedure {
 	return nil
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 `Procedure` is used to describe how to execute a set of operations of the procedure.
 All procedures like `SwitchLeaderProcedure` and `MergeShardProcedure` need to implement `Procedure`.

 <!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Define `Procedure` interface.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
No.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->