### PR TITLE
feat: add rebuild topology

### DIFF
--- a/server/coordinator/procedure/error.go
+++ b/server/coordinator/procedure/error.go
@@ -5,6 +5,7 @@ package procedure
 import "github.com/CeresDB/ceresmeta/pkg/coderr"
 
 var (
-	ErrShardLeaderNotFound = coderr.NewCodeError(coderr.Internal, "shard leader not found")
-	ErrProcedureNotFound   = coderr.NewCodeError(coderr.Internal, "procedure not found")
+	ErrShardLeaderNotFound  = coderr.NewCodeError(coderr.Internal, "shard leader not found")
+	ErrProcedureNotFound    = coderr.NewCodeError(coderr.Internal, "procedure not found")
+	ErrClusterConfigChanged = coderr.NewCodeError(coderr.Internal, "cluster config changed")
 )

--- a/server/coordinator/procedure/scatter.go
+++ b/server/coordinator/procedure/scatter.go
@@ -59,7 +59,7 @@ func scatterPrepareCallback(event *fsm.Event) {
 		err := reopenShards(ctx, c, request.dispatch)
 		// If rebuild topology failed, cancel event.
 		if err != nil {
-			cancelEventWithLog(event, err, "update cluster topology state failed")
+			cancelEventWithLog(event, err, "reopen shards failed")
 			return
 		}
 	}
@@ -259,7 +259,7 @@ func (p *ScatterProcedure) updateStateWithLock(state State) {
 func reopenShards(ctx context.Context, c *cluster.Cluster, dispatch eventdispatch.Dispatch) error {
 	nodeShardsResult, err := c.GetNodeShards(ctx)
 	if err != nil {
-		return errors.WithMessage(err, "get cluster shard view failed")
+		return errors.WithMessage(err, "get cluster node shards result failed")
 	}
 	for _, nodeShard := range nodeShardsResult.NodeShards {
 		err := dispatch.OpenShard(ctx, nodeShard.Endpoint, &eventdispatch.OpenShardRequest{

--- a/server/coordinator/procedure/scatter.go
+++ b/server/coordinator/procedure/scatter.go
@@ -102,8 +102,9 @@ func scatterPrepareCallback(event *fsm.Event) {
 	for _, shard := range shards {
 		openShardRequest := &eventdispatch.OpenShardRequest{
 			Shard: &cluster.ShardInfo{
-				ID:   shard.GetId(),
-				Role: clusterpb.ShardRole_LEADER,
+				ID:      shard.GetId(),
+				Role:    clusterpb.ShardRole_LEADER,
+				Version: uint64(0),
 			},
 		}
 		if err := request.dispatch.OpenShard(ctx, shard.Node, openShardRequest); err != nil {
@@ -262,7 +263,7 @@ func reopenShards(ctx context.Context, c *cluster.Cluster, dispatch eventdispatc
 	}
 	for _, shardView := range shardViews {
 		err := dispatch.OpenShard(ctx, shardView.GetNode(), &eventdispatch.OpenShardRequest{
-			Shard: &cluster.ShardInfo{ID: shardView.GetId(), Role: shardView.GetShardRole()},
+			Shard: &cluster.ShardInfo{ID: shardView.GetId(), Role: shardView.GetShardRole(), Version: uint64(0)},
 		})
 		if err != nil {
 			return errors.WithMessage(err, "open shard failed")


### PR DESCRIPTION
# Which issue does this PR close?
https://github.com/CeresDB/ceresmeta/issues/74

# Rationale for this change
Rebuild cluster topology based on metadata when restarted, recover to stable state.

 <!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
* Add `rebuildTopology` function, it will be rebuild cluster when `CeresMeta` leader node restarts.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->