### PR TITLE
fix: convert tableName & schemaName to lower case

### DIFF
--- a/server/service/grpc/service.go
+++ b/server/service/grpc/service.go
@@ -5,6 +5,7 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -100,6 +101,8 @@ func (s *Service) AllocSchemaID(ctx context.Context, req *metaservicepb.AllocSch
 		return ceresmetaClient.AllocSchemaID(ctx, req)
 	}
 
+	req.Name = strings.ToLower(req.Name)
+
 	schemaID, _, err := s.h.GetClusterManager().AllocSchemaID(ctx, req.GetHeader().GetClusterName(), req.GetName())
 	if err != nil {
 		return &metaservicepb.AllocSchemaIdResponse{Header: responseHeader(err, "grpc alloc schema id")}, nil
@@ -148,6 +151,9 @@ func (s *Service) CreateTable(ctx context.Context, req *metaservicepb.CreateTabl
 	if ceresmetaClient != nil {
 		return ceresmetaClient.CreateTable(ctx, req)
 	}
+
+	req.SchemaName = strings.ToLower(req.SchemaName)
+	req.Name = strings.ToLower(req.Name)
 
 	clusterManager := s.h.GetClusterManager()
 	factory := s.h.GetProcedureFactory()
@@ -219,6 +225,9 @@ func (s *Service) DropTable(ctx context.Context, req *metaservicepb.DropTableReq
 		return ceresmetaClient.DropTable(ctx, req)
 	}
 
+	req.SchemaName = strings.ToLower(req.SchemaName)
+	req.Name = strings.ToLower(req.Name)
+
 	clusterManager := s.h.GetClusterManager()
 	factory := s.h.GetProcedureFactory()
 	manager := s.h.GetProcedureManager()
@@ -278,6 +287,13 @@ func (s *Service) RouteTables(ctx context.Context, req *metaservicepb.RouteTable
 	if ceresmetaClient != nil {
 		return ceresmetaClient.RouteTables(ctx, req)
 	}
+
+	req.SchemaName = strings.ToLower(req.SchemaName)
+	tableNames := make([]string, len(req.TableNames))
+	for _, tableName := range req.TableNames {
+		tableNames = append(tableNames, strings.ToLower(tableName))
+	}
+	req.TableNames = tableNames
 
 	routeTableResult, err := s.h.GetClusterManager().RouteTables(ctx, req.GetHeader().GetClusterName(), req.GetSchemaName(), req.GetTableNames())
 	if err != nil {


### PR DESCRIPTION
# Which issue does this PR close?
https://github.com/CeresDB/ceresdb/issues/442

# Rationale for this change
As mentioned in issue, solve the problem of SQL case.

# What changes are included in this PR?
* Change tableName and schemaName to lower case when received grpc request.

# Are there any user-facing changes?
Ignore the case of the sql in the user request, and use it in lower case.

# How does this change test
Which issue does this PR close?
None.

Rationale for this change
Refactor applyMetaDataShardInfo in scheduler, encapsulate applyMetadata from scheduler as a standalone ApplyProcedure.

What changes are included in this PR?
Add ApplyProcedure, which is responsible for the shards correction of the inconsistency.
Refactor scheduler, use ApplyProcedure replace origin logic.
Are there any user-facing changes?
None.

How does this change test
Manual test in local environment.