### PR TITLE
chore: bump ceresdbproto to the latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,6 @@ check-license:
 
 build: check
 	@ go build -o ceresmeta ./cmd/meta/...
+
+clean:
+	@ rm -f ceresmeta

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.19
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
+	github.com/CeresDB/ceresdbproto/golang v0.0.0-20221115062517-8cd021e19e44
 	github.com/axw/gocov v1.1.0
+	github.com/json-iterator/go v1.1.11
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/looplab/fsm v0.3.0
 	github.com/mgechev/revive v1.2.1
@@ -23,7 +25,6 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.1.0 // indirect
-	github.com/CeresDB/ceresdbproto/golang v0.0.0-20221115062517-8cd021e19e44 // indirect
 	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
@@ -46,7 +47,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
-	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
-	github.com/CeresDB/ceresdbproto v0.0.0-20221019023918-29cb0c6fba76
 	github.com/axw/gocov v1.1.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/looplab/fsm v0.3.0
@@ -24,6 +23,7 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.1.0 // indirect
+	github.com/CeresDB/ceresdbproto v0.0.0-20221115062517-8cd021e19e44 // indirect
 	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CeresDB/ceresdbproto v0.0.0-20221019023918-29cb0c6fba76 h1:4x8ywwb4xanSSA0PwcXbMyhCEP/M9eN1VmIi01XVVys=
-github.com/CeresDB/ceresdbproto v0.0.0-20221019023918-29cb0c6fba76/go.mod h1:z2mc3V7rsBcpD1TlRrLtypMfr4G69iGMQi1E3ZWMkGY=
+github.com/CeresDB/ceresdbproto v0.0.0-20221115062517-8cd021e19e44 h1:DsUtrATJHUuJnxbUW9hLJEQjEQn9CUG/ZXcrLtqKu4Y=
+github.com/CeresDB/ceresdbproto v0.0.0-20221115062517-8cd021e19e44/go.mod h1:6qWvbMz3dvjcyKVZkg1L/yKb6OrD8r+/rk5Q1GWhyWQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/server/cluster/table_manager_test.go
+++ b/server/cluster/table_manager_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CeresDB/ceresdbproto/pkg/clusterpb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresmeta/server/etcdutil"
 	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/stretchr/testify/require"

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -3,8 +3,8 @@
 package cluster
 
 import (
-	"github.com/CeresDB/ceresdbproto/pkg/clusterpb"
-	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/server/storage"
 )
 

--- a/server/coordinator/eventdispatch/dispatch_impl.go
+++ b/server/coordinator/eventdispatch/dispatch_impl.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/CeresDB/ceresdbproto/pkg/metaeventpb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaeventpb"
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/service"

--- a/server/coordinator/procedure/create_drop_table_test.go
+++ b/server/coordinator/procedure/create_drop_table_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/stretchr/testify/require"
 )

--- a/server/coordinator/procedure/create_table.go
+++ b/server/coordinator/procedure/create_table.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"

--- a/server/coordinator/procedure/drop_table.go
+++ b/server/coordinator/procedure/drop_table.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"

--- a/server/coordinator/procedure/factory.go
+++ b/server/coordinator/procedure/factory.go
@@ -5,7 +5,7 @@ package procedure
 import (
 	"context"
 
-	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
 	"github.com/CeresDB/ceresmeta/server/id"

--- a/server/coordinator/scheduler.go
+++ b/server/coordinator/scheduler.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"

--- a/server/member/member.go
+++ b/server/member/member.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/CeresDB/ceresdbproto/pkg/metastoragepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metastoragepb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/etcdutil"
 	"go.etcd.io/etcd/api/v3/mvccpb"

--- a/server/server.go
+++ b/server/server.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"

--- a/server/service/grpc/forward.go
+++ b/server/service/grpc/forward.go
@@ -5,7 +5,7 @@ package grpc
 import (
 	"context"
 
-	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/service"
 	"github.com/pkg/errors"

--- a/server/service/grpc/service.go
+++ b/server/service/grpc/service.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/CeresDB/ceresdbproto/pkg/clusterpb"
-	"github.com/CeresDB/ceresdbproto/pkg/commonpb"
-	"github.com/CeresDB/ceresdbproto/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/commonpb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"

--- a/server/storage/storage_impl.go
+++ b/server/storage/storage_impl.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/CeresDB/ceresdbproto/pkg/clusterpb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresmeta/server/etcdutil"
 	"github.com/pkg/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -2,7 +2,7 @@
 
 package storage
 
-import "github.com/CeresDB/ceresdbproto/pkg/clusterpb"
+import "github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 
 type (
 	ClusterID    uint32


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
Dirs of underlying dependency `ceresdbproto` has been changed, bump to the latest version and do some related adaption

# What changes are included in this PR?

1. Dependency description for `ceresdbproto` has been modified.
2. Import path of several packages has been adpapted.

# Are there any user-facing changes?

nope.

# How does this change test

Pass the existing CI.