### PR TITLE
feat: add procedure scheduler

### DIFF
--- a/server/cluster/node.go
+++ b/server/cluster/node.go
@@ -2,7 +2,9 @@
 
 package cluster
 
-import "github.com/CeresDB/ceresdbproto/pkg/clusterpb"
+import (
+	"github.com/CeresDB/ceresdbproto/pkg/clusterpb"
+)
 
 type RegisteredNode struct {
 	meta       *clusterpb.Node
@@ -26,4 +28,8 @@ func (n *RegisteredNode) GetMeta() *clusterpb.Node {
 
 func (n *RegisteredNode) IsOnline() bool {
 	return n.meta.State == clusterpb.NodeState_ONLINE
+}
+
+func (n Node) IsExpire(now uint64, aliveThreshold uint64) bool {
+	return now-n.GetMeta().LastTouchTime >= aliveThreshold
 }

--- a/server/cluster/node.go
+++ b/server/cluster/node.go
@@ -30,6 +30,6 @@ func (n *RegisteredNode) IsOnline() bool {
 	return n.meta.State == clusterpb.NodeState_ONLINE
 }
 
-func (n Node) IsExpire(now uint64, aliveThreshold uint64) bool {
+func (n RegisteredNode) IsExpire(now uint64, aliveThreshold uint64) bool {
 	return now-n.GetMeta().LastTouchTime >= aliveThreshold
 }

--- a/server/cluster/node.go
+++ b/server/cluster/node.go
@@ -30,6 +30,6 @@ func (n *RegisteredNode) IsOnline() bool {
 	return n.meta.State == clusterpb.NodeState_ONLINE
 }
 
-func (n RegisteredNode) IsExpire(now uint64, aliveThreshold uint64) bool {
+func (n RegisteredNode) IsExpired(now uint64, aliveThreshold uint64) bool {
 	return now-n.GetMeta().LastTouchTime >= aliveThreshold
 }

--- a/server/cluster/node.go
+++ b/server/cluster/node.go
@@ -31,5 +31,5 @@ func (n *RegisteredNode) IsOnline() bool {
 }
 
 func (n RegisteredNode) IsExpired(now uint64, aliveThreshold uint64) bool {
-	return now-n.GetMeta().LastTouchTime >= aliveThreshold
+	return now >= aliveThreshold+n.GetMeta().LastTouchTime
 }

--- a/server/cluster/shard.go
+++ b/server/cluster/shard.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	MinShardID = 1
+	MinShardID = 0
 )
 
 type Shard struct {

--- a/server/coordinator/scheduler.go
+++ b/server/coordinator/scheduler.go
@@ -116,7 +116,6 @@ func (s *Scheduler) checkNode(ctx context.Context, ticker *time.Ticker) {
 // applyMetadata verify shardInfo in heartbeats and metadata, they are forcibly synchronized to the latest version if they are inconsistent.
 // TODO: Encapsulate the following logic as a standalone ApplyProcedure
 func (s *Scheduler) applyMetadataShardInfo(ctx context.Context, node string, realShards []*cluster.ShardInfo, expectShards []*cluster.ShardInfo) error {
-	// Create mapping for
 	realShardInfoMapping := make(map[uint32]*cluster.ShardInfo, len(realShards))
 	expectShardInfoMapping := make(map[uint32]*cluster.ShardInfo, len(expectShards))
 	for _, realShard := range realShards {

--- a/server/coordinator/scheduler.go
+++ b/server/coordinator/scheduler.go
@@ -1,0 +1,150 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package coordinator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/CeresDB/ceresdbproto/pkg/clusterpb"
+	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/CeresDB/ceresmeta/server/cluster"
+	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
+	"github.com/CeresDB/ceresmeta/server/coordinator/procedure"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+const (
+	heartbeatCheckInterval     = 10 * time.Second
+	heartbeatKeepAliveInterval = 15 * time.Second
+)
+
+type Scheduler struct {
+	// This lock is used to protect the field `running`.
+	lock    sync.RWMutex
+	running bool
+
+	clusterManager   cluster.Manager
+	procedureManager procedure.Manager
+	procedureFactory *procedure.Factory
+	dispatch         eventdispatch.Dispatch
+
+	checkNodeTicker *time.Ticker
+}
+
+func NewScheduler(clusterManager cluster.Manager, procedureManager procedure.Manager, procedureFactory *procedure.Factory, dispatch eventdispatch.Dispatch) *Scheduler {
+	return &Scheduler{
+		running:          false,
+		clusterManager:   clusterManager,
+		procedureManager: procedureManager,
+		procedureFactory: procedureFactory,
+		dispatch:         dispatch,
+	}
+}
+
+func (s *Scheduler) Start(ctx context.Context) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.running = true
+	ticker := time.NewTicker(heartbeatCheckInterval)
+	s.checkNodeTicker = ticker
+	go s.checkNode(ctx, ticker)
+	return nil
+}
+
+func (s *Scheduler) Stop(_ context.Context) error {
+	s.checkNodeTicker.Stop()
+	return nil
+}
+
+func (s *Scheduler) ProcessHeartbeat(_ context.Context, _ *metaservicepb.NodeInfo) {
+	// Check node version and update to latest.
+}
+
+func (s *Scheduler) checkNode(ctx context.Context, ticker *time.Ticker) {
+	for t := range ticker.C {
+		log.Info("procedure scheduler checkNodeState")
+		clusters, err := s.clusterManager.ListClusters(ctx)
+		if err != nil {
+			log.Error("list clusters failed", zap.Error(err))
+			continue
+		}
+		for _, c := range clusters {
+			nodes := c.GetRegisteredNodes()
+			nodeShards, err := c.GetNodeShards(ctx)
+			if err != nil {
+				log.Error("get node shards failed")
+				continue
+			}
+			nodeShardsMapping := make(map[string][]*cluster.ShardInfo)
+			for _, nodeShard := range nodeShards.NodeShards {
+				_, exists := nodeShardsMapping[nodeShard.Endpoint]
+				if !exists {
+					nodeShardsMapping[nodeShard.Endpoint] = make([]*cluster.ShardInfo, 0)
+				}
+				nodeShardsMapping[nodeShard.Endpoint] = append(nodeShardsMapping[nodeShard.Endpoint], nodeShard.ShardInfo)
+			}
+			for _, node := range nodes {
+				if node.GetMeta().GetState() == clusterpb.NodeState_OFFLINE {
+					continue
+				}
+				// Determines whether node is online by compares heartbeatKeepAliveInterval with time.now() - lastTouchTime.
+				if uint64(t.Unix())-node.GetMeta().LastTouchTime >= uint64((heartbeatKeepAliveInterval).Seconds()) {
+					node.GetMeta().State = clusterpb.NodeState_OFFLINE
+				} else {
+					// Shard versions of CeresDB and CeresMeta may be inconsistent. And close extra shards and open missing shards if so.
+					realShards := node.GetShardInfos()
+					expectShards := nodeShardsMapping[node.GetMeta().GetName()]
+					err := s.applyMetadataShardInfo(ctx, node.GetMeta().GetName(), realShards, expectShards)
+					if err != nil {
+						log.Error("apply metadata failed", zap.Error(err))
+					}
+				}
+			}
+		}
+		log.Info("procedure scheduler checkNodeState finish")
+	}
+}
+
+// applyMetadata verify shardInfo in heartbeats and metadata, they are forcibly synchronized to the latest version if they are inconsistent.
+// TODO: Encapsulate the following logic as a standalone ApplyProcedure
+func (s *Scheduler) applyMetadataShardInfo(ctx context.Context, node string, realShards []*cluster.ShardInfo, expectShards []*cluster.ShardInfo) error {
+	realShardInfoMapping := make(map[uint32]*cluster.ShardInfo, len(realShards))
+	expectShardInfoMapping := make(map[uint32]*cluster.ShardInfo, len(expectShards))
+	for _, realShard := range realShards {
+		realShardInfoMapping[realShard.ID] = realShard
+	}
+	for _, expectShard := range expectShards {
+		expectShardInfoMapping[expectShard.ID] = expectShard
+	}
+	for _, expectShard := range expectShards {
+		realShard, exists := realShardInfoMapping[expectShard.ID]
+		if !exists {
+			if err := s.dispatch.OpenShard(ctx, node, &eventdispatch.OpenShardRequest{Shard: expectShard}); err != nil {
+				return errors.WithMessage(err, fmt.Sprintf("reopen shard failed, shardInfo:%d", expectShard.ID))
+			}
+		} else {
+			if realShard.Version != expectShard.Version {
+				if err := s.dispatch.CloseShard(ctx, node, &eventdispatch.CloseShardRequest{ShardID: expectShard.ID}); err != nil {
+					return errors.WithMessage(err, fmt.Sprintf("close shard failed, shardInfo:%d", expectShard.ID))
+				}
+				if err := s.dispatch.OpenShard(ctx, node, &eventdispatch.OpenShardRequest{Shard: expectShard}); err != nil {
+					return errors.WithMessage(err, fmt.Sprintf("reopen shard failed, shardInfo:%d", expectShard.ID))
+				}
+			}
+		}
+	}
+	for _, realShard := range realShards {
+		_, exists := expectShardInfoMapping[realShard.ID]
+		if !exists {
+			if err := s.dispatch.CloseShard(ctx, node, &eventdispatch.CloseShardRequest{ShardID: realShard.ID}); err != nil {
+				return errors.WithMessage(err, fmt.Sprintf("close shard failed, shardInfo:%d", realShard.ID))
+			}
+		}
+	}
+	return nil
+}

--- a/server/coordinator/scheduler.go
+++ b/server/coordinator/scheduler.go
@@ -99,7 +99,7 @@ func (s *Scheduler) checkNode(ctx context.Context, ticker *time.Ticker) {
 func (s *Scheduler) processNodes(ctx context.Context, nodes []*cluster.RegisteredNode, t time.Time, nodeShardsMapping map[string][]*cluster.ShardInfo) {
 	for _, node := range nodes {
 		// Determines whether node is online by compares heartbeatKeepAliveInterval with time.now() - lastTouchTime.
-		if !node.IsExpire(uint64(t.Unix()), uint64((heartbeatKeepAliveInterval).Seconds())) {
+		if !node.IsExpired(uint64(t.Unix()), uint64((heartbeatKeepAliveInterval).Seconds())) {
 			// Shard versions of CeresDB and CeresMeta may be inconsistent. And close extra shards and open missing shards if so.
 			realShards := node.GetShardInfos()
 			expectShards := nodeShardsMapping[node.GetMeta().GetName()]


### PR DESCRIPTION
# Which issue does this PR close?

Closes # https://github.com/CeresDB/ceresmeta/issues/76

# Rationale for this change
Providing Basic failover capability of CeresDB cluster mode.

# What changes are included in this PR?
* Add `ProcedureScheduler` implementation.
* Add node crash detection in `checkNodeState`.
* Procedure scheduler automatically submit `TransferLeaderProcedure` when node crashed.

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->