### PR TITLE
chore: add env variable config parser

### DIFF
--- a/cmd/meta/main.go
+++ b/cmd/meta/main.go
@@ -27,7 +27,7 @@ func main() {
 		panicf("fail to generate config builder, err:%v", err)
 	}
 
-	cfg, configFilePath, err := cfgParser.Parse(os.Args[1:])
+	cfg, err := cfgParser.Parse(os.Args[1:])
 	if coderr.Is(err, coderr.PrintHelpUsage) {
 		return
 	}
@@ -45,7 +45,7 @@ func main() {
 		panicf("fail to init global logger, err:%v", err)
 	}
 
-	if err := cfgParser.ParseConfigFromToml(configFilePath); err != nil {
+	if err := cfgParser.ParseConfigFromToml(); err != nil {
 		panicf("fail to parse config from toml file, err%v", err)
 	}
 

--- a/cmd/meta/main.go
+++ b/cmd/meta/main.go
@@ -27,7 +27,7 @@ func main() {
 		panicf("fail to generate config builder, err:%v", err)
 	}
 
-	cfg, err := cfgParser.Parse(os.Args[1:])
+	cfg, configFilePath, err := cfgParser.Parse(os.Args[1:])
 	if coderr.Is(err, coderr.PrintHelpUsage) {
 		return
 	}
@@ -45,7 +45,7 @@ func main() {
 		panicf("fail to init global logger, err:%v", err)
 	}
 
-	if err := cfgParser.ParseConfigFromToml(); err != nil {
+	if err := cfgParser.ParseConfigFromToml(configFilePath); err != nil {
 		panicf("fail to parse config from toml file, err%v", err)
 	}
 

--- a/cmd/meta/main.go
+++ b/cmd/meta/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server"
 	"github.com/CeresDB/ceresmeta/server/config"
+	"github.com/pelletier/go-toml/v2"
 	"go.uber.org/zap"
 )
 
@@ -44,16 +45,21 @@ func main() {
 	if err != nil {
 		panicf("fail to init global logger, err:%v", err)
 	}
+	defer logger.Sync() //nolint:errcheck
 
 	if err := cfgParser.ParseConfigFromToml(); err != nil {
-		panicf("fail to parse config from toml file, err%v", err)
+		panicf("fail to parse config from toml file, err:%v", err)
 	}
 
 	if err := cfgParser.ParseConfigFromEnvVariables(); err != nil {
-		panicf("fail to parse config from environment variable, err%v", err)
+		panicf("fail to parse config from environment variable, err:%v", err)
 	}
 
-	defer logger.Sync() //nolint:errcheck
+	cfgByte, err := toml.Marshal(cfg)
+	if err != nil {
+		panicf("fail to marshal server config, err:%v", err)
+	}
+	log.Info("server start with config", zap.String("config", string(cfgByte)))
 
 	// TODO: Do adjustment to config for preparing joining existing cluster.
 

--- a/cmd/meta/main.go
+++ b/cmd/meta/main.go
@@ -45,8 +45,12 @@ func main() {
 		panicf("fail to init global logger, err:%v", err)
 	}
 
-	if err := config.ParseConfigFromToml(cfg); err != nil {
+	if err := cfgParser.ParseConfigFromToml(); err != nil {
 		panicf("fail to parse config from toml file, err%v", err)
+	}
+
+	if err := cfgParser.ParseConfigFromEnvVariables(); err != nil {
+		panicf("fail to parse config from environment variable, err%v", err)
 	}
 
 	defer logger.Sync() //nolint:errcheck

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -13,8 +13,8 @@ const (
 )
 
 type Config struct {
-	Level string `toml:"level" json:"level"`
-	File  string `toml:"file" json:"file"`
+	Level string `toml:"level"`
+	File  string `toml:"file"`
 }
 
 // DefaultZapLoggerConfig defines default zap logger configuration.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -59,17 +59,17 @@ type Config struct {
 	Log     log.Config `toml:"log" json:"log"`
 	EtcdLog log.Config `toml:"etcd-log" json:"etcd-log"`
 
-	GrpcHandleTimeoutMs int64 `toml:"grpc-handle-timeout-ms" json:"grpc-handle-timeout-ms"`
-	EtcdStartTimeoutMs  int64 `toml:"etcd-start-timeout-ms" json:"etcd-start-timeout-ms"`
-	EtcdCallTimeoutMs   int64 `toml:"etcd-call-timeout-ms" json:"etcd-call-timeout-ms"`
+	GrpcHandleTimeoutMs int64 `toml:"grpc-handle-timeout-ms"`
+	EtcdStartTimeoutMs  int64 `toml:"etcd-start-timeout-ms"`
+	EtcdCallTimeoutMs   int64 `toml:"etcd-call-timeout-ms"`
 
-	LeaseTTLSec int64 `toml:"lease-sec" json:"lease-sec"`
+	LeaseTTLSec int64 `toml:"lease-sec"`
 
-	NodeName            string `toml:"node-name" json:"node-name"`
-	DataDir             string `toml:"data-dir" json:"data-dir"`
-	WalDir              string `toml:"wal-dir" json:"wal-dir"`
-	StorageRootPath     string `toml:"storage-root-path" json:"storage-root-path"`
-	InitialCluster      string `toml:"initial-cluster" json:"initial-cluster"`
+	NodeName            string `toml:"node-name"`
+	DataDir             string `toml:"data-dir"`
+	WalDir              string `toml:"wal-dir"`
+	StorageRootPath     string `toml:"storage-root-path"`
+	InitialCluster      string `toml:"initial-cluster"`
 	InitialClusterState string `toml:"initial-cluster-state" json:"initial-cluster-state"`
 	InitialClusterToken string `toml:"initial-cluster-token" json:"initial-cluster-token"`
 	// TickInterval is the interval for etcd Raft tick.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -277,14 +277,14 @@ func (p *Parser) ParseConfigFromToml() error {
 	file, err := os.ReadFile(configFilePath)
 	if err != nil {
 		log.Error("err", zap.Error(err))
-		return errors.WithMessage(err, fmt.Sprintf("read config file failed, configFile:%v", configFilePath))
+		return errors.WithMessage(err, fmt.Sprintf("read config file failed, configFile:%s", configFilePath))
 	}
 	log.Info("toml config value", zap.String("config", string(file)))
 
 	err = toml.Unmarshal(file, p.cfg)
 	if err != nil {
 		log.Error("err", zap.Error(err))
-		return errors.WithMessagef(err, "unmarshal toml config failed, configFile:%v", configFilePath)
+		return errors.WithMessagef(err, "unmarshal toml config failed, configFile:%s", configFilePath)
 	}
 
 	return nil


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
At present, the server startup parameters do not support input through environment variables. We need to write some configurations in the configuration file, which is very inflexible. We hope to directly inject parameters through environment variables.


# What changes are included in this PR?
* Add env variables parser.

# Are there any user-facing changes?
The user can now configure the startup parameters of the server through the environment variables.

# How does this change test
Local manual test.