### PR TITLE
chore: add toml config parser

### DIFF
--- a/cmd/meta/main.go
+++ b/cmd/meta/main.go
@@ -44,6 +44,11 @@ func main() {
 	if err != nil {
 		panicf("fail to init global logger, err:%v", err)
 	}
+
+	if err := config.MakeConfigParseFromToml(cfg); err != nil {
+		panicf("fail to parse config from toml file, err%v", err)
+	}
+
 	defer logger.Sync() //nolint:errcheck
 
 	// TODO: Do adjustment to config for preparing joining existing cluster.

--- a/cmd/meta/main.go
+++ b/cmd/meta/main.go
@@ -45,7 +45,7 @@ func main() {
 		panicf("fail to init global logger, err:%v", err)
 	}
 
-	if err := config.MakeConfigParseFromToml(cfg); err != nil {
+	if err := config.ParseConfigFromToml(cfg); err != nil {
 		panicf("fail to parse config from toml file, err%v", err)
 	}
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,11 @@
+etcd-start-timeout-ms = 30000
+peer-urls = "http://127.0.0.1:2380"
+advertise-client-urls = "http://127.0.0.1:2379"
+advertise-peer-urls = "http://127.0.0.1:2380"
+client-urls = "http://127.0.0.1:2379"
+wal-dir = "/tmp/ceresmeta0/wal"
+data-dir = "/tmp/ceresmeta0/data"
+node-name = "meta0"
+etcd-log-file = "/tmp/ceresmeta0/etcd.log"
+initial-cluster = "meta0=http://127.0.0.1:2380"
+default-cluster-node-count = 1

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,9 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/looplab/fsm v0.3.0
 	github.com/mgechev/revive v1.2.1
+	github.com/pelletier/go-toml/v2 v2.0.6
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	github.com/tikv/pd v2.1.19+incompatible
 	go.etcd.io/etcd/api/v3 v3.5.4
 	go.etcd.io/etcd/client/v3 v3.5.4

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
+github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pingcap/errors v0.11.0 h1:DCJQB8jrHbQ1VVlMFIrbj2ApScNNotVmkSNplu2yUt4=
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/log v1.1.0 h1:ELiPxACz7vdo1qAvvaWJg1NrYFoY6gqAh/+Uo6aXdD8=
@@ -329,14 +331,16 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tikv/pd v2.1.19+incompatible h1:rqjHqO7t/STke/R2Yz6+lQj6NPA8u7G2Otwqup4K+P8=
 github.com/tikv/pd v2.1.19+incompatible/go.mod h1:v6C/D7ONC49SgjI4jbGnooSizvijaO/bdIm62DVR4tI=


### PR DESCRIPTION
# Which issue does this PR close?
Closes #

# Rationale for this change
At present, ceresmeta's startup parameters only support specifying in program arguments. These configurations are difficult to maintain. We want to specify startup parameters by setting configuration files. 

# What changes are included in this PR?
* Add toml config parser, it will parse toml config when ceresmeta starts.
* Add a sample toml config example.

# Are there any user-facing changes?
User can configure the startup parameters by input toml file path now.

# How does this change test
Local manual test.
