### PR TITLE
feat: add http server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlekSi/gocov-xml v1.0.0
 	github.com/CeresDB/ceresdbproto v0.0.0-20221019023918-29cb0c6fba76
 	github.com/axw/gocov v1.1.0
+	github.com/julienschmidt/httprouter v1.3.0
 	github.com/looplab/fsm v0.3.0
 	github.com/mgechev/revive v1.2.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,7 @@ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -95,7 +95,7 @@ type Config struct {
 	AdvertiseClientUrls string `toml:"advertise-client-urls" json:"advertise-client-urls"`
 	AdvertisePeerUrls   string `toml:"advertise-peer-urls" json:"advertise-peer-urls"`
 
-	DefaultHTTPPort int `toml:"default-http-port" json:"default-http-port"`
+	HTTPPort int `toml:"default-http-port" json:"default-http-port"`
 }
 
 func (c *Config) GrpcHandleTimeout() time.Duration {
@@ -247,6 +247,6 @@ func MakeConfigParser() (*Parser, error) {
 	fs.IntVar(&cfg.DefaultClusterReplicationFactor, "default-cluster-replication-factor", defaultClusterReplicationFactor, "replication factor of the default cluster")
 	fs.IntVar(&cfg.DefaultClusterShardTotal, "default-cluster-shard-total", defaultClusterShardTotal, "shard total of the default cluster")
 
-	fs.IntVar(&cfg.DefaultHTTPPort, "default-http-port", defaultHTTPPort, "port of http server")
+	fs.IntVar(&cfg.HTTPPort, "http-port", defaultHTTPPort, "port of http server")
 	return builder, nil
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -43,6 +43,8 @@ const (
 	defaultClusterNodeCount         = 2
 	defaultClusterReplicationFactor = 1
 	defaultClusterShardTotal        = 8
+
+	defaultHTTPPort = 8080
 )
 
 type Config struct {
@@ -92,6 +94,8 @@ type Config struct {
 	PeerUrls            string `toml:"peer-urls" json:"peer-urls"`
 	AdvertiseClientUrls string `toml:"advertise-client-urls" json:"advertise-client-urls"`
 	AdvertisePeerUrls   string `toml:"advertise-peer-urls" json:"advertise-peer-urls"`
+
+	DefaultHTTPPort int `toml:"default-http-port" json:"default-http-port"`
 }
 
 func (c *Config) GrpcHandleTimeout() time.Duration {
@@ -243,5 +247,6 @@ func MakeConfigParser() (*Parser, error) {
 	fs.IntVar(&cfg.DefaultClusterReplicationFactor, "default-cluster-replication-factor", defaultClusterReplicationFactor, "replication factor of the default cluster")
 	fs.IntVar(&cfg.DefaultClusterShardTotal, "default-cluster-shard-total", defaultClusterShardTotal, "shard total of the default cluster")
 
+	fs.IntVar(&cfg.DefaultHTTPPort, "default-http-port", defaultHTTPPort, "port of http server")
 	return builder, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,7 @@ import (
 	"github.com/CeresDB/ceresmeta/server/id"
 	"github.com/CeresDB/ceresmeta/server/member"
 	metagrpc "github.com/CeresDB/ceresmeta/server/service/grpc"
-	http2 "github.com/CeresDB/ceresmeta/server/service/http"
+	"github.com/CeresDB/ceresmeta/server/service/http"
 	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/pkg/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -57,7 +57,7 @@ type Server struct {
 	etcdSrv *embed.Etcd
 
 	// httpService contains http server and api set.
-	httpService *http2.Service
+	httpService *http.Service
 
 	// bgJobWg can be used to join with the background jobs.
 	bgJobWg sync.WaitGroup
@@ -181,8 +181,8 @@ func (srv *Server) startServer(_ context.Context) error {
 	srv.procedureFactory = procedureFactory
 	srv.scheduler = coordinator.NewScheduler(manager, procedureManager, procedureFactory, dispatch)
 
-	api := http2.NewAPI(procedureManager, procedureFactory, manager)
-	httpService := http2.NewHTTPService(srv.cfg.HTTPPort, time.Second*10, time.Second*10, api.NewAPIRouter())
+	api := http.NewAPI(procedureManager, procedureFactory, manager)
+	httpService := http.NewHTTPService(srv.cfg.HTTPPort, time.Second*10, time.Second*10, api.NewAPIRouter())
 	err = httpService.Start()
 	if err != nil {
 		return errors.WithMessage(err, "start http service failed")

--- a/server/server.go
+++ b/server/server.go
@@ -182,7 +182,7 @@ func (srv *Server) startServer(_ context.Context) error {
 	srv.scheduler = coordinator.NewScheduler(manager, procedureManager, procedureFactory, dispatch)
 
 	api := http2.NewAPI(procedureManager, procedureFactory, manager)
-	httpService := http2.NewHTTPService(srv.cfg.DefaultHTTPPort, time.Second*10, time.Second*10, api.NewAPIRouter())
+	httpService := http2.NewHTTPService(srv.cfg.HTTPPort, time.Second*10, time.Second*10, api.NewAPIRouter())
 	err = httpService.Start()
 	if err != nil {
 		return errors.WithMessage(err, "start http service failed")

--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
@@ -20,6 +21,7 @@ import (
 	"github.com/CeresDB/ceresmeta/server/id"
 	"github.com/CeresDB/ceresmeta/server/member"
 	metagrpc "github.com/CeresDB/ceresmeta/server/service/grpc"
+	http2 "github.com/CeresDB/ceresmeta/server/service/http"
 	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/pkg/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -53,6 +55,9 @@ type Server struct {
 	member  *member.Member
 	etcdCli *clientv3.Client
 	etcdSrv *embed.Etcd
+
+	// httpService contains http server and api set.
+	httpService *http2.Service
 
 	// bgJobWg can be used to join with the background jobs.
 	bgJobWg sync.WaitGroup
@@ -175,6 +180,14 @@ func (srv *Server) startServer(_ context.Context) error {
 	procedureFactory := procedure.NewFactory(id.NewAllocatorImpl(srv.etcdCli, defaultProcedurePrefixKey, defaultAllocStep), dispatch)
 	srv.procedureFactory = procedureFactory
 	srv.scheduler = coordinator.NewScheduler(manager, procedureManager, procedureFactory, dispatch)
+
+	api := http2.NewAPI(procedureManager, procedureFactory, manager)
+	httpService := http2.NewHTTPService(srv.cfg.DefaultHTTPPort, time.Second*10, time.Second*10, api.NewAPIRouter())
+	err = httpService.Start()
+	if err != nil {
+		return errors.WithMessage(err, "start http service failed")
+	}
+	srv.httpService = httpService
 
 	log.Info("server started")
 	return nil

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -78,7 +78,6 @@ func (a *API) respond(w http.ResponseWriter, data interface{}) {
 	}
 }
 
-// nolint
 func (a *API) respondError(w http.ResponseWriter, apiErr coderr.CodeError, data interface{}) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	b, err := json.Marshal(&response{
@@ -110,6 +109,7 @@ func (a *API) transferLeader(writer http.ResponseWriter, req *http.Request) {
 	err := json.NewDecoder(req.Body).Decode(&transferLeaderRequest)
 	if err != nil {
 		log.Error("decode request body failed", zap.Error(err))
+		a.respondError(writer, ErrParseRequest, nil)
 		return
 	}
 	a.respond(writer, "ok")

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -4,7 +4,6 @@ package http
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/CeresDB/ceresmeta/pkg/log"
@@ -39,12 +38,7 @@ func (a *API) NewAPIRouter() *Router {
 // printRequestInsmt used for printing every request information.
 func printRequestInsmt(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		body, err := io.ReadAll(request.Body)
-		if err != nil {
-			log.Error("parse http body failed", zap.String("handlerName", handlerName))
-			body = []byte("")
-		}
-		log.Info("receive http request", zap.String("handlerName", handlerName), zap.String("client host", request.RemoteAddr), zap.String("method", request.Method), zap.String("params", request.Form.Encode()), zap.String("body", string(body)))
+		log.Info("receive http request", zap.String("handlerName", handlerName), zap.String("client host", request.RemoteAddr), zap.String("method", request.Method), zap.String("params", request.Form.Encode()))
 		handler.ServeHTTP(writer, request)
 	}
 }

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -4,19 +4,21 @@ package http
 
 import (
 	"encoding/json"
-	"github.com/CeresDB/ceresmeta/pkg/coderr"
-	jsoniter "github.com/json-iterator/go"
 	"net/http"
 
+	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/coordinator/procedure"
+	jsoniter "github.com/json-iterator/go"
 	"go.uber.org/zap"
 )
 
 const (
 	statusSuccess string = "success"
 	statusError   string = "error"
+
+	apiPrefix string = "/api/v1"
 )
 
 type API struct {
@@ -35,7 +37,7 @@ func NewAPI(procedureManager procedure.Manager, procedureFactory *procedure.Fact
 }
 
 func (a *API) NewAPIRouter() *Router {
-	router := New().WithPrefix("/api/v1").WithInstrumentation(printRequestInsmt)
+	router := New().WithPrefix(apiPrefix).WithInstrumentation(printRequestInsmt)
 
 	router.Post("/transferLeader", a.transferLeader)
 
@@ -76,6 +78,7 @@ func (a *API) respond(w http.ResponseWriter, data interface{}) {
 	}
 }
 
+// nolint
 func (a *API) respondError(w http.ResponseWriter, apiErr coderr.CodeError, data interface{}) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	b, err := json.Marshal(&response{
@@ -102,11 +105,12 @@ type TransferLeaderRequest struct {
 }
 
 // TODO: impl this function
-func (a *API) transferLeader(_ http.ResponseWriter, req *http.Request) {
+func (a *API) transferLeader(writer http.ResponseWriter, req *http.Request) {
 	var transferLeaderRequest TransferLeaderRequest
 	err := json.NewDecoder(req.Body).Decode(&transferLeaderRequest)
 	if err != nil {
-		log.Error("decode request body failed")
+		log.Error("decode request body failed", zap.Error(err))
 		return
 	}
+	a.respond(writer, "ok")
 }

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -1,0 +1,65 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/CeresDB/ceresmeta/server/cluster"
+	"github.com/CeresDB/ceresmeta/server/coordinator/procedure"
+	"go.uber.org/zap"
+)
+
+type API struct {
+	procedureManager procedure.Manager
+	procedureFactory *procedure.Factory
+
+	clusterManager cluster.Manager
+}
+
+func NewAPI(procedureManager procedure.Manager, procedureFactory *procedure.Factory, clusterManager cluster.Manager) *API {
+	return &API{
+		procedureManager: procedureManager,
+		procedureFactory: procedureFactory,
+		clusterManager:   clusterManager,
+	}
+}
+
+func (a *API) NewAPIRouter() *Router {
+	router := New().WithPrefix("/api/v1").WithInstrumentation(printRequestInsmt)
+
+	router.Post("/transferLeader", a.transferLeader)
+
+	return router
+}
+
+// printRequestInsmt used for printing every request information.
+func printRequestInsmt(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			log.Error("parse http body failed", zap.String("handlerName", handlerName))
+			body = []byte("")
+		}
+		log.Info("receive http request", zap.String("handlerName", handlerName), zap.String("client host", request.RemoteAddr), zap.String("method", request.Method), zap.String("params", request.Form.Encode()), zap.String("body", string(body)))
+		handler.ServeHTTP(writer, request)
+	}
+}
+
+type TransferLeaderRequest struct {
+	ShardID           uint64 `json:"shardID"`
+	NewLeaderNodeName string `json:"newLeaderNodeName"`
+}
+
+// TODO: impl this function
+func (a *API) transferLeader(_ http.ResponseWriter, req *http.Request) {
+	var transferLeaderRequest TransferLeaderRequest
+	err := json.NewDecoder(req.Body).Decode(&transferLeaderRequest)
+	if err != nil {
+		log.Error("decode request body failed")
+		return
+	}
+}

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -1,0 +1,7 @@
+package http
+
+import "github.com/CeresDB/ceresmeta/pkg/coderr"
+
+var (
+	ErrParseRequest = coderr.NewCodeError(coderr.BadRequest, "parse request params failed")
+)

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -1,7 +1,10 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 package http
 
 import "github.com/CeresDB/ceresmeta/pkg/coderr"
 
 var (
-	ErrParseRequest = coderr.NewCodeError(coderr.BadRequest, "parse request params failed")
+	ErrParseRequest  = coderr.NewCodeError(coderr.BadRequest, "parse request params failed")
+	ErrParseResponse = coderr.NewCodeError(coderr.Internal, "error marshaling json response")
 )

--- a/server/service/http/route.go
+++ b/server/service/http/route.go
@@ -1,5 +1,5 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
-// This file fork from [Prometheus](https://github.com/prometheus/common/blob/main/route/route.go)
+// This file fork from [Prometheus](https://github.com/prometheus/common/blob/8c9cb3fa6d01832ea16937b20ea561eed81abd2f/route/route.go)
 
 package http
 

--- a/server/service/http/route.go
+++ b/server/service/http/route.go
@@ -1,5 +1,9 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+// Copyright 2013 Julien Schmidt. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
 package http
 
 import (

--- a/server/service/http/route.go
+++ b/server/service/http/route.go
@@ -1,5 +1,5 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
-// This file fork from [Prometheus](https://github.com/prometheus/prometheus)
+// This file fork from [Prometheus](https://github.com/prometheus/common/blob/main/route/route.go)
 
 package http
 

--- a/server/service/http/route.go
+++ b/server/service/http/route.go
@@ -1,0 +1,90 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package http
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// Router wraps httprouter.Router and adds support for prefixed sub-routers,
+// per-request context injections and instrumentation.
+type Router struct {
+	rtr    *httprouter.Router
+	prefix string
+	instrh func(handlerName string, handler http.HandlerFunc) http.HandlerFunc
+}
+
+// New returns a new Router.
+func New() *Router {
+	return &Router{
+		rtr: httprouter.New(),
+	}
+}
+
+// WithPrefix returns a router that prefixes all registered routes with prefix.
+func (r *Router) WithPrefix(prefix string) *Router {
+	return &Router{rtr: r.rtr, prefix: r.prefix + prefix, instrh: r.instrh}
+}
+
+// WithInstrumentation returns a router with instrumentation support.
+func (r *Router) WithInstrumentation(instrh func(handlerName string, handler http.HandlerFunc) http.HandlerFunc) *Router {
+	if r.instrh != nil {
+		newInstrh := instrh
+		instrh = func(handlerName string, handler http.HandlerFunc) http.HandlerFunc {
+			return newInstrh(handlerName, r.instrh(handlerName, handler))
+		}
+	}
+	return &Router{rtr: r.rtr, prefix: r.prefix, instrh: instrh}
+}
+
+// ServeHTTP implements http.Handler.
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.rtr.ServeHTTP(w, req)
+}
+
+// Get registers a new GET route.
+func (r *Router) Get(path string, h http.HandlerFunc) {
+	r.rtr.GET(r.prefix+path, r.handle(path, h))
+}
+
+// Options registers a new OPTIONS route.
+func (r *Router) Options(path string, h http.HandlerFunc) {
+	r.rtr.OPTIONS(r.prefix+path, r.handle(path, h))
+}
+
+// Del registers a new DELETE route.
+func (r *Router) Del(path string, h http.HandlerFunc) {
+	r.rtr.DELETE(r.prefix+path, r.handle(path, h))
+}
+
+// Put registers a new PUT route.
+func (r *Router) Put(path string, h http.HandlerFunc) {
+	r.rtr.PUT(r.prefix+path, r.handle(path, h))
+}
+
+// Post registers a new POST route.
+func (r *Router) Post(path string, h http.HandlerFunc) {
+	r.rtr.POST(r.prefix+path, r.handle(path, h))
+}
+
+// Head registers a new HEAD route.
+func (r *Router) Head(path string, h http.HandlerFunc) {
+	r.rtr.HEAD(r.prefix+path, r.handle(path, h))
+}
+
+// handle turns a HandlerFunc into a httprouter.Handle.
+func (r *Router) handle(handlerName string, h http.HandlerFunc) httprouter.Handle {
+	if r.instrh != nil {
+		// This needs to be outside the closure to avoid data race when reading and writing to 'h'.
+		h = r.instrh(handlerName, h)
+	}
+	return func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+
+		h(w, req.WithContext(ctx))
+	}
+}

--- a/server/service/http/route.go
+++ b/server/service/http/route.go
@@ -1,8 +1,5 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
-
-// Copyright 2013 Julien Schmidt. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be found
-// in the LICENSE file.
+// This file fork from [Prometheus](https://github.com/prometheus/prometheus)
 
 package http
 

--- a/server/service/http/service.go
+++ b/server/service/http/service.go
@@ -1,0 +1,41 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Service is wrapper for http.Server
+type Service struct {
+	port         int
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+
+	router *Router
+	server http.Server
+}
+
+func NewHTTPService(port int, readTimeout time.Duration, writeTimeout time.Duration, router *Router) *Service {
+	return &Service{
+		port:         port,
+		readTimeout:  readTimeout,
+		writeTimeout: writeTimeout,
+		router:       router,
+	}
+}
+
+func (s *Service) Start() error {
+	s.server.ReadTimeout = s.readTimeout
+	s.server.WriteTimeout = s.writeTimeout
+	s.server.Addr = fmt.Sprintf(":%d", s.port)
+	s.server.Handler = s.router
+
+	return s.server.ListenAndServe()
+}
+
+func (s *Service) Stop() error {
+	return s.server.Close()
+}


### PR DESCRIPTION
# Which issue does this PR close?
None.

# Rationale for this change
CeresMeta currently only includes grpc server, not http server. But http interface need to be provided for some operation and maintenance operations.

# What changes are included in this PR?
* Import third-party library `httprouter`, it is used for simplify server development. https://github.com/julienschmidt/httprouter
* Implement http server based on `httprouter` and `http` in standard library.

# Are there any user-facing changes?
None.

# How does this change test
Local manual test.