### PR TITLE
feat: add etcd max txn ops config

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -20,6 +20,7 @@ const (
 	defaultGrpcHandleTimeoutMs int64 = 10 * 1000
 	defaultEtcdStartTimeoutMs  int64 = 10 * 1000
 	defaultCallTimeoutMs             = 5 * 1000
+	defaultMaxTxnOps                 = 128
 	defaultEtcdLeaseTTLSec           = 10
 
 	defaultNodeNamePrefix          = "ceresmeta"
@@ -63,6 +64,7 @@ type Config struct {
 	GrpcHandleTimeoutMs int64 `toml:"grpc-handle-timeout-ms" env:"GRPC_HANDLER_TIMEOUT_MS"`
 	EtcdStartTimeoutMs  int64 `toml:"etcd-start-timeout-ms" env:"ETCD_START_TIMEOUT_MS"`
 	EtcdCallTimeoutMs   int64 `toml:"etcd-call-timeout-ms" env:"ETCD_CALL_TIMEOUT_MS"`
+	EtcdMaxTxnOps       int64 `toml:"etcd-max-txn-ops" env:"ETCD_MAX_TXN_OPS"`
 
 	LeaseTTLSec int64 `toml:"lease-sec" env:"LEASE_SEC"`
 
@@ -141,6 +143,7 @@ func (c *Config) GenEtcdConfig() (*embed.Config, error) {
 	cfg.AutoCompactionRetention = c.AutoCompactionRetention
 	cfg.QuotaBackendBytes = c.QuotaBackendBytes
 	cfg.MaxRequestBytes = c.MaxRequestBytes
+	cfg.MaxTxnOps = uint(c.EtcdMaxTxnOps)
 
 	var err error
 	cfg.LPUrls, err = parseUrls(c.PeerUrls)
@@ -220,6 +223,7 @@ func MakeConfigParser() (*Parser, error) {
 		GrpcHandleTimeoutMs: defaultGrpcHandleTimeoutMs,
 		EtcdStartTimeoutMs:  defaultEtcdStartTimeoutMs,
 		EtcdCallTimeoutMs:   defaultCallTimeoutMs,
+		EtcdMaxTxnOps:       defaultMaxTxnOps,
 
 		LeaseTTLSec: defaultEtcdLeaseTTLSec,
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Because of the limitation of etcd on single txn ops (128 by default), when the cluster is configured with a large number of shards, etcd will fail to write. Therefore, it is necessary to provide a configuration entry to adjust the maxTxnOps.

# What changes are included in this PR?
* Add EtcdMaxTxnOps in start config.
* Start etcd server with EtcdMaxTxnOps.

# Are there any user-facing changes?
None.

# How does this change test
