### PR TITLE
feat: support forwarding http requests

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -185,7 +185,7 @@ func (srv *Server) startServer(_ context.Context) error {
 	srv.procedureFactory = procedureFactory
 	srv.scheduler = coordinator.NewScheduler(manager, procedureManager, procedureFactory, dispatch)
 
-	api := http.NewAPI(procedureManager, procedureFactory, manager)
+	api := http.NewAPI(procedureManager, procedureFactory, manager, http.NewForwardClient(srv.member, srv.cfg.HTTPPort))
 	httpService := http.NewHTTPService(srv.cfg.HTTPPort, time.Second*10, time.Second*10, api.NewAPIRouter())
 	go func() {
 		err := httpService.Start()

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -12,4 +12,5 @@ var (
 	ErrSubmitProcedure = coderr.NewCodeError(coderr.Internal, "submit procedure")
 	ErrGetCluster      = coderr.NewCodeError(coderr.Internal, "get cluster")
 	ErrAllocShardID    = coderr.NewCodeError(coderr.Internal, "alloc shard id")
+	ErrForwardToLeader = coderr.NewCodeError(coderr.Internal, "forward to leader")
 )

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -13,4 +13,5 @@ var (
 	ErrGetCluster      = coderr.NewCodeError(coderr.Internal, "get cluster")
 	ErrAllocShardID    = coderr.NewCodeError(coderr.Internal, "alloc shard id")
 	ErrForwardToLeader = coderr.NewCodeError(coderr.Internal, "forward to leader")
+	ErrParseLeaderAddr = coderr.NewCodeError(coderr.Internal, "parse leader addr")
 )

--- a/server/service/http/forward.go
+++ b/server/service/http/forward.go
@@ -1,0 +1,85 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package http
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/CeresDB/ceresmeta/server/member"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+type ForwardClient struct {
+	member *member.Member
+	client *http.Client
+	port   int
+}
+
+func NewForwardClient(member *member.Member, port int) *ForwardClient {
+	return &ForwardClient{
+		member: member,
+		client: getForwardedHTTPClient(),
+		port:   port,
+	}
+}
+
+func getForwardedHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout: 10 * time.Second,
+		},
+	}
+}
+
+func (s *ForwardClient) getForwardedAddr(ctx context.Context) (string, bool, error) {
+	member, err := s.member.GetLeader(ctx)
+	if err != nil {
+		return "", false, errors.WithMessage(err, "get forwarded addr")
+	}
+	if member.IsLocal {
+		return "", true, nil
+	}
+	leaderAddr := strings.Split(member.Leader.GetEndpoint(), ":")
+	leaderAddr[2] = strconv.Itoa(s.port)
+	return strings.Join(leaderAddr, ":"), false, nil
+}
+
+func (s *ForwardClient) forwardToLeader(req *http.Request) (*http.Response, bool, error) {
+	addr, isLeader, err := s.getForwardedAddr(req.Context())
+	if err != nil {
+		log.Error("get forward addr failed", zap.Error(err))
+		return &http.Response{}, false, err
+	}
+	if isLeader {
+		return &http.Response{}, true, nil
+	}
+
+	// Update remote host
+	req.RequestURI = ""
+	if req.TLS == nil {
+		req.URL.Scheme = "http"
+	} else {
+		req.URL.Scheme = "https"
+	}
+	req.URL.Host = addr
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		log.Error("forward client send request failed", zap.Error(err))
+		return &http.Response{}, false, err
+	}
+
+	return resp, false, nil
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
When CeresMeta is started in the cluster mode, the cluster contains the leader node and follower node, and only the leader node can process requests normally. However, the current http requests sent to the follower node are not forwarded like grpc requests, which will result in that the requests cannot be processed normally.

# What changes are included in this PR?
* Add http forward client implementation.
* Add forward logic, follower node will forwarded request to leader node.

# Are there any user-facing changes?
None.

# How does this change test