### PR TITLE
fix: fix input address format mistake

### DIFF
--- a/server/service/util.go
+++ b/server/service/util.go
@@ -4,6 +4,8 @@ package service
 
 import (
 	"context"
+	"net/url"
+	"strings"
 
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"google.golang.org/grpc"
@@ -19,7 +21,16 @@ var (
 func GetClientConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {
 	opt := grpc.WithTransportCredentials(insecure.NewCredentials())
 
-	cc, err := grpc.DialContext(ctx, addr, opt)
+	host := addr
+	if strings.HasPrefix(addr, "http") {
+		u, err := url.Parse(addr)
+		if err != nil {
+			return nil, ErrParseURL.WithCause(err)
+		}
+		host = u.Host
+	}
+
+	cc, err := grpc.DialContext(ctx, host, opt)
 	if err != nil {
 		return nil, ErrGRPCDial.WithCause(err)
 	}


### PR DESCRIPTION
# Which issue does this PR close?

Closes # https://github.com/CeresDB/ceresmeta/issues/88

# Rationale for this change
It has been mentioned in the issue.

# What changes are included in this PR?
Add `addr` format check in `GetClientConn`, parse `addr` when it's prefix is http. 

# Are there any user-facing changes?
None.


# How does this change test
Manually tested in the local environment.