### PR TITLE
fix: fix some scatter error

### DIFF
--- a/pkg/coderr/code.go
+++ b/pkg/coderr/code.go
@@ -15,8 +15,9 @@ const (
 	Internal           = http.StatusInternalServerError
 
 	// HTTPCodeUpperBound is a bound under which any Code should have the same meaning with the http status code.
-	HTTPCodeUpperBound = Code(1000)
-	PrintHelpUsage     = 1001
+	HTTPCodeUpperBound   = Code(1000)
+	PrintHelpUsage       = 1001
+	ClusterAlreadyExists = 1002
 )
 
 // ToHTTPCode converts the Code to http code.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -49,7 +49,7 @@ func (c *Cluster) GetNodes() []*Node {
 	nodes := make([]*Node, 0, len(c.nodesCache))
 	for _, node := range c.nodesCache {
 		nodes = append(nodes, &Node{
-			meta:     ConvertNodeTOPB(node),
+			meta:     ConvertNodeToPB(node),
 			shardIDs: node.shardIDs,
 		})
 	}
@@ -629,8 +629,6 @@ func (c *Cluster) RouteTables(_ context.Context, schemaName string, tableNames [
 
 	schema, ok := c.schemasCache[schemaName]
 	if !ok {
-		// TODO: add
-		// return nil, ErrSchemaNotFound.WithCausef("schemaName:%s", schemaName)
 		routeEntries := make(map[string]*RouteEntry)
 
 		return &RouteTablesResult{
@@ -810,7 +808,7 @@ func (c *Cluster) UnlockShardByID(shardID uint32) {
 	delete(c.shardLock, shardID)
 }
 
-func (c *Cluster) UpdateNodeState(ctx context.Context, state clusterpb.NodeState, node string) error {
+func (c *Cluster) UpdateNodeState(ctx context.Context, node string, state clusterpb.NodeState) error {
 	for _, n := range c.nodesCache {
 		if n.GetMeta().GetName() == node {
 			n.GetMeta().State = state

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -553,11 +553,6 @@ func (c *Cluster) GetShardByID(id uint32) (*Shard, error) {
 // GetShardByID return immutable `Shard`.
 func (c *Cluster) getShardByIDLocked(id uint32) (*Shard, error) {
 	shard, ok := c.shardsCache[id]
-	for leaderID, s := range c.shardsCache {
-		if leaderID == id {
-			return s, nil
-		}
-	}
 	if !ok {
 		return nil, ErrShardNotFound.WithCausef("cluster GetShardByID, shardID:%s", id)
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -41,7 +41,7 @@ type Cluster struct {
 	shardIDAlloc  id.Allocator
 }
 
-func (c *Cluster) GetNodesSize() int {
+func (c *Cluster) GetAvailableNodesSize() int {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	nodeSize := 0
@@ -56,7 +56,7 @@ func (c *Cluster) GetNodesSize() int {
 func (c *Cluster) GetNodes() []*Node {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	nodes := make([]*Node, 0)
+	nodes := make([]*Node, 0, len(c.nodesCache))
 	for _, node := range c.nodesCache {
 		nodes = append(nodes, &Node{
 			meta: &clusterpb.Node{
@@ -816,8 +816,8 @@ func (c *Cluster) UpdateNodeState(ctx context.Context, state clusterpb.NodeState
 	for _, n := range nodes {
 		if n.Name == node {
 			n.State = state
-			_, err1 := c.storage.CreateOrUpdateNode(ctx, c.clusterID, n)
-			if err1 != nil {
+			_, err := c.storage.CreateOrUpdateNode(ctx, c.clusterID, n)
+			if err != nil {
 				return errors.WithMessage(err, "update node state failed")
 			}
 		}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -60,7 +60,7 @@ func (c *Cluster) GetClusterNodeCache() map[string]*Node {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	newNodes := make(map[string]*Node)
+	newNodes := map[string]*Node{}
 	for key, value := range c.nodesCache {
 		newNodes[key] = value
 	}
@@ -464,7 +464,7 @@ func (c *Cluster) loadClusterTopologyLocked(ctx context.Context) (map[uint32][]*
 		return nil, nil, ErrClusterTopologyNotFound.WithCausef("cluster:%v", c)
 	}
 
-	shardMap := make(map[uint32][]*clusterpb.Shard)
+	shardMap := map[uint32][]*clusterpb.Shard{}
 	for _, shard := range c.metaData.clusterTopology.ShardView {
 		shardMap[shard.Id] = append(shardMap[shard.Id], shard)
 	}

--- a/server/cluster/error.go
+++ b/server/cluster/error.go
@@ -6,7 +6,7 @@ import "github.com/CeresDB/ceresmeta/pkg/coderr"
 
 var (
 	ErrCreateCluster           = coderr.NewCodeError(coderr.BadRequest, "create cluster")
-	ErrClusterAlreadyExists    = coderr.NewCodeError(coderr.Internal, "cluster already exists")
+	ErrClusterAlreadyExists    = coderr.NewCodeError(coderr.ClusterAlreadyExists, "cluster already exists")
 	ErrClusterStateInvalid     = coderr.NewCodeError(coderr.Internal, "cluster state invalid")
 	ErrClusterNotFound         = coderr.NewCodeError(coderr.NotFound, "cluster not found")
 	ErrClusterTopologyNotFound = coderr.NewCodeError(coderr.NotFound, "cluster topology not found")

--- a/server/cluster/error.go
+++ b/server/cluster/error.go
@@ -14,6 +14,7 @@ var (
 	ErrTableNotFound           = coderr.NewCodeError(coderr.NotFound, "Table not found")
 	ErrShardNotFound           = coderr.NewCodeError(coderr.NotFound, "shard not found")
 	ErrNodeNotFound            = coderr.NewCodeError(coderr.NotFound, "node not found")
+	ErrNodeIsEmpty             = coderr.NewCodeError(coderr.NotFound, "cluster nodes list is empty")
 	ErrNodeShardsIsEmpty       = coderr.NewCodeError(coderr.Internal, "node's shard list is empty")
 	ErrGetShardTopology        = coderr.NewCodeError(coderr.Internal, "get shard topology")
 	ErrTableAlreadyExists      = coderr.NewCodeError(coderr.Internal, "table already exists")

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -29,6 +29,7 @@ type Manager interface {
 	// Stop must be called before manager is dropped.
 	Stop(ctx context.Context) error
 
+	ListClusters(ctx context.Context) ([]*Cluster, error)
 	CreateCluster(ctx context.Context, clusterName string, nodeCount, replicationFactor, shardTotal uint32) (*Cluster, error)
 	GetCluster(ctx context.Context, clusterName string) (*Cluster, error)
 	// AllocSchemaID means get or create schema.
@@ -42,7 +43,7 @@ type Manager interface {
 	RegisterNode(ctx context.Context, clusterName string, nodeInfo *metaservicepb.NodeInfo) error
 	GetShards(ctx context.Context, clusterName, nodeName string) ([]uint32, error)
 	RouteTables(ctx context.Context, clusterName, schemaName string, tableNames []string) (*RouteTablesResult, error)
-	GetNodes(ctx context.Context, clusterName string) (*GetNodesResult, error)
+	GetNodeShards(ctx context.Context, clusterName string) (*GetNodeShardsResult, error)
 }
 
 type managerImpl struct {
@@ -73,6 +74,16 @@ func NewManagerImpl(storage storage.Storage, kv clientv3.KV, rootPath string, id
 	return manager, nil
 }
 
+func (m *managerImpl) ListClusters(_ context.Context) ([]*Cluster, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	clusters := make([]*Cluster, 0)
+	for _, cluster := range m.clusters {
+		clusters = append(clusters, cluster)
+	}
+	return clusters, nil
+}
+
 func (m *managerImpl) CreateCluster(ctx context.Context, clusterName string, initialNodeCount,
 	replicationFactor, shardTotal uint32,
 ) (*Cluster, error) {
@@ -84,10 +95,10 @@ func (m *managerImpl) CreateCluster(ctx context.Context, clusterName string, ini
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	_, ok := m.clusters[clusterName]
+	cluster, ok := m.clusters[clusterName]
 	if ok {
-		log.Error("cluster already exists", zap.String("clusterName", clusterName))
-		return nil, ErrClusterAlreadyExists
+		// log.Error("cluster already exists", zap.String("clusterName", clusterName))
+		return cluster, ErrClusterAlreadyExists
 	}
 
 	clusterID, err := m.allocClusterID(ctx)
@@ -109,7 +120,7 @@ func (m *managerImpl) CreateCluster(ctx context.Context, clusterName string, ini
 		return nil, errors.WithMessagef(err, "cluster manager CreateCluster, clusters:%v", clusterPb)
 	}
 
-	cluster := NewCluster(clusterPb, m.storage, m.kv, m.rootPath, m.idAllocatorStep)
+	cluster = NewCluster(clusterPb, m.storage, m.kv, m.rootPath, m.idAllocatorStep)
 
 	if err = cluster.init(ctx); err != nil {
 		log.Error("fail to init cluster", zap.Error(err))
@@ -183,6 +194,17 @@ func (m *managerImpl) GetTables(ctx context.Context, clusterName, nodeName strin
 	if err != nil {
 		log.Error("cluster not found", zap.Error(err))
 		return nil, errors.WithMessage(err, "cluster manager GetTables")
+	}
+
+	if cluster.GetClusterState() == clusterpb.ClusterTopology_EMPTY {
+		ret := make(map[uint32]*ShardTables, len(shardIDs))
+		for _, shardID := range shardIDs {
+			ret[shardID] = &ShardTables{
+				Tables: nil,
+				Shard:  &ShardInfo{ID: shardID, Role: clusterpb.ShardRole_LEADER},
+			}
+		}
+		return ret, nil
 	}
 
 	shardTablesWithRole, err := cluster.GetTables(ctx, shardIDs, nodeName)
@@ -329,13 +351,13 @@ func (m *managerImpl) RouteTables(ctx context.Context, clusterName, schemaName s
 	return ret, nil
 }
 
-func (m *managerImpl) GetNodes(ctx context.Context, clusterName string) (*GetNodesResult, error) {
+func (m *managerImpl) GetNodeShards(ctx context.Context, clusterName string) (*GetNodeShardsResult, error) {
 	cluster, err := m.getCluster(clusterName)
 	if err != nil {
 		return nil, errors.WithMessage(err, "cluster manager GetNodes")
 	}
 
-	ret, err := cluster.GetNodes(ctx)
+	ret, err := cluster.GetNodeShards(ctx)
 	if err != nil {
 		return nil, errors.WithMessage(err, "cluster manager GetNodes")
 	}

--- a/server/cluster/manager_test.go
+++ b/server/cluster/manager_test.go
@@ -249,7 +249,7 @@ func testAllocTableIDMultiThread(ctx context.Context, re *require.Assertions, ma
 }
 
 func testGetNodes(ctx context.Context, re *require.Assertions, manager Manager, cluster string) {
-	getNodesResult, err := manager.GetNodes(ctx, cluster)
+	getNodesResult, err := manager.GetNodeShards(ctx, cluster)
 	re.NoError(err)
 	re.Equal(defaultShardTotal, len(getNodesResult.NodeShards))
 }

--- a/server/cluster/node.go
+++ b/server/cluster/node.go
@@ -16,3 +16,7 @@ func (n Node) GetShardIDs() []uint32 {
 func (n Node) GetMeta() *clusterpb.Node {
 	return n.meta
 }
+
+func (n Node) IsAvailable() bool {
+	return n.meta.State == clusterpb.NodeState_ONLINE
+}

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -69,7 +69,7 @@ func ConvertTableInfoToPB(table *TableInfo) *metaservicepb.TableInfo {
 	}
 }
 
-func ConvertNodeTOPB(node *Node) *clusterpb.Node {
+func ConvertNodeToPB(node *Node) *clusterpb.Node {
 	return &clusterpb.Node{
 		Name:                  node.meta.Name,
 		NodeStats:             node.meta.NodeStats,

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -68,3 +68,14 @@ func ConvertTableInfoToPB(table *TableInfo) *metaservicepb.TableInfo {
 		SchemaName: table.SchemaName,
 	}
 }
+
+func ConvertNodeTOPB(node *Node) *clusterpb.Node {
+	return &clusterpb.Node{
+		Name:                  node.meta.Name,
+		NodeStats:             node.meta.NodeStats,
+		CreateTime:            node.meta.CreateTime,
+		LastTouchTime:         node.meta.LastTouchTime,
+		State:                 node.meta.State,
+		HeartbeatSamplingInfo: node.meta.HeartbeatSamplingInfo,
+	}
+}

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -47,7 +47,7 @@ type RouteTablesResult struct {
 	RouteEntries map[string]*RouteEntry
 }
 
-type GetNodesResult struct {
+type GetNodeShardsResult struct {
 	ClusterTopologyVersion uint64
 	NodeShards             []*NodeShard
 }

--- a/server/coordinator/eventdispatch/dispatch_impl.go
+++ b/server/coordinator/eventdispatch/dispatch_impl.go
@@ -35,7 +35,7 @@ func (d *DispatchImpl) OpenShard(ctx context.Context, addr string, request *Open
 	if err != nil {
 		return errors.WithMessage(err, "open shard")
 	}
-	if resp.GetHeader().Code != 0 {
+	if resp.GetHeader().Code != 200 {
 		return ErrDispatch.WithCausef("open shard, err:%s", resp.GetHeader().GetError())
 	}
 	return nil
@@ -52,7 +52,7 @@ func (d *DispatchImpl) CloseShard(ctx context.Context, addr string, request *Clo
 	if err != nil {
 		return errors.WithMessage(err, "close shard")
 	}
-	if resp.GetHeader().Code != 0 {
+	if resp.GetHeader().Code != 200 {
 		return ErrDispatch.WithCausef("close shard, err:%s", resp.GetHeader().GetError())
 	}
 	return nil
@@ -67,7 +67,7 @@ func (d *DispatchImpl) CreateTableOnShard(ctx context.Context, addr string, requ
 	if err != nil {
 		return errors.WithMessage(err, "create table on shard")
 	}
-	if resp.GetHeader().Code != 0 {
+	if resp.GetHeader().Code != 200 {
 		return ErrDispatch.WithCausef("create table on shard, err:%s", resp.GetHeader().GetError())
 	}
 	return nil
@@ -82,7 +82,7 @@ func (d *DispatchImpl) DropTableOnShard(ctx context.Context, addr string, reques
 	if err != nil {
 		return errors.WithMessage(err, "drop table on shard")
 	}
-	if resp.GetHeader().Code != 0 {
+	if resp.GetHeader().Code != 200 {
 		return ErrDispatch.WithCausef("drop table on shard, err:%s", resp.GetHeader().GetError())
 	}
 	return nil

--- a/server/coordinator/eventdispatch/dispatch_impl.go
+++ b/server/coordinator/eventdispatch/dispatch_impl.go
@@ -35,7 +35,7 @@ func (d *DispatchImpl) OpenShard(ctx context.Context, addr string, request *Open
 	if err != nil {
 		return errors.WithMessage(err, "open shard")
 	}
-	if resp.GetHeader().Code != 200 {
+	if resp.GetHeader().Code != 0 {
 		return ErrDispatch.WithCausef("open shard, err:%s", resp.GetHeader().GetError())
 	}
 	return nil
@@ -52,7 +52,7 @@ func (d *DispatchImpl) CloseShard(ctx context.Context, addr string, request *Clo
 	if err != nil {
 		return errors.WithMessage(err, "close shard")
 	}
-	if resp.GetHeader().Code != 200 {
+	if resp.GetHeader().Code != 0 {
 		return ErrDispatch.WithCausef("close shard, err:%s", resp.GetHeader().GetError())
 	}
 	return nil
@@ -67,7 +67,7 @@ func (d *DispatchImpl) CreateTableOnShard(ctx context.Context, addr string, requ
 	if err != nil {
 		return errors.WithMessage(err, "create table on shard")
 	}
-	if resp.GetHeader().Code != 200 {
+	if resp.GetHeader().Code != 0 {
 		return ErrDispatch.WithCausef("create table on shard, err:%s", resp.GetHeader().GetError())
 	}
 	return nil
@@ -82,7 +82,7 @@ func (d *DispatchImpl) DropTableOnShard(ctx context.Context, addr string, reques
 	if err != nil {
 		return errors.WithMessage(err, "drop table on shard")
 	}
-	if resp.GetHeader().Code != 200 {
+	if resp.GetHeader().Code != 0 {
 		return ErrDispatch.WithCausef("drop table on shard, err:%s", resp.GetHeader().GetError())
 	}
 	return nil

--- a/server/coordinator/procedure/factory.go
+++ b/server/coordinator/procedure/factory.go
@@ -25,8 +25,8 @@ type ScatterRequest struct {
 
 type TransferLeaderRequest struct {
 	Cluster   *cluster.Cluster
-	OldLeader clusterpb.Shard
-	NewLeader clusterpb.Shard
+	OldLeader *clusterpb.Shard
+	NewLeader *clusterpb.Shard
 }
 
 type CreateTableRequest struct {
@@ -66,7 +66,7 @@ func (f *Factory) CreateTransferLeaderProcedure(ctx context.Context, request *Tr
 	if err != nil {
 		return nil, err
 	}
-	procedure := NewTransferLeaderProcedure(f.dispatch, request.Cluster, &request.OldLeader, &request.NewLeader, id)
+	procedure := NewTransferLeaderProcedure(f.dispatch, request.Cluster, request.OldLeader, request.NewLeader, id)
 	return procedure, nil
 }
 

--- a/server/coordinator/procedure/scatter.go
+++ b/server/coordinator/procedure/scatter.go
@@ -90,6 +90,11 @@ func scatterPrepareCallback(event *fsm.Event) {
 		return
 	}
 
+	if err := request.cluster.Load(request.ctx); err != nil {
+		cancelEventWithLog(event, err, "cluster load data failed")
+		return
+	}
+
 	for _, shard := range shards {
 		openShardRequest := &eventdispatch.OpenShardRequest{
 			Shard: &cluster.ShardInfo{

--- a/server/coordinator/procedure/scatter.go
+++ b/server/coordinator/procedure/scatter.go
@@ -90,11 +90,6 @@ func scatterPrepareCallback(event *fsm.Event) {
 		return
 	}
 
-	if err := request.cluster.Load(request.ctx); err != nil {
-		cancelEventWithLog(event, err, "cluster load data failed")
-		return
-	}
-
 	for _, shard := range shards {
 		openShardRequest := &eventdispatch.OpenShardRequest{
 			Shard: &cluster.ShardInfo{
@@ -107,6 +102,7 @@ func scatterPrepareCallback(event *fsm.Event) {
 			return
 		}
 	}
+
 }
 
 func waitForNodesReady(c *cluster.Cluster) {
@@ -158,7 +154,13 @@ func allocNodeShards(_ context.Context, shardTotal uint32, minNodeCount uint32, 
 	return shards, nil
 }
 
-func scatterSuccessCallback(_ *fsm.Event) {
+func scatterSuccessCallback(event *fsm.Event) {
+	request := event.Args[0].(*ScatterCallbackRequest)
+
+	if err := request.cluster.Load(request.ctx); err != nil {
+		cancelEventWithLog(event, err, "cluster load data failed")
+		return
+	}
 	log.Info("scatter procedure execute finish")
 }
 

--- a/server/coordinator/procedure/scatter.go
+++ b/server/coordinator/procedure/scatter.go
@@ -107,7 +107,6 @@ func scatterPrepareCallback(event *fsm.Event) {
 			return
 		}
 	}
-
 }
 
 func waitForNodesReady(c *cluster.Cluster) {

--- a/server/coordinator/procedure/scatter.go
+++ b/server/coordinator/procedure/scatter.go
@@ -158,9 +158,7 @@ func allocNodeShards(_ context.Context, shardTotal uint32, minNodeCount uint32, 
 	return shards, nil
 }
 
-func scatterSuccessCallback(event *fsm.Event) {
-	// request := event.Args[0].(*ScatterCallbackRequest)
-
+func scatterSuccessCallback(_ *fsm.Event) {
 	log.Info("scatter procedure execute finish")
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -220,7 +220,7 @@ func (srv *Server) createDefaultCluster(ctx context.Context) {
 			log.Info("create default cluster succeed", zap.String("cluster", c.Name()))
 		}
 		// Create and submit scatter procedure for default cluster
-		if defaultCluster, err := srv.clusterManager.GetCluster(ctx, srv.cfg.DefaultClusterName); err != nil {
+		if defaultCluster, err := srv.clusterManager.GetCluster(ctx, srv.cfg.DefaultClusterName); err == nil {
 			shardIDs := make([]uint32, 0)
 			for i := uint32(0); i < defaultCluster.GetClusterShardTotal(); i++ {
 				shardID, err := defaultCluster.AllocShardID(ctx)

--- a/server/server.go
+++ b/server/server.go
@@ -205,7 +205,7 @@ func (srv *Server) watchEtcdLeaderPriority(_ context.Context) {
 	defer srv.bgJobWg.Done()
 }
 
-func (srv *Server) createDefaultCluster(ctx context.Context) {
+func (srv *Server) createDefaultCluster(ctx context.Context) error {
 	leaderResp, err := srv.member.GetLeader(ctx)
 	if err != nil {
 		log.Warn("get leader failed", zap.Error(err))
@@ -213,35 +213,37 @@ func (srv *Server) createDefaultCluster(ctx context.Context) {
 
 	// Create default cluster by the leader.
 	if leaderResp.IsLocal {
-		c, err := srv.clusterManager.CreateCluster(ctx, srv.cfg.DefaultClusterName, uint32(srv.cfg.DefaultClusterNodeCount), uint32(srv.cfg.DefaultClusterReplicationFactor), uint32(srv.cfg.DefaultClusterShardTotal))
+		defaultCluster, err := srv.clusterManager.CreateCluster(ctx, srv.cfg.DefaultClusterName, uint32(srv.cfg.DefaultClusterNodeCount), uint32(srv.cfg.DefaultClusterReplicationFactor), uint32(srv.cfg.DefaultClusterShardTotal))
 		if err != nil {
 			log.Warn("create default cluster failed", zap.Error(err))
-		} else {
-			log.Info("create default cluster succeed", zap.String("cluster", c.Name()))
-		}
-		// Create and submit scatter procedure for default cluster
-		if defaultCluster, err := srv.clusterManager.GetCluster(ctx, srv.cfg.DefaultClusterName); err == nil {
-			shardIDs := make([]uint32, 0)
-			for i := uint32(0); i < defaultCluster.GetClusterShardTotal(); i++ {
-				shardID, err := defaultCluster.AllocShardID(ctx)
+			if err == cluster.ErrClusterAlreadyExists {
+				defaultCluster, err = srv.clusterManager.GetCluster(ctx, srv.cfg.DefaultClusterName)
 				if err != nil {
-					log.Error("alloc shard id failed")
-					return
+					return errors.WithMessage(err, "get default cluster failed")
 				}
-				shardIDs = append(shardIDs, shardID)
 			}
-			scatterRequest := &procedure.ScatterRequest{Cluster: defaultCluster, ShardIDs: shardIDs}
-			scatterProcedure, err := srv.procedureFactory.CreateScatterProcedure(ctx, scatterRequest)
+		} else {
+			log.Info("create default cluster succeed", zap.String("cluster", defaultCluster.Name()))
+		}
+		// Create and submit scatter procedure for default cluster.
+		shardIDs := make([]uint32, 0)
+		for i := uint32(0); i < defaultCluster.GetClusterShardTotal(); i++ {
+			shardID, err := defaultCluster.AllocShardID(ctx)
 			if err != nil {
-				log.Error("create scatter procedure failed")
-				return
+				return errors.WithMessage(err, "alloc shard id failed")
 			}
-			if err := srv.procedureManager.Submit(ctx, scatterProcedure); err != nil {
-				log.Error("submit scatter procedure failed")
-				return
-			}
+			shardIDs = append(shardIDs, shardID)
+		}
+		scatterRequest := &procedure.ScatterRequest{Cluster: defaultCluster, ShardIDs: shardIDs}
+		scatterProcedure, err := srv.procedureFactory.CreateScatterProcedure(ctx, scatterRequest)
+		if err != nil {
+			return errors.WithMessage(err, "create scatter procedure failed")
+		}
+		if err := srv.procedureManager.Submit(ctx, scatterProcedure); err != nil {
+			return errors.WithMessage(err, "submit scatter procedure failed")
 		}
 	}
+	return nil
 }
 
 type leaderWatchContext struct {
@@ -287,7 +289,9 @@ func (c *leadershipEventCallbacks) AfterElected(ctx context.Context) {
 	if err := c.srv.procedureManager.Start(ctx); err != nil {
 		panic(fmt.Sprintf("procedure manager fail to start, err:%v", err))
 	}
-	c.srv.createDefaultCluster(ctx)
+	if err := c.srv.createDefaultCluster(ctx); err != nil {
+		panic(fmt.Sprintf("create default cluster failed, err:%v", err))
+	}
 }
 
 func (c *leadershipEventCallbacks) BeforeTransfer(ctx context.Context) {

--- a/server/server.go
+++ b/server/server.go
@@ -5,11 +5,11 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"sync"
 	"sync/atomic"
 
 	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/config"

--- a/server/server.go
+++ b/server/server.go
@@ -227,7 +227,7 @@ func (srv *Server) createDefaultCluster(ctx context.Context) error {
 			log.Info("create default cluster succeed", zap.String("cluster", defaultCluster.Name()))
 		}
 		// Create and submit scatter procedure for default cluster.
-		var shardIDs []uint32
+		shardIDs := make([]uint32, defaultCluster.GetClusterShardTotal())
 		for i := uint32(0); i < defaultCluster.GetClusterShardTotal(); i++ {
 			shardID, err := defaultCluster.AllocShardID(ctx)
 			if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -295,7 +295,7 @@ func (c *leadershipEventCallbacks) BeforeTransfer(ctx context.Context) {
 		panic(fmt.Sprintf("cluster manager fail to stop, err:%v", err))
 	}
 
-	if err := c.srv.clusterManager.Stop(ctx); err != nil {
+	if err := c.srv.procedureManager.Stop(ctx); err != nil {
 		panic(fmt.Sprintf("procedure manager fail to stop, err:%v", err))
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"sync"
 	"sync/atomic"
 
@@ -216,7 +217,7 @@ func (srv *Server) createDefaultCluster(ctx context.Context) error {
 		defaultCluster, err := srv.clusterManager.CreateCluster(ctx, srv.cfg.DefaultClusterName, uint32(srv.cfg.DefaultClusterNodeCount), uint32(srv.cfg.DefaultClusterReplicationFactor), uint32(srv.cfg.DefaultClusterShardTotal))
 		if err != nil {
 			log.Warn("create default cluster failed", zap.Error(err))
-			if err == cluster.ErrClusterAlreadyExists {
+			if coderr.Is(err, cluster.ErrClusterAlreadyExists.Code()) {
 				defaultCluster, err = srv.clusterManager.GetCluster(ctx, srv.cfg.DefaultClusterName)
 				if err != nil {
 					return errors.WithMessage(err, "get default cluster failed")
@@ -226,7 +227,7 @@ func (srv *Server) createDefaultCluster(ctx context.Context) error {
 			log.Info("create default cluster succeed", zap.String("cluster", defaultCluster.Name()))
 		}
 		// Create and submit scatter procedure for default cluster.
-		shardIDs := make([]uint32, 0)
+		var shardIDs []uint32
 		for i := uint32(0); i < defaultCluster.GetClusterShardTotal(); i++ {
 			shardID, err := defaultCluster.AllocShardID(ctx)
 			if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -227,7 +227,7 @@ func (srv *Server) createDefaultCluster(ctx context.Context) error {
 			log.Info("create default cluster succeed", zap.String("cluster", defaultCluster.Name()))
 		}
 		// Create and submit scatter procedure for default cluster.
-		shardIDs := make([]uint32, defaultCluster.GetClusterShardTotal())
+		shardIDs := make([]uint32, 0, defaultCluster.GetClusterShardTotal())
 		for i := uint32(0); i < defaultCluster.GetClusterShardTotal(); i++ {
 			shardID, err := defaultCluster.AllocShardID(ctx)
 			if err != nil {

--- a/server/service/grpc/service.go
+++ b/server/service/grpc/service.go
@@ -253,7 +253,7 @@ func (s *Service) GetNodes(ctx context.Context, req *metaservicepb.GetNodesReque
 		return ceresmetaClient.GetNodes(ctx, req)
 	}
 
-	nodesResult, err := s.h.GetClusterManager().GetNodes(ctx, req.GetHeader().GetClusterName())
+	nodesResult, err := s.h.GetClusterManager().GetNodeShards(ctx, req.GetHeader().GetClusterName())
 	if err != nil {
 		log.Error("fail to get nodes", zap.Error(err))
 		return &metaservicepb.GetNodesResponse{Header: responseHeader(err, "grpc get nodes")}, nil
@@ -307,7 +307,7 @@ func convertRouteTableResult(routeTablesResult *cluster.RouteTablesResult) *meta
 	}
 }
 
-func convertToGetNodesResponse(nodesResult *cluster.GetNodesResult) *metaservicepb.GetNodesResponse {
+func convertToGetNodesResponse(nodesResult *cluster.GetNodeShardsResult) *metaservicepb.GetNodesResponse {
 	nodeShards := make([]*metaservicepb.NodeShard, 0, len(nodesResult.NodeShards))
 	for _, nodeShard := range nodesResult.NodeShards {
 		nodeShards = append(nodeShards, &metaservicepb.NodeShard{

--- a/server/service/util.go
+++ b/server/service/util.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/server/service/util.go
+++ b/server/service/util.go
@@ -4,8 +4,6 @@ package service
 
 import (
 	"context"
-	"net/url"
-
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -20,12 +18,7 @@ var (
 func GetClientConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {
 	opt := grpc.WithTransportCredentials(insecure.NewCredentials())
 
-	u, err := url.Parse(addr)
-	if err != nil {
-		return nil, ErrParseURL.WithCause(err)
-	}
-
-	cc, err := grpc.DialContext(ctx, u.Host, opt)
+	cc, err := grpc.DialContext(ctx, addr, opt)
 	if err != nil {
 		return nil, ErrGRPCDial.WithCause(err)
 	}


### PR DESCRIPTION
# Which issue does this PR close?


# Rationale for this change
Fix some problem when debugging scatter locally.

# What changes are included in this PR?
* Move `CreateShardTopologies` to `ScatterProcedure`, solve hard coding problem of shardID
* Avoid `GetTables`  throw error when `ScatterProcedure` send `OpenShardRequest` to CeresDB. In this case,  shard has not yet been created
* When `ScatterProcedure` start and `ClusterTopologyState` is `Empty` , just print some warning log instead of cancel event.
# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->