### PR TITLE
refactor: encapsulate applyMetadata from scheduler as a standalone ApplyProcedure

### DIFF
--- a/server/coordinator/procedure/apply.go
+++ b/server/coordinator/procedure/apply.go
@@ -1,0 +1,292 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package procedure
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/CeresDB/ceresmeta/server/cluster"
+	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
+	"github.com/looplab/fsm"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	eventApplyCloseShard = "EventApplyCloseShard"
+	eventApplyOpenShard  = "EventApplyOpenShard"
+	eventApplyFinish     = "EventApplyFinish"
+
+	stateApplyBegin      = "StateApplyBegin"
+	stateApplyCloseShard = "StateApplyCloseShard"
+	stateApplyOpenShard  = "StateApplyOpenShard"
+	stateApplyFinish     = "stateApplyFinish"
+)
+
+var (
+	applyEvents = fsm.Events{
+		{Name: eventApplyCloseShard, Src: []string{stateApplyBegin}, Dst: stateApplyCloseShard},
+		{Name: eventApplyOpenShard, Src: []string{stateApplyCloseShard}, Dst: stateApplyOpenShard},
+		{Name: eventApplyFinish, Src: []string{stateApplyOpenShard}, Dst: stateApplyFinish},
+	}
+	applyCallbacks = fsm.Callbacks{
+		eventApplyCloseShard: applyCloseShardCallback,
+		eventApplyOpenShard:  applyOpenShardCallback,
+		eventApplyFinish:     applyFinishCallback,
+	}
+)
+
+type ApplyCallbackRequest struct {
+	ctx context.Context
+
+	nodeName                   string
+	shardsNeedToReopen         []cluster.ShardInfo
+	shardsNeedToCloseAndReopen []cluster.ShardInfo
+	shardsNeedToClose          []cluster.ShardInfo
+
+	dispatch eventdispatch.Dispatch
+}
+
+// ApplyProcedure used for apply the latest cluster topology to CeresDB node when metadata version is not equal to CeresDB node version.
+type ApplyProcedure struct {
+	id       uint64
+	fsm      *fsm.FSM
+	dispatch eventdispatch.Dispatch
+	storage  Storage
+
+	nodeName                   string
+	shardsNeedToReopen         []cluster.ShardInfo
+	shardsNeedToCloseAndReopen []cluster.ShardInfo
+	shardsNeedToClose          []cluster.ShardInfo
+
+	// Protect the state.
+	lock  sync.RWMutex
+	state State
+}
+
+type ApplyProcedureRequest struct {
+	Dispatch                   eventdispatch.Dispatch
+	ID                         uint64
+	NodeName                   string
+	ShardsNeedToReopen         []cluster.ShardInfo
+	ShardsNeedToCloseAndReopen []cluster.ShardInfo
+	ShardNeedToClose           []cluster.ShardInfo
+	Storage                    Storage
+}
+
+func NewApplyProcedure(request ApplyProcedureRequest) Procedure {
+	return &ApplyProcedure{
+		id:                         request.ID,
+		fsm:                        fsm.NewFSM(stateApplyBegin, applyEvents, applyCallbacks),
+		nodeName:                   request.NodeName,
+		shardsNeedToReopen:         request.ShardsNeedToReopen,
+		shardsNeedToClose:          request.ShardNeedToClose,
+		shardsNeedToCloseAndReopen: request.ShardsNeedToCloseAndReopen,
+		dispatch:                   request.Dispatch,
+		storage:                    request.Storage,
+	}
+}
+
+func (p *ApplyProcedure) ID() uint64 {
+	return p.id
+}
+
+func (p *ApplyProcedure) Typ() Typ {
+	return Apply
+}
+
+func (p *ApplyProcedure) Start(ctx context.Context) error {
+	log.Info("apply procedure start", zap.Uint64("procedureID", p.id))
+
+	p.updateStateWithLock(StateRunning)
+
+	applyCallbackRequest := &ApplyCallbackRequest{
+		ctx:                        ctx,
+		nodeName:                   p.nodeName,
+		shardsNeedToReopen:         p.shardsNeedToReopen,
+		shardsNeedToCloseAndReopen: p.shardsNeedToCloseAndReopen,
+		shardsNeedToClose:          p.shardsNeedToClose,
+		dispatch:                   p.dispatch,
+	}
+
+	for {
+		switch p.fsm.Current() {
+		// TODO: add double check shard info state.
+		case stateApplyBegin:
+			if err := p.persist(ctx); err != nil {
+				return errors.WithMessage(err, "apply procedure persist")
+			}
+			if err := p.fsm.Event(eventApplyCloseShard, applyCallbackRequest); err != nil {
+				p.updateStateWithLock(StateFailed)
+				return errors.WithMessage(err, "apply procedure close shard")
+			}
+		case stateApplyCloseShard:
+			if err := p.persist(ctx); err != nil {
+				return errors.WithMessage(err, "apply procedure persist")
+			}
+			if err := p.fsm.Event(eventApplyOpenShard, applyCallbackRequest); err != nil {
+				p.updateStateWithLock(StateFailed)
+				return errors.WithMessage(err, "apply procedure open shard")
+			}
+		case stateApplyOpenShard:
+			if err := p.persist(ctx); err != nil {
+				return errors.WithMessage(err, "apply procedure persist")
+			}
+			if err := p.fsm.Event(eventApplyFinish, applyCallbackRequest); err != nil {
+				p.updateStateWithLock(StateFailed)
+				return errors.WithMessage(err, "apply procedure oepn new leader")
+			}
+		case stateApplyFinish:
+			p.updateStateWithLock(StateFinished)
+			if err := p.persist(ctx); err != nil {
+				return errors.WithMessage(err, "apply procedure persist")
+			}
+			return nil
+		}
+	}
+}
+
+func (p *ApplyProcedure) Cancel(_ context.Context) error {
+	p.updateStateWithLock(StateCancelled)
+	return nil
+}
+
+func (p *ApplyProcedure) State() State {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.state
+}
+
+func (p *ApplyProcedure) updateStateWithLock(state State) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.state = state
+}
+
+func applyCloseShardCallback(event *fsm.Event) {
+	request, err := getRequestFromEvent[*ApplyCallbackRequest](event)
+	if err != nil {
+		cancelEventWithLog(event, err, "get request from event")
+		return
+	}
+
+	shardsToClose := []cluster.ShardInfo{}
+	shardsToClose = append(shardsToClose, request.shardsNeedToCloseAndReopen...)
+	shardsToClose = append(shardsToClose, request.shardsNeedToClose...)
+
+	g := new(errgroup.Group)
+	for _, shardInfo := range shardsToClose {
+		shardInfo := shardInfo
+		g.Go(func() error {
+			log.Info("close shard begin", zap.Uint32("shardID", uint32(shardInfo.ID)))
+			if err := request.dispatch.CloseShard(request.ctx, request.nodeName, eventdispatch.CloseShardRequest{ShardID: uint32(shardInfo.ID)}); err != nil {
+				log.Error("close shard failed", zap.Uint32("shardID", uint32(shardInfo.ID)))
+				return err
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		cancelEventWithLog(event, err, "close shard failed")
+		return
+	}
+}
+
+func applyOpenShardCallback(event *fsm.Event) {
+	request, err := getRequestFromEvent[*ApplyCallbackRequest](event)
+	if err != nil {
+		cancelEventWithLog(event, err, "get request from event")
+		return
+	}
+
+	shardsToOpen := []cluster.ShardInfo{}
+	shardsToOpen = append(shardsToOpen, request.shardsNeedToCloseAndReopen...)
+	shardsToOpen = append(shardsToOpen, request.shardsNeedToReopen...)
+
+	g := new(errgroup.Group)
+	for _, shardInfo := range shardsToOpen {
+		shardInfo := shardInfo
+		g.Go(func() error {
+			log.Info("open shard begin", zap.Uint32("shardID", uint32(shardInfo.ID)))
+			if err := request.dispatch.OpenShard(request.ctx, request.nodeName, eventdispatch.OpenShardRequest{Shard: shardInfo}); err != nil {
+				log.Error("open shard failed", zap.Uint32("shardID", uint32(shardInfo.ID)))
+				return err
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		cancelEventWithLog(event, err, "open shard failed")
+		return
+	}
+}
+
+func applyFinishCallback(event *fsm.Event) {
+	request, err := getRequestFromEvent[*ApplyCallbackRequest](event)
+	if err != nil {
+		cancelEventWithLog(event, err, "get request from event")
+		return
+	}
+
+	log.Info("apply procedure finish", zap.String("targetNode", request.nodeName))
+}
+
+func (p *ApplyProcedure) persist(ctx context.Context) error {
+	meta, err := p.convertToMeta()
+	if err != nil {
+		return errors.WithMessage(err, "convert to meta")
+	}
+	err = p.storage.CreateOrUpdate(ctx, meta)
+	if err != nil {
+		return errors.WithMessage(err, "createOrUpdate in storage")
+	}
+	return nil
+}
+
+type ApplyProcedurePersistRawData struct {
+	ID       uint64
+	FsmState string
+	State    State
+
+	NodeName                   string
+	ShardsNeedToReopen         []cluster.ShardInfo
+	ShardsNeedToCloseAndReopen []cluster.ShardInfo
+	ShardsNeedToClose          []cluster.ShardInfo
+}
+
+func (p *ApplyProcedure) convertToMeta() (Meta, error) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	rawData := ApplyProcedurePersistRawData{
+		ID:                         p.id,
+		FsmState:                   p.fsm.Current(),
+		State:                      p.state,
+		NodeName:                   p.nodeName,
+		ShardsNeedToReopen:         p.shardsNeedToReopen,
+		ShardsNeedToCloseAndReopen: p.shardsNeedToCloseAndReopen,
+		ShardsNeedToClose:          p.shardsNeedToClose,
+	}
+	rawDataBytes, err := json.Marshal(rawData)
+	if err != nil {
+		return Meta{}, ErrEncodeRawData.WithCausef("marshal raw data, procedureID:%d, err:%v", p.id, err)
+	}
+
+	meta := Meta{
+		ID:    p.id,
+		Typ:   Apply,
+		State: p.state,
+
+		RawData: rawDataBytes,
+	}
+
+	return meta, nil
+}

--- a/server/coordinator/procedure/apply_test.go
+++ b/server/coordinator/procedure/apply_test.go
@@ -1,0 +1,62 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package procedure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CeresDB/ceresmeta/server/cluster"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+	dispatch := MockDispatch{}
+	_, c := prepare(t)
+	s := NewTestStorage(t)
+
+	getNodeShardsResult, err := c.GetNodeShards(ctx)
+	re.NoError(err)
+
+	// Apply procedure does not modify any data, but only uses the dispatch to synchronize the metadata, so it only ensures that no error is thrown.
+	shardNeedToReopen := getNodeShardsResult.NodeShards[0]
+	procedure := NewApplyProcedure(ApplyProcedureRequest{
+		Dispatch:                   dispatch,
+		ID:                         uint64(1),
+		NodeName:                   shardNeedToReopen.ShardNode.NodeName,
+		ShardsNeedToReopen:         []cluster.ShardInfo{shardNeedToReopen.ShardInfo},
+		ShardsNeedToCloseAndReopen: []cluster.ShardInfo{},
+		ShardNeedToClose:           []cluster.ShardInfo{},
+		Storage:                    s,
+	})
+	err = procedure.Start(ctx)
+	re.NoError(err)
+
+	shardNeedToCloseAndReopen := getNodeShardsResult.NodeShards[0]
+	procedure = NewApplyProcedure(ApplyProcedureRequest{
+		Dispatch:                   dispatch,
+		ID:                         uint64(1),
+		NodeName:                   shardNeedToReopen.ShardNode.NodeName,
+		ShardsNeedToReopen:         []cluster.ShardInfo{},
+		ShardsNeedToCloseAndReopen: []cluster.ShardInfo{shardNeedToCloseAndReopen.ShardInfo},
+		ShardNeedToClose:           []cluster.ShardInfo{},
+		Storage:                    s,
+	})
+	err = procedure.Start(ctx)
+	re.NoError(err)
+
+	shardNeedToClose := getNodeShardsResult.NodeShards[0]
+	procedure = NewApplyProcedure(ApplyProcedureRequest{
+		Dispatch:                   dispatch,
+		ID:                         uint64(1),
+		NodeName:                   shardNeedToReopen.ShardNode.NodeName,
+		ShardsNeedToReopen:         []cluster.ShardInfo{},
+		ShardsNeedToCloseAndReopen: []cluster.ShardInfo{},
+		ShardNeedToClose:           []cluster.ShardInfo{shardNeedToClose.ShardInfo},
+		Storage:                    s,
+	})
+	err = procedure.Start(ctx)
+	re.NoError(err)
+}

--- a/server/coordinator/procedure/create_partition_table.go
+++ b/server/coordinator/procedure/create_partition_table.go
@@ -67,6 +67,7 @@ type CreatePartitionTableProcedure struct {
 	onSucceeded func(cluster.CreateTableResult) error
 	onFailed    func(error) error
 
+	// Protect the state.
 	lock  sync.RWMutex
 	state State
 }

--- a/server/coordinator/procedure/drop_table.go
+++ b/server/coordinator/procedure/drop_table.go
@@ -180,6 +180,7 @@ type DropTableProcedure struct {
 	onSucceeded func(cluster.TableInfo) error
 	onFailed    func(error) error
 
+	// Protect the state.
 	lock  sync.RWMutex
 	state State
 }

--- a/server/coordinator/procedure/factory.go
+++ b/server/coordinator/procedure/factory.go
@@ -82,6 +82,13 @@ type SplitRequest struct {
 	ClusterVersion uint64
 }
 
+type ApplyRequest struct {
+	NodeName                 string
+	ShardsNeedReopen         []cluster.ShardInfo
+	ShardsNeedClose          []cluster.ShardInfo
+	ShardsNeedCloseAndReopen []cluster.ShardInfo
+}
+
 type CreatePartitionTableRequest struct {
 	Cluster   *cluster.Cluster
 	SourceReq *metaservicepb.CreateTableRequest
@@ -255,6 +262,23 @@ func (f *Factory) CreateSplitProcedure(ctx context.Context, request SplitRequest
 	}
 
 	procedure := NewSplitProcedure(id, f.dispatch, f.storage, c, request.SchemaName, request.ShardID, request.NewShardID, request.TableNames, request.TargetNodeName)
+	return procedure, nil
+}
+
+func (f *Factory) CreateApplyProcedure(ctx context.Context, request ApplyRequest) (Procedure, error) {
+	id, err := f.allocProcedureID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	procedure := NewApplyProcedure(ApplyProcedureRequest{
+		Dispatch:                   f.dispatch,
+		ID:                         id,
+		NodeName:                   request.NodeName,
+		ShardsNeedToReopen:         request.ShardsNeedReopen,
+		ShardsNeedToCloseAndReopen: request.ShardsNeedCloseAndReopen,
+		ShardNeedToClose:           request.ShardsNeedClose,
+		Storage:                    f.storage,
+	})
 	return procedure, nil
 }
 

--- a/server/coordinator/procedure/procedure.go
+++ b/server/coordinator/procedure/procedure.go
@@ -28,6 +28,7 @@ const (
 	Scatter
 	CreateTable
 	DropTable
+	Apply
 	CreatePartitionTable
 	DropPartitionTable
 )

--- a/server/coordinator/procedure/scatter.go
+++ b/server/coordinator/procedure/scatter.go
@@ -193,6 +193,7 @@ type ScatterProcedure struct {
 	cluster  *cluster.Cluster
 	shardIDs []storage.ShardID
 
+	// Protect the state.
 	lock  sync.RWMutex
 	state State
 }
@@ -206,6 +207,8 @@ func (p *ScatterProcedure) Typ() Typ {
 }
 
 func (p *ScatterProcedure) Start(ctx context.Context) error {
+	log.Info("scatter procedure start", zap.Uint64("procedureID", p.id))
+
 	p.updateStateWithLock(StateRunning)
 
 	scatterCallbackRequest := &ScatterCallbackRequest{


### PR DESCRIPTION
# Which issue does this PR close?
None.

# Rationale for this change
Refactor `applyMetaDataShardInfo` in `scheduler`, encapsulate applyMetadata from scheduler as a standalone ApplyProcedure.

# What changes are included in this PR?
* Add `ApplyProcedure`, which is responsible for the shards correction of the inconsistency.
* Refactor `scheduler`, use `ApplyProcedure` replace origin logic.

# Are there any user-facing changes?
None.

# How does this change test
Manual test in local environment.