### PR TITLE
fix: fix http server start

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -184,10 +184,14 @@ func (srv *Server) startServer(_ context.Context) error {
 
 	api := http.NewAPI(procedureManager, procedureFactory, manager)
 	httpService := http.NewHTTPService(srv.cfg.HTTPPort, time.Second*10, time.Second*10, api.NewAPIRouter())
-	err = httpService.Start()
-	if err != nil {
-		return errors.WithMessage(err, "start http service failed")
-	}
+	go func() {
+		err := httpService.Start()
+		if err != nil {
+			if err != nil {
+				log.Error("start http service failed", zap.Error(err))
+			}
+		}
+	}()
 	srv.httpService = httpService
 
 	log.Info("server started")

--- a/server/server.go
+++ b/server/server.go
@@ -187,9 +187,7 @@ func (srv *Server) startServer(_ context.Context) error {
 	go func() {
 		err := httpService.Start()
 		if err != nil {
-			if err != nil {
-				log.Error("start http service failed", zap.Error(err))
-			}
+			log.Error("start http service failed", zap.Error(err))
 		}
 	}()
 	srv.httpService = httpService

--- a/server/server.go
+++ b/server/server.go
@@ -114,7 +114,10 @@ func (srv *Server) Close() {
 		}
 	}
 
-	// TODO: release other resources: httpclient, etcd server and so on.
+	err := srv.httpService.Stop()
+	if err != nil {
+		log.Error("fail to close http server", zap.Error(err))
+	}
 }
 
 func (srv *Server) IsClosed() bool {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Now the http server will be started when the meta starts synchronously, this will cause the meta server to fail to initialize normally.


# What changes are included in this PR?
* Change the start of http server from synchronous to asynchronous.

# Are there any user-facing changes?
None.

# How does this change test
Local manual test.