### PR TITLE
feat: set warningCode = 1 in revive config

### DIFF
--- a/revive.toml
+++ b/revive.toml
@@ -1,8 +1,8 @@
 ignoreGeneratedHeader = true
 severity = "warning"
 confidence = 0.8
-errorCode = 0
-warningCode = 0
+errorCode = 1
+warningCode = 1
 
 [rule.blank-imports]
 [rule.context-as-argument]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #64 

# Rationale for this change
 CI should fail when encountering revive lint warnings.
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Set `warningCode = 1` in revive config, ci will fail when encountering revive lint warnings .
Refer to https://github.com/mgechev/revive/blob/a4add4a769339021d98d1cbf241a4b043957ac93/README.md.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
No need.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->