### PR TITLE
fix: remove dropTable rollback when createTable failed

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -128,7 +128,7 @@ func (c *Cluster) DropTable(ctx context.Context, schemaName, tableName string) (
 	ret := DropTableResult{
 		ShardVersionUpdate: updateVersion,
 	}
-	log.Info(fmt.Sprintf("create table success, result:%v", ret), zap.String("cluster", c.Name()), zap.String("schemaName", schemaName), zap.String("tableName", tableName))
+	log.Info("drop table success", zap.String("cluster", c.Name()), zap.String("schemaName", schemaName), zap.String("tableName", tableName), zap.String("result", fmt.Sprintf("%+v", ret)))
 	return ret, nil
 }
 
@@ -170,7 +170,7 @@ func (c *Cluster) CreateTable(ctx context.Context, nodeName string, schemaName s
 		Table:              table,
 		ShardVersionUpdate: result,
 	}
-	log.Info(fmt.Sprintf("create table succeed, result:%v", ret), zap.String("cluster", c.Name()))
+	log.Info("create table succeed", zap.String("cluster", c.Name()), zap.String("result", fmt.Sprintf("%+v", ret)))
 	return ret, nil
 }
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -4,6 +4,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"sync"
 
@@ -101,6 +102,8 @@ func (c *Cluster) GetShardTables(shardIDs []storage.ShardID, nodeName string) ma
 }
 
 func (c *Cluster) DropTable(ctx context.Context, schemaName, tableName string) (DropTableResult, error) {
+	log.Info("drop table start", zap.String("cluster", c.Name()), zap.String("schemaName", schemaName), zap.String("tableName", tableName))
+
 	table, ok, err := c.tableManager.GetTable(schemaName, tableName)
 	if err != nil {
 		return DropTableResult{}, errors.WithMessage(err, "get table")
@@ -122,9 +125,11 @@ func (c *Cluster) DropTable(ctx context.Context, schemaName, tableName string) (
 		return DropTableResult{}, errors.WithMessagef(err, "topology manager remove table")
 	}
 
-	return DropTableResult{
+	ret := DropTableResult{
 		ShardVersionUpdate: updateVersion,
-	}, nil
+	}
+	log.Info(fmt.Sprintf("create table success, result:%v", ret), zap.String("cluster", c.Name()), zap.String("schemaName", schemaName), zap.String("tableName", tableName))
+	return ret, nil
 }
 
 // GetOrCreateSchema the second output parameter bool: returns true if the schema was newly created.
@@ -138,6 +143,8 @@ func (c *Cluster) GetTable(schemaName, tableName string) (storage.Table, bool, e
 }
 
 func (c *Cluster) CreateTable(ctx context.Context, nodeName string, schemaName string, tableName string) (CreateTableResult, error) {
+	log.Info("create table start", zap.String("cluster", c.Name()), zap.String("nodeName", nodeName), zap.String("schemaName", schemaName), zap.String("tableName", tableName))
+
 	_, exists, err := c.tableManager.GetTable(schemaName, tableName)
 	if err != nil {
 		return CreateTableResult{}, err
@@ -159,10 +166,12 @@ func (c *Cluster) CreateTable(ctx context.Context, nodeName string, schemaName s
 		return CreateTableResult{}, errors.WithMessage(err, "topology manager add table")
 	}
 
-	return CreateTableResult{
+	ret := CreateTableResult{
 		Table:              table,
 		ShardVersionUpdate: result,
-	}, nil
+	}
+	log.Info(fmt.Sprintf("create table succeed, result:%v", ret), zap.String("cluster", c.Name()))
+	return ret, nil
 }
 
 func (c *Cluster) GetShardNodesByShardID(id storage.ShardID) ([]storage.ShardNode, error) {

--- a/server/cluster/table_manager.go
+++ b/server/cluster/table_manager.go
@@ -242,7 +242,7 @@ func (m *TableManagerImpl) loadSchemas(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "list schemas")
 	}
-	log.Debug(fmt.Sprintf("load schema, data:%v", schemasResult))
+	log.Debug("load schema", zap.String("data", fmt.Sprintf("%+v", schemasResult)))
 
 	// Reset data in memory.
 	m.schemas = make(map[string]storage.Schema, len(schemasResult.Schemas))
@@ -264,7 +264,7 @@ func (m *TableManagerImpl) loadTables(ctx context.Context) error {
 		if err != nil {
 			return errors.WithMessage(err, "list tables")
 		}
-		log.Debug(fmt.Sprintf("load table, schema:%v, tables:%v", schema, tablesResult))
+		log.Debug("load table", zap.String("schema", fmt.Sprintf("%+v", schema)), zap.String("tables", fmt.Sprintf("%+v", tablesResult)))
 
 		for _, table := range tablesResult.Tables {
 			tables, ok := m.schemaTables[table.SchemaID]

--- a/server/cluster/topology_manager.go
+++ b/server/cluster/topology_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/CeresDB/ceresmeta/server/id"
 	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 // TopologyManager manages the cluster topology, including the mapping relationship between shards, nodes, and tables.
@@ -384,7 +385,7 @@ func (m *TopologyManagerImpl) loadClusterView(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "storage get cluster view")
 	}
-	log.Debug(fmt.Sprintf("load cluster view, cluster views:%v", clusterViewResult))
+	log.Debug("load cluster view", zap.String("clusterViews", fmt.Sprintf("%+v", clusterViewResult)))
 
 	m.shardNodesMapping = make(map[storage.ShardID][]storage.ShardNode, len(clusterViewResult.ClusterView.ShardNodes))
 	m.nodeShardsMapping = make(map[string][]storage.ShardNode, len(clusterViewResult.ClusterView.ShardNodes))
@@ -410,7 +411,7 @@ func (m *TopologyManagerImpl) loadShardViews(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "storage list shard views")
 	}
-	log.Debug(fmt.Sprintf("load shard views, cluster:%d, shard views:%v", m.clusterID, shardViewsResult))
+	log.Debug("load shard views", zap.Int32("clusterID", int32(m.clusterID)), zap.String("shardViews", fmt.Sprintf("%+v", shardViewsResult)))
 
 	// Reset data in memory.
 	m.shardTablesMapping = make(map[storage.ShardID]*storage.ShardView, len(shardViewsResult.ShardViews))

--- a/server/coordinator/procedure/create_table.go
+++ b/server/coordinator/procedure/create_table.go
@@ -14,7 +14,6 @@ import (
 	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/looplab/fsm"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 const (
@@ -121,22 +120,6 @@ func createTableFailedCallback(event *fsm.Event) {
 
 	if err := req.onFailed(event.Err); err != nil {
 		log.Error("exec failed callback failed")
-	}
-
-	table, exists, err := req.cluster.GetTable(req.sourceReq.GetSchemaName(), req.sourceReq.GetName())
-	if err != nil {
-		log.Error("create table failed, get table failed", zap.String("schemaName", req.sourceReq.GetSchemaName()), zap.String("tableName", req.sourceReq.GetName()))
-		return
-	}
-	if !exists {
-		return
-	}
-
-	// Rollback, drop table in ceresmeta.
-	_, err = req.cluster.DropTable(req.ctx, req.sourceReq.GetSchemaName(), table.Name)
-	if err != nil {
-		log.Error("drop table failed, get table failed", zap.String("schemaName", req.sourceReq.GetSchemaName()), zap.String("tableName", table.Name), zap.Uint64("tableID", uint64(table.ID)))
-		return
 	}
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
There is a very serious bug when creating an existing table will cause the old table to be deleted.
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Remove `dropTable` rollback when `createTable` failed.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Manual testing.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->