### PR TITLE
feat: add procedure storage implementation

### DIFF
--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -21,5 +21,5 @@ type Meta struct {
 type Storage interface {
 	Write
 	List(ctx context.Context, batchSize int) ([]*Meta, error)
-	MarkDeleted(ctx context.Context, meta *Meta) error
+	MarkDeleted(ctx context.Context, id uint64) error
 }

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -8,7 +8,6 @@ import (
 
 type Write interface {
 	CreateOrUpdate(ctx context.Context, meta *Meta) error
-	Delete(ctx context.Context, meta *Meta) error
 }
 
 // nolint
@@ -21,5 +20,5 @@ type Meta struct {
 
 type Storage interface {
 	Write
-	Scan(ctx context.Context, batchSize int) ([]*Meta, error)
+	ReadAll(ctx context.Context, batchSize int, metas *[]*Meta) error
 }

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -8,6 +8,7 @@ import (
 
 type Write interface {
 	CreateOrUpdate(ctx context.Context, meta *Meta) error
+	Delete(ctx context.Context, meta *Meta) error
 }
 
 // nolint

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -20,5 +20,6 @@ type Meta struct {
 
 type Storage interface {
 	Write
-	ReadAllNeedRetry(ctx context.Context, batchSize int, metas *[]*Meta) error
+	List(ctx context.Context, batchSize int) ([]*Meta, error)
+	MarkDeleted(ctx context.Context, meta *Meta) error
 }

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -21,5 +21,5 @@ type Meta struct {
 
 type Storage interface {
 	Write
-	Scan(ctx context.Context, batchSize uint) ([]*Procedure, error)
+	Scan(ctx context.Context, batchSize int) ([]*Meta, error)
 }

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -20,5 +20,5 @@ type Meta struct {
 
 type Storage interface {
 	Write
-	Scan(ctx context.Context, batchSize uint, state State, meta []*Meta) error
+	Scan(ctx context.Context, batchSize uint, state State, typ Typ) ([]*Procedure, error)
 }

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -20,5 +20,5 @@ type Meta struct {
 
 type Storage interface {
 	Write
-	ReadAll(ctx context.Context, batchSize int, metas *[]*Meta) error
+	ReadAllNeedRetry(ctx context.Context, batchSize int, metas *[]*Meta) error
 }

--- a/server/coordinator/procedure/storage.go
+++ b/server/coordinator/procedure/storage.go
@@ -21,5 +21,5 @@ type Meta struct {
 
 type Storage interface {
 	Write
-	Scan(ctx context.Context, batchSize uint, state State, typ Typ) ([]*Procedure, error)
+	Scan(ctx context.Context, batchSize uint) ([]*Procedure, error)
 }

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -26,7 +26,7 @@ type EtcdStorageImpl struct {
 	rootPath  string
 }
 
-func NewEtcdStorageImpl(client *clientv3.Client, clusterID uint32, rootPath string) *EtcdStorageImpl {
+func NewEtcdStorageImpl(client *clientv3.Client, clusterID uint32, rootPath string) Storage {
 	return &EtcdStorageImpl{
 		client:    client,
 		clusterID: clusterID,

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -1,3 +1,5 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 package procedure
 
 import (

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -59,7 +59,7 @@ func (e EtcdStorageImpl) CreateOrUpdate(ctx context.Context, meta *Meta) error {
 }
 
 // Delete example:
-// historyProcedure : /{rootPath}/v1/historyProcedure/{clusterID}/{procedureID}
+// deletedProcedure : /{rootPath}/v1/historyProcedure/{clusterID}/{procedureID}
 func (e EtcdStorageImpl) deleteAndRecord(ctx context.Context, meta *Meta) error {
 	str, err := encode(meta)
 	if err != nil {
@@ -75,7 +75,7 @@ func (e EtcdStorageImpl) deleteAndRecord(ctx context.Context, meta *Meta) error 
 	return err
 }
 
-func (e EtcdStorageImpl) ReadAll(ctx context.Context, batchSize int, metas *[]*Meta) error {
+func (e EtcdStorageImpl) ReadAllNeedRetry(ctx context.Context, batchSize int, metas *[]*Meta) error {
 	do := func(_ string, value []byte) error {
 		meta := &Meta{}
 		if err := decode(meta, string(value)); err != nil {

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -22,14 +22,14 @@ const (
 
 type EtcdStorageImpl struct {
 	client    *clientv3.Client
-	clusterId uint32
+	clusterID uint32
 	rootPath  string
 }
 
-func NewEtcdStorageImpl(client *clientv3.Client, clusterId uint32, rootPath string) *EtcdStorageImpl {
+func NewEtcdStorageImpl(client *clientv3.Client, clusterID uint32, rootPath string) *EtcdStorageImpl {
 	return &EtcdStorageImpl{
 		client:    client,
-		clusterId: clusterId,
+		clusterID: clusterID,
 		rootPath:  rootPath,
 	}
 }
@@ -90,14 +90,14 @@ func (e EtcdStorageImpl) Scan(ctx context.Context, batchSize int) ([]*Meta, erro
 	return metas, nil
 }
 
-func (e EtcdStorageImpl) generateKeyPath(procedureId uint64, isHistory bool) string {
+func (e EtcdStorageImpl) generateKeyPath(procedureID uint64, isHistory bool) string {
 	var pathPrefix string
 	if isHistory {
 		pathPrefix = PathHistoryProcedure
 	} else {
 		pathPrefix = PathProcedure
 	}
-	return path.Join(e.rootPath, Version, pathPrefix, fmtID(uint64(e.clusterId)), fmtID(procedureId))
+	return path.Join(e.rootPath, Version, pathPrefix, fmtID(uint64(e.clusterID)), fmtID(procedureID))
 }
 
 func fmtID(id uint64) string {
@@ -105,11 +105,11 @@ func fmtID(id uint64) string {
 }
 
 func encode(meta *Meta) (string, error) {
-	if bytes, err := json.Marshal(meta); err != nil {
+	bytes, err := json.Marshal(meta)
+	if err != nil {
 		return "", err
-	} else {
-		return string(bytes), nil
 	}
+	return string(bytes), nil
 }
 
 func decode(m *Meta, meta string) error {

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -107,6 +107,7 @@ func fmtID(id uint64) string {
 	return fmt.Sprintf("%020d", id)
 }
 
+// TODO: Use proto.Marshal replace json.Marshal
 func encode(meta *Meta) (string, error) {
 	bytes, err := json.Marshal(meta)
 	if err != nil {
@@ -115,6 +116,7 @@ func encode(meta *Meta) (string, error) {
 	return string(bytes), nil
 }
 
+// TODO: Use proto.Unmarshal replace json.unmarshal
 func decode(m *Meta, meta string) error {
 	err := json.Unmarshal([]byte(meta), &m)
 	return err

--- a/server/coordinator/procedure/storage_impl.go
+++ b/server/coordinator/procedure/storage_impl.go
@@ -1,0 +1,93 @@
+package procedure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"path"
+
+	"github.com/CeresDB/ceresmeta/server/etcdutil"
+	"github.com/pkg/errors"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+const (
+	Version       = "v1"
+	PathProcedure = "procedure"
+)
+
+type EtcdStorageImpl struct {
+	client *clientv3.Client
+
+	// opts Options
+	clusterId uint32
+
+	rootPath string
+}
+
+// example:
+// procedure 1: v1/procedure/{ClusterID}/{procedureID} -> {procedureType} + {procedureState} + {data}
+
+func (e EtcdStorageImpl) CreateOrUpdate(ctx context.Context, meta *Meta) error {
+	keyPath := e.generateKeyPath(meta.ID)
+
+	str, err := encode(meta)
+	if err != nil {
+		return errors.WithMessage(err, "encode meta failed")
+	}
+	opPutProcedure := clientv3.OpPut(keyPath, str)
+
+	_, err = e.client.Txn(ctx).
+		Then(opPutProcedure).
+		Commit()
+
+	return err
+}
+
+func (e EtcdStorageImpl) Scan(ctx context.Context, batchSize uint, state State, typ Typ) ([]*Meta, error) {
+
+	metas := make([]*Meta, 0)
+	do := func(_ string, value []byte) error {
+		meta := &Meta{}
+		if err := decode(meta, string(value)); err != nil {
+			return errors.WithMessage(err, "decode meta failed")
+		}
+
+		metas = append(metas, meta)
+		return nil
+	}
+
+	startKey := e.generateKeyPath(0)
+	endKey := e.generateKeyPath(math.MaxUint64)
+
+	err := etcdutil.Scan(ctx, e.client, startKey, endKey, math.MaxInt, do)
+	if err != nil {
+		return nil, errors.WithMessage(err, "scan procedure failed")
+	}
+	return metas, nil
+}
+
+/*
+*
+ */
+func (e EtcdStorageImpl) generateKeyPath(procedureId uint64) string {
+	return path.Join(e.rootPath, Version, PathProcedure, fmtID(uint64(e.clusterId)), fmtID(procedureId))
+}
+
+func fmtID(id uint64) string {
+	return fmt.Sprintf("%020d", id)
+}
+
+func encode(meta *Meta) (string, error) {
+	if bytes, err := json.Marshal(meta); err != nil {
+		return "", err
+	} else {
+		return string(bytes), nil
+	}
+}
+
+func decode(m *Meta, meta string) error {
+	err := json.Unmarshal([]byte(meta), &m)
+	return err
+}

--- a/server/coordinator/procedure/storage_test.go
+++ b/server/coordinator/procedure/storage_test.go
@@ -4,10 +4,11 @@ package procedure
 
 import (
 	"context"
-	"github.com/CeresDB/ceresmeta/server/etcdutil"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/CeresDB/ceresmeta/server/etcdutil"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/server/coordinator/procedure/storage_test.go
+++ b/server/coordinator/procedure/storage_test.go
@@ -60,8 +60,7 @@ func testScan(t *testing.T, storage *EtcdStorageImpl) {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancel()
 
-	metas := make([]*Meta, 0)
-	err := storage.ReadAllNeedRetry(ctx, DefaultScanBatchSie, &metas)
+	metas, err := storage.List(ctx, DefaultScanBatchSie)
 	re.NoError(err)
 	re.Equal(2, len(metas))
 	re.Equal("test", string(metas[0].RawData))
@@ -79,11 +78,10 @@ func testDelete(t *testing.T, storage *EtcdStorageImpl) {
 		State:   StateInit,
 		RawData: []byte("test"),
 	}
-	err := storage.deleteAndRecord(ctx, testMeta1)
+	err := storage.MarkDeleted(ctx, testMeta1.ID)
 	re.NoError(err)
 
-	metas := make([]*Meta, 0)
-	err = storage.ReadAllNeedRetry(ctx, DefaultScanBatchSie, &metas)
+	metas, err := storage.List(ctx, DefaultScanBatchSie)
 	re.NoError(err)
 	re.Equal(1, len(metas))
 }

--- a/server/coordinator/procedure/storage_test.go
+++ b/server/coordinator/procedure/storage_test.go
@@ -1,0 +1,13 @@
+package procedure
+
+import (
+	"testing"
+)
+
+func TestWrite(t *testing.T) {
+
+}
+
+func TestScan(t *testing.T) {
+
+}

--- a/server/coordinator/procedure/storage_test.go
+++ b/server/coordinator/procedure/storage_test.go
@@ -61,9 +61,11 @@ func testScan(t *testing.T, storage *EtcdStorageImpl) {
 	defer cancel()
 
 	metas := make([]*Meta, 0)
-	err := storage.ReadAll(ctx, DefaultScanBatchSie, &metas)
+	err := storage.ReadAllNeedRetry(ctx, DefaultScanBatchSie, &metas)
 	re.NoError(err)
 	re.Equal(2, len(metas))
+	re.Equal("test", string(metas[0].RawData))
+	re.Equal("test update", string(metas[1].RawData))
 }
 
 func testDelete(t *testing.T, storage *EtcdStorageImpl) {
@@ -81,7 +83,7 @@ func testDelete(t *testing.T, storage *EtcdStorageImpl) {
 	re.NoError(err)
 
 	metas := make([]*Meta, 0)
-	err = storage.ReadAll(ctx, DefaultScanBatchSie, &metas)
+	err = storage.ReadAllNeedRetry(ctx, DefaultScanBatchSie, &metas)
 	re.NoError(err)
 	re.Equal(1, len(metas))
 }

--- a/server/coordinator/procedure/storage_test.go
+++ b/server/coordinator/procedure/storage_test.go
@@ -60,7 +60,8 @@ func testScan(t *testing.T, storage *EtcdStorageImpl) {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancel()
 
-	metas, err := storage.Scan(ctx, DefaultScanBatchSie)
+	metas := make([]*Meta, 0)
+	err := storage.ReadAll(ctx, DefaultScanBatchSie, &metas)
 	re.NoError(err)
 	re.Equal(2, len(metas))
 }
@@ -76,10 +77,11 @@ func testDelete(t *testing.T, storage *EtcdStorageImpl) {
 		State:   StateInit,
 		RawData: []byte("test"),
 	}
-	err := storage.Delete(ctx, testMeta1)
+	err := storage.deleteAndRecord(ctx, testMeta1)
 	re.NoError(err)
 
-	metas, err := storage.Scan(ctx, DefaultScanBatchSie)
+	metas := make([]*Meta, 0)
+	err = storage.ReadAll(ctx, DefaultScanBatchSie, &metas)
 	re.NoError(err)
 	re.Equal(1, len(metas))
 }

--- a/server/coordinator/procedure/storage_test.go
+++ b/server/coordinator/procedure/storage_test.go
@@ -18,13 +18,13 @@ const (
 	DefaultScanBatchSie = 100
 )
 
-func newTestStorage(t *testing.T) *EtcdStorageImpl {
+func newTestStorage(t *testing.T) Storage {
 	_, client, _ := etcdutil.PrepareEtcdServerAndClient(t)
 	storage := NewEtcdStorageImpl(client, uint32(TestClusterID), TestRootPath)
 	return storage
 }
 
-func testWrite(t *testing.T, storage *EtcdStorageImpl) {
+func testWrite(t *testing.T, storage Storage) {
 	re := require.New(t)
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancel()
@@ -55,7 +55,7 @@ func testWrite(t *testing.T, storage *EtcdStorageImpl) {
 	re.NoError(err)
 }
 
-func testScan(t *testing.T, storage *EtcdStorageImpl) {
+func testScan(t *testing.T, storage Storage) {
 	re := require.New(t)
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancel()
@@ -67,7 +67,7 @@ func testScan(t *testing.T, storage *EtcdStorageImpl) {
 	re.Equal("test update", string(metas[1].RawData))
 }
 
-func testDelete(t *testing.T, storage *EtcdStorageImpl) {
+func testDelete(t *testing.T, storage Storage) {
 	re := require.New(t)
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
 	defer cancel()

--- a/server/coordinator/procedure/storage_test.go
+++ b/server/coordinator/procedure/storage_test.go
@@ -1,3 +1,5 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 package procedure
 
 import (

--- a/server/coordinator/procedure/storage_test.go
+++ b/server/coordinator/procedure/storage_test.go
@@ -1,13 +1,89 @@
 package procedure
 
 import (
+	"context"
+	"github.com/CeresDB/ceresmeta/server/etcdutil"
+	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
-func TestWrite(t *testing.T) {
+const (
+	TestClusterID       = 1
+	TestRootPath        = "/rootPath"
+	DefaultTimeout      = time.Second * 10
+	DefaultScanBatchSie = 100
+)
 
+func newTestStorage(t *testing.T) *EtcdStorageImpl {
+	_, client, _ := etcdutil.PrepareEtcdServerAndClient(t)
+	storage := NewEtcdStorageImpl(client, uint32(TestClusterID), TestRootPath)
+	return storage
 }
 
-func TestScan(t *testing.T) {
+func testWrite(t *testing.T, storage *EtcdStorageImpl) {
+	re := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
 
+	testMeta1 := &Meta{
+		ID:      uint64(1),
+		Typ:     TransferLeader,
+		State:   StateInit,
+		RawData: []byte("test"),
+	}
+
+	// Test create new procedure
+	err := storage.CreateOrUpdate(ctx, testMeta1)
+	re.NoError(err)
+
+	testMeta2 := &Meta{
+		ID:      uint64(2),
+		Typ:     TransferLeader,
+		State:   StateInit,
+		RawData: []byte("test"),
+	}
+	err = storage.CreateOrUpdate(ctx, testMeta2)
+	re.NoError(err)
+
+	// Test update procedure
+	testMeta2.RawData = []byte("test update")
+	err = storage.CreateOrUpdate(ctx, testMeta2)
+	re.NoError(err)
+}
+
+func testScan(t *testing.T, storage *EtcdStorageImpl) {
+	re := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	metas, err := storage.Scan(ctx, DefaultScanBatchSie)
+	re.NoError(err)
+	re.Equal(2, len(metas))
+}
+
+func testDelete(t *testing.T, storage *EtcdStorageImpl) {
+	re := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	testMeta1 := &Meta{
+		ID:      uint64(1),
+		Typ:     TransferLeader,
+		State:   StateInit,
+		RawData: []byte("test"),
+	}
+	err := storage.Delete(ctx, testMeta1)
+	re.NoError(err)
+
+	metas, err := storage.Scan(ctx, DefaultScanBatchSie)
+	re.NoError(err)
+	re.Equal(1, len(metas))
+}
+
+func TestStorage(t *testing.T) {
+	storage := newTestStorage(t)
+	testWrite(t, storage)
+	testScan(t, storage)
+	testDelete(t, storage)
 }

--- a/server/etcdutil/util.go
+++ b/server/etcdutil/util.go
@@ -33,6 +33,9 @@ func Scan(ctx context.Context, client *clientv3.Client, startKey, endKey string,
 	if err != nil {
 		return ErrEtcdKVGet.WithCause(err)
 	}
+	if len(resp.Kvs) == 0 {
+		return nil
+	}
 
 	doIfNotEndKey := func(key, val []byte) error {
 		// TODO: avoid such a copy on key.


### PR DESCRIPTION
# Which issue does this PR close?
https://github.com/CeresDB/ceresmeta/issues/62

# Rationale for this change
Implementation of procedure storage based on `etcd`, and expose appropriate interfaces externally.

# What changes are included in this PR?
* Add `Delete` func to `Write` interface
* Add implementation for `EtcdStorageImpl`
* Add test for `EtcdStorageImpl`

# Are there any user-facing changes?
None.

# How does this change test
Pass unit test.