### PR TITLE
fix: fix load schema table mapping & logger initialization

### DIFF
--- a/cmd/meta/main.go
+++ b/cmd/meta/main.go
@@ -41,12 +41,6 @@ func main() {
 		panicf("invalid config, err:%v", err)
 	}
 
-	logger, err := log.InitGlobalLogger(&cfg.Log)
-	if err != nil {
-		panicf("fail to init global logger, err:%v", err)
-	}
-	defer logger.Sync() //nolint:errcheck
-
 	if err := cfgParser.ParseConfigFromToml(); err != nil {
 		panicf("fail to parse config from toml file, err:%v", err)
 	}
@@ -59,9 +53,14 @@ func main() {
 	if err != nil {
 		panicf("fail to marshal server config, err:%v", err)
 	}
-	log.Info("server start with config", zap.String("config", string(cfgByte)))
 
+	logger, err := log.InitGlobalLogger(&cfg.Log)
+	if err != nil {
+		panicf("fail to init global logger, err:%v", err)
+	}
+	defer logger.Sync() //nolint:errcheck
 	// TODO: Do adjustment to config for preparing joining existing cluster.
+	log.Info("server start with config", zap.String("config", string(cfgByte)))
 
 	srv, err := server.CreateServer(cfg)
 	if err != nil {

--- a/server/cluster/table_manager.go
+++ b/server/cluster/table_manager.go
@@ -269,6 +269,7 @@ func (m *TableManagerImpl) loadTable(ctx context.Context) error {
 					tables:     make(map[string]storage.Table, 0),
 					tablesByID: make(map[storage.TableID]storage.Table, 0),
 				}
+				m.schemaTables[table.SchemaID] = tables
 			}
 
 			tables.tables[table.Name] = table


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
When server restart, it will reload all metadata in memory, but schema table mapping is not initialized normally.

# What changes are included in this PR?
* Fix schema table mapping initialization.
* Fix the initialization problem of the logger to avoid invalid log configuration.

# Are there any user-facing changes?
None.

# How does this change test
Local manual test.