### PR TITLE
feat: add create partition table procedure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
-	github.com/CeresDB/ceresdbproto/golang v0.0.0-20221219083612-b9c45bcdbf7d
 	github.com/axw/gocov v1.1.0
+	github.com/CeresDB/ceresdbproto/golang v0.0.0-20221223085501-cfa70e972d3d
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/json-iterator/go v1.1.11
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
-	github.com/axw/gocov v1.1.0
 	github.com/CeresDB/ceresdbproto/golang v0.0.0-20221223085501-cfa70e972d3d
+	github.com/axw/gocov v1.1.0
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/json-iterator/go v1.1.11
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
-	github.com/CeresDB/ceresdbproto/golang v0.0.0-20221129093313-317dca741863
+	github.com/CeresDB/ceresdbproto/golang v0.0.0-20221219083612-b9c45bcdbf7d
 	github.com/axw/gocov v1.1.0
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/json-iterator/go v1.1.11

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CeresDB/ceresdbproto v0.0.0-20221223085501-cfa70e972d3d h1:JE5WIMGC2EguLKKJa/C9+too26Q8gwW1FmaFKY2yQ2Q=
-github.com/CeresDB/ceresdbproto v0.0.0-20221223085501-cfa70e972d3d/go.mod h1:6qWvbMz3dvjcyKVZkg1L/yKb6OrD8r+/rk5Q1GWhyWQ=
-github.com/CeresDB/ceresdbproto/golang v0.0.0-20221219083612-b9c45bcdbf7d h1:7rvulrlvO5iTDBHujyy3jYqcCzyoNj8NOZIU92qxnZg=
-github.com/CeresDB/ceresdbproto/golang v0.0.0-20221219083612-b9c45bcdbf7d/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/CeresDB/ceresdbproto/golang v0.0.0-20221223085501-cfa70e972d3d h1:ItxqVqy0v74qMyLl3qv0Tp7Z54Kb9NNrVS6P/Y2IQ/8=
 github.com/CeresDB/ceresdbproto/golang v0.0.0-20221223085501-cfa70e972d3d/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,12 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/CeresDB/ceresdbproto v0.0.0-20221223085501-cfa70e972d3d h1:JE5WIMGC2EguLKKJa/C9+too26Q8gwW1FmaFKY2yQ2Q=
+github.com/CeresDB/ceresdbproto v0.0.0-20221223085501-cfa70e972d3d/go.mod h1:6qWvbMz3dvjcyKVZkg1L/yKb6OrD8r+/rk5Q1GWhyWQ=
 github.com/CeresDB/ceresdbproto/golang v0.0.0-20221219083612-b9c45bcdbf7d h1:7rvulrlvO5iTDBHujyy3jYqcCzyoNj8NOZIU92qxnZg=
 github.com/CeresDB/ceresdbproto/golang v0.0.0-20221219083612-b9c45bcdbf7d/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20221223085501-cfa70e972d3d h1:ItxqVqy0v74qMyLl3qv0Tp7Z54Kb9NNrVS6P/Y2IQ/8=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20221223085501-cfa70e972d3d/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CeresDB/ceresdbproto/golang v0.0.0-20221129093313-317dca741863 h1:LJOG/OhSD0YB9SpYKM6I1sNcwicQ4AqgCneHim+PL+U=
-github.com/CeresDB/ceresdbproto/golang v0.0.0-20221129093313-317dca741863/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20221219083612-b9c45bcdbf7d h1:7rvulrlvO5iTDBHujyy3jYqcCzyoNj8NOZIU92qxnZg=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20221219083612-b9c45bcdbf7d/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -171,7 +171,7 @@ func (c *Cluster) GetTable(schemaName, tableName string) (storage.Table, bool, e
 	return c.tableManager.GetTable(schemaName, tableName)
 }
 
-func (c *Cluster) CreateTable(ctx context.Context, nodeName string, schemaName string, tableName string) (CreateTableResult, error) {
+func (c *Cluster) CreateTable(ctx context.Context, nodeName string, schemaName string, tableName string, partitioned bool) (CreateTableResult, error) {
 	log.Info("create table start", zap.String("cluster", c.Name()), zap.String("nodeName", nodeName), zap.String("schemaName", schemaName), zap.String("tableName", tableName))
 
 	_, exists, err := c.tableManager.GetTable(schemaName, tableName)
@@ -184,7 +184,7 @@ func (c *Cluster) CreateTable(ctx context.Context, nodeName string, schemaName s
 	}
 
 	// Create table in table manager.
-	table, err := c.tableManager.CreateTable(ctx, schemaName, tableName)
+	table, err := c.tableManager.CreateTable(ctx, schemaName, tableName, partitioned)
 	if err != nil {
 		return CreateTableResult{}, errors.WithMessage(err, "table manager create table")
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -347,6 +347,13 @@ func (c *Cluster) GetTotalShardNum() uint32 {
 	return c.metaData.ShardTotal
 }
 
+func (c *Cluster) GetPartitionTableNum() uint32 {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.metaData.PartitionTableNum
+}
+
 func (c *Cluster) GetClusterState() storage.ClusterState {
 	c.lock.RLock()
 	defer c.lock.RUnlock()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -347,11 +347,11 @@ func (c *Cluster) GetTotalShardNum() uint32 {
 	return c.metaData.ShardTotal
 }
 
-func (c *Cluster) GetTablePartitionNum() uint32 {
+func (c *Cluster) GetPartitionTableRatioOfNodes() uint32 {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	return c.metaData.TablePartitionNum
+	return c.metaData.PartitionTableRatioOfNodes
 }
 
 func (c *Cluster) GetClusterState() storage.ClusterState {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -347,13 +347,6 @@ func (c *Cluster) GetTotalShardNum() uint32 {
 	return c.metaData.ShardTotal
 }
 
-func (c *Cluster) GetPartitionTableRatioOfNodes() uint32 {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-
-	return c.metaData.PartitionTableRatioOfNodes
-}
-
 func (c *Cluster) GetClusterState() storage.ClusterState {
 	c.lock.RLock()
 	defer c.lock.RUnlock()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -347,11 +347,11 @@ func (c *Cluster) GetTotalShardNum() uint32 {
 	return c.metaData.ShardTotal
 }
 
-func (c *Cluster) GetPartitionTableNum() uint32 {
+func (c *Cluster) GetTablePartitionNum() uint32 {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	return c.metaData.PartitionTableNum
+	return c.metaData.TablePartitionNum
 }
 
 func (c *Cluster) GetClusterState() storage.ClusterState {

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -103,13 +103,12 @@ func (m *managerImpl) CreateCluster(ctx context.Context, clusterName string, opt
 	}
 
 	clusterMetadata := storage.Cluster{
-		ID:                         clusterID,
-		Name:                       clusterName,
-		MinNodeCount:               opts.NodeCount,
-		ReplicationFactor:          opts.ReplicationFactor,
-		ShardTotal:                 opts.ShardTotal,
-		PartitionTableRatioOfNodes: opts.PartitionTableRatioOfNodes,
-		CreatedAt:                  uint64(time.Now().UnixMilli()),
+		ID:                clusterID,
+		Name:              clusterName,
+		MinNodeCount:      opts.NodeCount,
+		ReplicationFactor: opts.ReplicationFactor,
+		ShardTotal:        opts.ShardTotal,
+		CreatedAt:         uint64(time.Now().UnixMilli()),
 	}
 	err = m.storage.CreateCluster(ctx, storage.CreateClusterRequest{
 		Cluster: clusterMetadata,

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -103,13 +103,13 @@ func (m *managerImpl) CreateCluster(ctx context.Context, clusterName string, opt
 	}
 
 	clusterMetadata := storage.Cluster{
-		ID:                clusterID,
-		Name:              clusterName,
-		MinNodeCount:      opts.NodeCount,
-		ReplicationFactor: opts.ReplicationFactor,
-		ShardTotal:        opts.ShardTotal,
-		TablePartitionNum: opts.TablePartitionNum,
-		CreatedAt:         uint64(time.Now().UnixMilli()),
+		ID:                         clusterID,
+		Name:                       clusterName,
+		MinNodeCount:               opts.NodeCount,
+		ReplicationFactor:          opts.ReplicationFactor,
+		ShardTotal:                 opts.ShardTotal,
+		PartitionTableRatioOfNodes: opts.PartitionTableRatioOfNodes,
+		CreatedAt:                  uint64(time.Now().UnixMilli()),
 	}
 	err = m.storage.CreateCluster(ctx, storage.CreateClusterRequest{
 		Cluster: clusterMetadata,

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -29,7 +29,7 @@ type Manager interface {
 	Stop(ctx context.Context) error
 
 	ListClusters(ctx context.Context) ([]*Cluster, error)
-	CreateCluster(ctx context.Context, clusterName string, nodeCount, replicationFactor, shardTotal uint32) (*Cluster, error)
+	CreateCluster(ctx context.Context, clusterName string, nodeCount, replicationFactor, shardTotal, partitionTableNum uint32) (*Cluster, error)
 	GetCluster(ctx context.Context, clusterName string) (*Cluster, error)
 	// AllocSchemaID means get or create schema.
 	// The second output parameter bool: Returns true if the table was newly created.
@@ -83,7 +83,7 @@ func (m *managerImpl) ListClusters(_ context.Context) ([]*Cluster, error) {
 }
 
 func (m *managerImpl) CreateCluster(ctx context.Context, clusterName string, initialNodeCount,
-	replicationFactor, shardTotal uint32,
+	replicationFactor, shardTotal, partitionTableNum uint32,
 ) (*Cluster, error) {
 	if initialNodeCount < 1 {
 		log.Error("cluster's nodeCount must > 0", zap.String("clusterName", clusterName))
@@ -110,6 +110,7 @@ func (m *managerImpl) CreateCluster(ctx context.Context, clusterName string, ini
 		MinNodeCount:      initialNodeCount,
 		ReplicationFactor: replicationFactor,
 		ShardTotal:        shardTotal,
+		PartitionTableNum: partitionTableNum,
 		CreatedAt:         uint64(time.Now().UnixMilli()),
 	}
 	err = m.storage.CreateCluster(ctx, storage.CreateClusterRequest{

--- a/server/cluster/table_manager.go
+++ b/server/cluster/table_manager.go
@@ -24,7 +24,7 @@ type TableManager interface {
 	// GetTablesByIDs get tables with tableIDs.
 	GetTablesByIDs(tableIDs []storage.TableID) []storage.Table
 	// CreateTable create table with schemaName and tableName.
-	CreateTable(ctx context.Context, schemaName string, tableName string) (storage.Table, error)
+	CreateTable(ctx context.Context, schemaName string, tableName string, partitioned bool) (storage.Table, error)
 	// DropTable drop table with schemaName and tableName.
 	DropTable(ctx context.Context, schemaName string, tableName string) error
 	// GetSchemaByName get schema with schemaName.
@@ -102,7 +102,7 @@ func (m *TableManagerImpl) GetTablesByIDs(tableIDs []storage.TableID) []storage.
 	return result
 }
 
-func (m *TableManagerImpl) CreateTable(ctx context.Context, schemaName string, tableName string) (storage.Table, error) {
+func (m *TableManagerImpl) CreateTable(ctx context.Context, schemaName string, tableName string, partitioned bool) (storage.Table, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	_, exists, err := m.getTable(schemaName, tableName)
@@ -126,10 +126,11 @@ func (m *TableManagerImpl) CreateTable(ctx context.Context, schemaName string, t
 	}
 
 	table := storage.Table{
-		ID:        storage.TableID(id),
-		Name:      tableName,
-		SchemaID:  schema.ID,
-		CreatedAt: uint64(time.Now().UnixMilli()),
+		ID:          storage.TableID(id),
+		Name:        tableName,
+		SchemaID:    schema.ID,
+		CreatedAt:   uint64(time.Now().UnixMilli()),
+		Partitioned: partitioned,
 	}
 	err = m.storage.CreateTable(ctx, storage.CreateTableRequest{
 		ClusterID: m.clusterID,

--- a/server/cluster/table_manager_test.go
+++ b/server/cluster/table_manager_test.go
@@ -160,10 +160,9 @@ func testCluster(ctx context.Context, re *require.Assertions, manager Manager, c
 
 func testCreateCluster(ctx context.Context, re *require.Assertions, manager Manager, clusterName string) {
 	_, err := manager.CreateCluster(ctx, clusterName, CreateClusterOpts{
-		NodeCount:                  defaultNodeCount,
-		ReplicationFactor:          defaultReplicationFactor,
-		ShardTotal:                 defaultShardTotal,
-		PartitionTableRatioOfNodes: defaultPartitionTableRatioOfNodes,
+		NodeCount:         defaultNodeCount,
+		ReplicationFactor: defaultReplicationFactor,
+		ShardTotal:        defaultShardTotal,
 	})
 	re.NoError(err)
 }
@@ -194,7 +193,7 @@ func testCreateTable(ctx context.Context, re *require.Assertions, manager Manage
 ) {
 	c, err := manager.GetCluster(ctx, clusterName)
 	re.NoError(err)
-	table, err := c.CreateTable(ctx, node, schema, tableName)
+	table, err := c.CreateTable(ctx, node, schema, tableName, false)
 	re.NoError(err)
 	re.Equal(tableID, table.Table.ID)
 }

--- a/server/cluster/table_manager_test.go
+++ b/server/cluster/table_manager_test.go
@@ -17,29 +17,29 @@ import (
 )
 
 const (
-	defaultTimeout                  = time.Second * 10
-	cluster1                        = "ceresdbCluster1"
-	cluster2                        = "ceresdbCluster2"
-	defaultSchema                   = "ceresdbSchema"
-	defaultNodeCount                = 2
-	defaultReplicationFactor        = 1
-	defaultShardTotal               = 8
-	defaultTablePartitionNum        = 2
-	defaultLease                    = 100
-	node1                           = "127.0.0.1:8081"
-	node2                           = "127.0.0.2:8081"
-	table1                          = "table1"
-	table2                          = "table2"
-	table3                          = "table3"
-	table4                          = "table4"
-	defaultSchemaID          uint32 = 0
-	tableID1                 uint64 = 0
-	tableID2                 uint64 = 1
-	tableID3                 uint64 = 2
-	tableID4                 uint64 = 3
-	testRootPath                    = "/rootPath"
-	defaultIDAllocatorStep          = 20
-	defaultThreadNum                = 20
+	defaultTimeout                           = time.Second * 10
+	cluster1                                 = "ceresdbCluster1"
+	cluster2                                 = "ceresdbCluster2"
+	defaultSchema                            = "ceresdbSchema"
+	defaultNodeCount                         = 2
+	defaultReplicationFactor                 = 1
+	defaultShardTotal                        = 8
+	defaultPartitionTableRatioOfNodes        = 2
+	defaultLease                             = 100
+	node1                                    = "127.0.0.1:8081"
+	node2                                    = "127.0.0.2:8081"
+	table1                                   = "table1"
+	table2                                   = "table2"
+	table3                                   = "table3"
+	table4                                   = "table4"
+	defaultSchemaID                   uint32 = 0
+	tableID1                          uint64 = 0
+	tableID2                          uint64 = 1
+	tableID3                          uint64 = 2
+	tableID4                          uint64 = 3
+	testRootPath                             = "/rootPath"
+	defaultIDAllocatorStep                   = 20
+	defaultThreadNum                         = 20
 )
 
 func newTestStorage(t *testing.T) (storage.Storage, clientv3.KV, etcdutil.CloseFn) {
@@ -160,10 +160,10 @@ func testCluster(ctx context.Context, re *require.Assertions, manager Manager, c
 
 func testCreateCluster(ctx context.Context, re *require.Assertions, manager Manager, clusterName string) {
 	_, err := manager.CreateCluster(ctx, clusterName, CreateClusterOpts{
-		NodeCount:         defaultNodeCount,
-		ReplicationFactor: defaultReplicationFactor,
-		ShardTotal:        defaultShardTotal,
-		TablePartitionNum: defaultTablePartitionNum,
+		NodeCount:                  defaultNodeCount,
+		ReplicationFactor:          defaultReplicationFactor,
+		ShardTotal:                 defaultShardTotal,
+		PartitionTableRatioOfNodes: defaultPartitionTableRatioOfNodes,
 	})
 	re.NoError(err)
 }

--- a/server/cluster/table_manager_test.go
+++ b/server/cluster/table_manager_test.go
@@ -39,6 +39,7 @@ const (
 	testRootPath                    = "/rootPath"
 	defaultIDAllocatorStep          = 20
 	defaultThreadNum                = 20
+	defaultPartitionTableNum        = 2
 )
 
 func newTestStorage(t *testing.T) (storage.Storage, clientv3.KV, etcdutil.CloseFn) {
@@ -158,7 +159,7 @@ func testCluster(ctx context.Context, re *require.Assertions, manager Manager, c
 }
 
 func testCreateCluster(ctx context.Context, re *require.Assertions, manager Manager, clusterName string) {
-	_, err := manager.CreateCluster(ctx, clusterName, defaultNodeCount, defaultReplicationFactor, defaultShardTotal)
+	_, err := manager.CreateCluster(ctx, clusterName, defaultNodeCount, defaultReplicationFactor, defaultShardTotal, defaultPartitionTableNum)
 	re.NoError(err)
 }
 

--- a/server/cluster/table_manager_test.go
+++ b/server/cluster/table_manager_test.go
@@ -24,6 +24,7 @@ const (
 	defaultNodeCount                = 2
 	defaultReplicationFactor        = 1
 	defaultShardTotal               = 8
+	defaultTablePartitionNum        = 2
 	defaultLease                    = 100
 	node1                           = "127.0.0.1:8081"
 	node2                           = "127.0.0.2:8081"
@@ -39,7 +40,6 @@ const (
 	testRootPath                    = "/rootPath"
 	defaultIDAllocatorStep          = 20
 	defaultThreadNum                = 20
-	defaultPartitionTableNum        = 2
 )
 
 func newTestStorage(t *testing.T) (storage.Storage, clientv3.KV, etcdutil.CloseFn) {
@@ -159,7 +159,12 @@ func testCluster(ctx context.Context, re *require.Assertions, manager Manager, c
 }
 
 func testCreateCluster(ctx context.Context, re *require.Assertions, manager Manager, clusterName string) {
-	_, err := manager.CreateCluster(ctx, clusterName, defaultNodeCount, defaultReplicationFactor, defaultShardTotal, defaultPartitionTableNum)
+	_, err := manager.CreateCluster(ctx, clusterName, CreateClusterOpts{
+		NodeCount:         defaultNodeCount,
+		ReplicationFactor: defaultReplicationFactor,
+		ShardTotal:        defaultShardTotal,
+		TablePartitionNum: defaultTablePartitionNum,
+	})
 	re.NoError(err)
 }
 

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -12,10 +12,11 @@ const (
 )
 
 type TableInfo struct {
-	ID         storage.TableID
-	Name       string
-	SchemaID   storage.SchemaID
-	SchemaName string
+	ID          storage.TableID
+	Name        string
+	SchemaID    storage.SchemaID
+	SchemaName  string
+	Partitioned bool
 }
 
 type ShardTables struct {

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -37,10 +37,9 @@ type ShardNodeWithVersion struct {
 }
 
 type CreateClusterOpts struct {
-	NodeCount                  uint32
-	ReplicationFactor          uint32
-	ShardTotal                 uint32
-	PartitionTableRatioOfNodes uint32
+	NodeCount         uint32
+	ReplicationFactor uint32
+	ShardTotal        uint32
 }
 
 type CreateTableResult struct {

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -36,10 +36,10 @@ type ShardNodeWithVersion struct {
 }
 
 type CreateClusterOpts struct {
-	NodeCount         uint32
-	ReplicationFactor uint32
-	ShardTotal        uint32
-	TablePartitionNum uint32
+	NodeCount                  uint32
+	ReplicationFactor          uint32
+	ShardTotal                 uint32
+	PartitionTableRatioOfNodes uint32
 }
 
 type CreateTableResult struct {

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -35,6 +35,13 @@ type ShardNodeWithVersion struct {
 	ShardNode storage.ShardNode
 }
 
+type CreateClusterOpts struct {
+	NodeCount         uint32
+	ReplicationFactor uint32
+	ShardTotal        uint32
+	TablePartitionNum uint32
+}
+
 type CreateTableResult struct {
 	Table              storage.Table
 	ShardVersionUpdate ShardVersionUpdate

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -43,11 +43,11 @@ const (
 	defaultMinScanLimit    int  = 20
 	defaultIDAllocatorStep uint = 20
 
-	defaultClusterName              = "defaultCluster"
-	defaultClusterNodeCount         = 2
-	defaultClusterReplicationFactor = 1
-	defaultClusterShardTotal        = 8
-	defaultClusterTablePartitionNum = 2
+	defaultClusterName                       = "defaultCluster"
+	defaultClusterNodeCount                  = 2
+	defaultClusterReplicationFactor          = 1
+	defaultClusterShardTotal                 = 8
+	defaultClusterPartitionTableRatioOfNodes = 2
 
 	defaultHTTPPort = 8080
 )
@@ -95,11 +95,11 @@ type Config struct {
 	IDAllocatorStep         uint   `toml:"id-allocator-step" env:"ID_ALLOCATOR_STEP"`
 
 	// Following fields are the settings for the default cluster.
-	DefaultClusterName              string `toml:"default-cluster-name" env:"DEFAULT_CLUSTER_NAME"`
-	DefaultClusterNodeCount         int    `toml:"default-cluster-node-count" env:"DEFAULT_CLUSTER_NODE_COUNT"`
-	DefaultClusterReplicationFactor int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
-	DefaultClusterShardTotal        int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
-	DefaultClusterTablePartitionNum uint   `toml:"default-cluster-table-partition-num" env:"DEFAULT_CLUSTER_TABLE_PARTITION_NUM"`
+	DefaultClusterName                       string `toml:"default-cluster-name" env:"DEFAULT_CLUSTER_NAME"`
+	DefaultClusterNodeCount                  int    `toml:"default-cluster-node-count" env:"DEFAULT_CLUSTER_NODE_COUNT"`
+	DefaultClusterReplicationFactor          int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
+	DefaultClusterShardTotal                 int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
+	DefaultClusterPartitionTableRatioOfNodes uint   `toml:"default-cluster-partition_table_radio_of_nodes" env:"DEFAULT_CLUSTER_CLUSTER_PARTITION_TABLE_RADIO_OF_NODES"`
 
 	ClientUrls          string `toml:"client-urls" env:"CLIENT_URLS"`
 	PeerUrls            string `toml:"peer-urls" env:"PEER_URLS"`
@@ -250,11 +250,11 @@ func MakeConfigParser() (*Parser, error) {
 		MinScanLimit:            defaultMinScanLimit,
 		IDAllocatorStep:         defaultIDAllocatorStep,
 
-		DefaultClusterName:              defaultClusterName,
-		DefaultClusterNodeCount:         defaultClusterNodeCount,
-		DefaultClusterReplicationFactor: defaultClusterReplicationFactor,
-		DefaultClusterShardTotal:        defaultClusterShardTotal,
-		DefaultClusterTablePartitionNum: defaultClusterTablePartitionNum,
+		DefaultClusterName:                       defaultClusterName,
+		DefaultClusterNodeCount:                  defaultClusterNodeCount,
+		DefaultClusterReplicationFactor:          defaultClusterReplicationFactor,
+		DefaultClusterShardTotal:                 defaultClusterShardTotal,
+		DefaultClusterPartitionTableRatioOfNodes: defaultClusterPartitionTableRatioOfNodes,
 
 		HTTPPort: defaultHTTPPort,
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -47,7 +47,7 @@ const (
 	defaultClusterNodeCount         = 2
 	defaultClusterReplicationFactor = 1
 	defaultClusterShardTotal        = 8
-	defaultClusterPartitionTableNum = 2
+	defaultClusterTablePartitionNum = 2
 
 	defaultHTTPPort = 8080
 )
@@ -99,7 +99,7 @@ type Config struct {
 	DefaultClusterNodeCount         int    `toml:"default-cluster-node-count" env:"DEFAULT_CLUSTER_NODE_COUNT"`
 	DefaultClusterReplicationFactor int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
 	DefaultClusterShardTotal        int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
-	DefaultClusterPartitionTableNum uint   `toml:"default-cluster-partition-table-num" env:"DEFAULT_CLUSTER_PARTITION_TABLE_NUM"`
+	DefaultClusterTablePartitionNum uint   `toml:"default-cluster-table-partition-num" env:"DEFAULT_CLUSTER_TABLE_PARTITION_NUM"`
 
 	ClientUrls          string `toml:"client-urls" env:"CLIENT_URLS"`
 	PeerUrls            string `toml:"peer-urls" env:"PEER_URLS"`
@@ -254,7 +254,7 @@ func MakeConfigParser() (*Parser, error) {
 		DefaultClusterNodeCount:         defaultClusterNodeCount,
 		DefaultClusterReplicationFactor: defaultClusterReplicationFactor,
 		DefaultClusterShardTotal:        defaultClusterShardTotal,
-		DefaultClusterPartitionTableNum: defaultClusterPartitionTableNum,
+		DefaultClusterTablePartitionNum: defaultClusterTablePartitionNum,
 
 		HTTPPort: defaultHTTPPort,
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -47,6 +47,7 @@ const (
 	defaultClusterNodeCount         = 2
 	defaultClusterReplicationFactor = 1
 	defaultClusterShardTotal        = 8
+	defaultClusterPartitionTableNum = 2
 
 	defaultHTTPPort = 8080
 )
@@ -98,6 +99,7 @@ type Config struct {
 	DefaultClusterNodeCount         int    `toml:"default-cluster-node-count" env:"DEFAULT_CLUSTER_NODE_COUNT"`
 	DefaultClusterReplicationFactor int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
 	DefaultClusterShardTotal        int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
+	DefaultClusterPartitionTableNum uint   `toml:"default-cluster-partition-table-num" env:"DEFAULT_CLUSTER_PARTITION_TABLE_NUM"`
 
 	ClientUrls          string `toml:"client-urls" env:"CLIENT_URLS"`
 	PeerUrls            string `toml:"peer-urls" env:"PEER_URLS"`
@@ -252,6 +254,7 @@ func MakeConfigParser() (*Parser, error) {
 		DefaultClusterNodeCount:         defaultClusterNodeCount,
 		DefaultClusterReplicationFactor: defaultClusterReplicationFactor,
 		DefaultClusterShardTotal:        defaultClusterShardTotal,
+		DefaultClusterPartitionTableNum: defaultClusterPartitionTableNum,
 
 		HTTPPort: defaultHTTPPort,
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -47,7 +47,7 @@ const (
 	defaultClusterNodeCount                = 2
 	defaultClusterReplicationFactor        = 1
 	defaultClusterShardTotal               = 8
-	defaultPartitionTableProportionOfNodes = float32(0.5)
+	defaultPartitionTableProportionOfNodes = 0.5
 
 	defaultHTTPPort = 8080
 )

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -43,11 +43,11 @@ const (
 	defaultMinScanLimit    int  = 20
 	defaultIDAllocatorStep uint = 20
 
-	defaultClusterName                       = "defaultCluster"
-	defaultClusterNodeCount                  = 2
-	defaultClusterReplicationFactor          = 1
-	defaultClusterShardTotal                 = 8
-	defaultClusterPartitionTableRatioOfNodes = 2
+	defaultClusterName                     = "defaultCluster"
+	defaultClusterNodeCount                = 2
+	defaultClusterReplicationFactor        = 1
+	defaultClusterShardTotal               = 8
+	defaultPartitionTableProportionOfNodes = float32(0.5)
 
 	defaultHTTPPort = 8080
 )
@@ -95,16 +95,17 @@ type Config struct {
 	IDAllocatorStep         uint   `toml:"id-allocator-step" env:"ID_ALLOCATOR_STEP"`
 
 	// Following fields are the settings for the default cluster.
-	DefaultClusterName                       string `toml:"default-cluster-name" env:"DEFAULT_CLUSTER_NAME"`
-	DefaultClusterNodeCount                  int    `toml:"default-cluster-node-count" env:"DEFAULT_CLUSTER_NODE_COUNT"`
-	DefaultClusterReplicationFactor          int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
-	DefaultClusterShardTotal                 int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
-	DefaultClusterPartitionTableRatioOfNodes uint   `toml:"default-cluster-partition_table_radio_of_nodes" env:"DEFAULT_CLUSTER_CLUSTER_PARTITION_TABLE_RADIO_OF_NODES"`
+	DefaultClusterName              string `toml:"default-cluster-name" env:"DEFAULT_CLUSTER_NAME"`
+	DefaultClusterNodeCount         int    `toml:"default-cluster-node-count" env:"DEFAULT_CLUSTER_NODE_COUNT"`
+	DefaultClusterReplicationFactor int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
+	DefaultClusterShardTotal        int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
 
 	ClientUrls          string `toml:"client-urls" env:"CLIENT_URLS"`
 	PeerUrls            string `toml:"peer-urls" env:"PEER_URLS"`
 	AdvertiseClientUrls string `toml:"advertise-client-urls" env:"ADVERTISE_CLIENT_URLS"`
 	AdvertisePeerUrls   string `toml:"advertise-peer-urls" env:"ADVERTISE_PEER_URLS"`
+
+	DefaultPartitionTableProportionOfNodes float32 `toml:"default-partition_table_proportion_of_nodes" env:"DEFAULT_PARTITION_TABLE_PROPORTION_OF_NODES"`
 
 	HTTPPort int `toml:"default-http-port" env:"DEFAULT_HTTP_PORT"`
 }
@@ -250,11 +251,11 @@ func MakeConfigParser() (*Parser, error) {
 		MinScanLimit:            defaultMinScanLimit,
 		IDAllocatorStep:         defaultIDAllocatorStep,
 
-		DefaultClusterName:                       defaultClusterName,
-		DefaultClusterNodeCount:                  defaultClusterNodeCount,
-		DefaultClusterReplicationFactor:          defaultClusterReplicationFactor,
-		DefaultClusterShardTotal:                 defaultClusterShardTotal,
-		DefaultClusterPartitionTableRatioOfNodes: defaultClusterPartitionTableRatioOfNodes,
+		DefaultClusterName:                     defaultClusterName,
+		DefaultClusterNodeCount:                defaultClusterNodeCount,
+		DefaultClusterReplicationFactor:        defaultClusterReplicationFactor,
+		DefaultClusterShardTotal:               defaultClusterShardTotal,
+		DefaultPartitionTableProportionOfNodes: defaultPartitionTableProportionOfNodes,
 
 		HTTPPort: defaultHTTPPort,
 	}

--- a/server/coordinator/procedure/ShardPicker.go
+++ b/server/coordinator/procedure/ShardPicker.go
@@ -1,0 +1,72 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package procedure
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+
+	"github.com/CeresDB/ceresmeta/server/cluster"
+	"github.com/pkg/errors"
+)
+
+// ShardPicker is used to pick up the shards suitable for scheduling in the cluster.
+type ShardPicker interface {
+	PickShards(ctx context.Context, clusterName string, num int) ([]cluster.ShardNodeWithVersion, error)
+}
+
+// RandomShardPicker randomly pick up shards not on the same node exists in current cluster.
+type RandomShardPicker struct {
+	clusterManager cluster.Manager
+}
+
+func NewRandomShardPicker(manager cluster.Manager) ShardPicker {
+	return &RandomShardPicker{
+		clusterManager: manager,
+	}
+}
+
+func (p *RandomShardPicker) PickShards(ctx context.Context, clusterName string, num int) ([]cluster.ShardNodeWithVersion, error) {
+	getNodeShardResult, err := p.clusterManager.GetNodeShards(ctx, clusterName)
+	if err != nil {
+		return []cluster.ShardNodeWithVersion{}, errors.WithMessage(err, "get node shards")
+	}
+	nodeShardsMapping := make(map[string][]cluster.ShardNodeWithVersion, 0)
+	var nodeNames []string
+	for _, nodeShard := range getNodeShardResult.NodeShards {
+		_, exists := nodeShardsMapping[nodeShard.ShardNode.NodeName]
+		if !exists {
+			nodeShards := []cluster.ShardNodeWithVersion{}
+			nodeNames = append(nodeNames, nodeShard.ShardNode.NodeName)
+			nodeShardsMapping[nodeShard.ShardNode.NodeName] = nodeShards
+		}
+		nodeShardsMapping[nodeShard.ShardNode.NodeName] = append(nodeShardsMapping[nodeShard.ShardNode.NodeName], nodeShard)
+	}
+	if len(nodeShardsMapping) < num {
+		return []cluster.ShardNodeWithVersion{}, errors.WithMessage(ErrNodeNumberNotEnough, fmt.Sprintf("number of nodes is: %d, expecet number of shards is: %d", len(nodeShardsMapping), num))
+	}
+
+	var selectNodeNames []string
+	for i := 0; i < num; i++ {
+		selectNodeIndex, err := rand.Int(rand.Reader, big.NewInt(int64(len(nodeNames))))
+		if err != nil {
+			return []cluster.ShardNodeWithVersion{}, errors.WithMessage(err, "generate random node index")
+		}
+		selectNodeNames = append(selectNodeNames, nodeNames[selectNodeIndex.Int64()])
+		nodeNames = append(nodeNames[:selectNodeIndex.Int64()], nodeNames[selectNodeIndex.Int64()+1:]...)
+	}
+
+	result := []cluster.ShardNodeWithVersion{}
+	for _, nodeName := range selectNodeNames {
+		nodeShards := nodeShardsMapping[nodeName]
+		selectShardIndex, err := rand.Int(rand.Reader, big.NewInt(int64(len(nodeShards))))
+		if err != nil {
+			return []cluster.ShardNodeWithVersion{}, errors.WithMessage(err, "generate random node index")
+		}
+		result = append(result, nodeShards[selectShardIndex.Int64()])
+	}
+
+	return result, nil
+}

--- a/server/coordinator/procedure/common_test.go
+++ b/server/coordinator/procedure/common_test.go
@@ -16,18 +16,18 @@ import (
 )
 
 const (
-	testTableName0                    = "table0"
-	testTableName1                    = "table1"
-	testSchemaName                    = "testSchemaName"
-	nodeName0                         = "node0"
-	nodeName1                         = "node1"
-	testRootPath                      = "/rootPath"
-	defaultIDAllocatorStep            = 20
-	clusterName                       = "ceresdbCluster1"
-	defaultNodeCount                  = 2
-	defaultReplicationFactor          = 1
-	defaultPartitionTableRatioOfNodes = 1
-	defaultShardTotal                 = 2
+	testTableName0                         = "table0"
+	testTableName1                         = "table1"
+	testSchemaName                         = "testSchemaName"
+	nodeName0                              = "node0"
+	nodeName1                              = "node1"
+	testRootPath                           = "/rootPath"
+	defaultIDAllocatorStep                 = 20
+	clusterName                            = "ceresdbCluster1"
+	defaultNodeCount                       = 2
+	defaultReplicationFactor               = 1
+	defaultPartitionTableProportionOfNodes = float32(0.5)
+	defaultShardTotal                      = 2
 )
 
 type MockDispatch struct{}
@@ -63,10 +63,9 @@ func newTestCluster(ctx context.Context, t *testing.T) (cluster.Manager, *cluste
 	re.NoError(err)
 
 	cluster, err := manager.CreateCluster(ctx, clusterName, cluster.CreateClusterOpts{
-		NodeCount:                  defaultNodeCount,
-		ReplicationFactor:          defaultReplicationFactor,
-		ShardTotal:                 defaultShardTotal,
-		PartitionTableRatioOfNodes: defaultPartitionTableRatioOfNodes,
+		NodeCount:         defaultNodeCount,
+		ReplicationFactor: defaultReplicationFactor,
+		ShardTotal:        defaultShardTotal,
 	})
 	re.NoError(err)
 	return manager, cluster

--- a/server/coordinator/procedure/common_test.go
+++ b/server/coordinator/procedure/common_test.go
@@ -16,18 +16,18 @@ import (
 )
 
 const (
-	testTableName0           = "table0"
-	testTableName1           = "table1"
-	testSchemaName           = "testSchemaName"
-	nodeName0                = "node0"
-	nodeName1                = "node1"
-	testRootPath             = "/rootPath"
-	defaultIDAllocatorStep   = 20
-	clusterName              = "ceresdbCluster1"
-	defaultNodeCount         = 2
-	defaultReplicationFactor = 1
-	defaultTablePartitionNum = 2
-	defaultShardTotal        = 2
+	testTableName0                    = "table0"
+	testTableName1                    = "table1"
+	testSchemaName                    = "testSchemaName"
+	nodeName0                         = "node0"
+	nodeName1                         = "node1"
+	testRootPath                      = "/rootPath"
+	defaultIDAllocatorStep            = 20
+	clusterName                       = "ceresdbCluster1"
+	defaultNodeCount                  = 2
+	defaultReplicationFactor          = 1
+	defaultPartitionTableRatioOfNodes = 1
+	defaultShardTotal                 = 2
 )
 
 type MockDispatch struct{}
@@ -63,10 +63,10 @@ func newTestCluster(ctx context.Context, t *testing.T) (cluster.Manager, *cluste
 	re.NoError(err)
 
 	cluster, err := manager.CreateCluster(ctx, clusterName, cluster.CreateClusterOpts{
-		NodeCount:         defaultNodeCount,
-		ReplicationFactor: defaultReplicationFactor,
-		ShardTotal:        defaultShardTotal,
-		TablePartitionNum: defaultTablePartitionNum,
+		NodeCount:                  defaultNodeCount,
+		ReplicationFactor:          defaultReplicationFactor,
+		ShardTotal:                 defaultShardTotal,
+		PartitionTableRatioOfNodes: defaultPartitionTableRatioOfNodes,
 	})
 	re.NoError(err)
 	return manager, cluster

--- a/server/coordinator/procedure/common_test.go
+++ b/server/coordinator/procedure/common_test.go
@@ -26,7 +26,7 @@ const (
 	clusterName                            = "ceresdbCluster1"
 	defaultNodeCount                       = 2
 	defaultReplicationFactor               = 1
-	defaultPartitionTableProportionOfNodes = float32(0.5)
+	defaultPartitionTableProportionOfNodes = 0.5
 	defaultShardTotal                      = 2
 )
 

--- a/server/coordinator/procedure/common_test.go
+++ b/server/coordinator/procedure/common_test.go
@@ -26,7 +26,7 @@ const (
 	clusterName              = "ceresdbCluster1"
 	defaultNodeCount         = 2
 	defaultReplicationFactor = 1
-	defaultPartitionNum      = 2
+	defaultTablePartitionNum = 2
 	defaultShardTotal        = 2
 )
 
@@ -62,7 +62,12 @@ func newTestCluster(ctx context.Context, t *testing.T) (cluster.Manager, *cluste
 	manager, err := cluster.NewManagerImpl(storage, kv, testRootPath, defaultIDAllocatorStep)
 	re.NoError(err)
 
-	cluster, err := manager.CreateCluster(ctx, clusterName, defaultNodeCount, defaultReplicationFactor, defaultShardTotal, defaultPartitionNum)
+	cluster, err := manager.CreateCluster(ctx, clusterName, cluster.CreateClusterOpts{
+		NodeCount:         defaultNodeCount,
+		ReplicationFactor: defaultReplicationFactor,
+		ShardTotal:        defaultShardTotal,
+		TablePartitionNum: defaultTablePartitionNum,
+	})
 	re.NoError(err)
 	return manager, cluster
 }

--- a/server/coordinator/procedure/create_drop_table_test.go
+++ b/server/coordinator/procedure/create_drop_table_test.go
@@ -70,7 +70,7 @@ func TestCreateAndDropTable(t *testing.T) {
 func testCreateTable(t *testing.T, dispatch eventdispatch.Dispatch, c *cluster.Cluster, tableName string) {
 	re := require.New(t)
 	// New CreateTableProcedure to create a new table.
-	procedure := NewCreateTableProcedure(dispatch, c, uint64(1), &metaservicepb.CreateTableRequest{
+	procedure := NewCreateNormalTableProcedure(dispatch, c, uint64(1), &metaservicepb.CreateTableRequest{
 		Header: &metaservicepb.RequestHeader{
 			Node:        nodeName0,
 			ClusterName: clusterName,

--- a/server/coordinator/procedure/create_drop_table_test.go
+++ b/server/coordinator/procedure/create_drop_table_test.go
@@ -17,7 +17,7 @@ import (
 func TestCreateAndDropTable(t *testing.T) {
 	re := require.New(t)
 	dispatch := MockDispatch{}
-	c := prepare(t)
+	_, c := prepare(t)
 	testTableNum := 20
 	// Create table.
 	for i := 0; i < testTableNum; i++ {

--- a/server/coordinator/procedure/create_normal_table.go
+++ b/server/coordinator/procedure/create_normal_table.go
@@ -1,0 +1,166 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package procedure
+
+import (
+	"context"
+	"sync"
+
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/CeresDB/ceresmeta/server/cluster"
+	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
+	"github.com/looplab/fsm"
+	"github.com/pkg/errors"
+)
+
+const (
+	eventCreateTablePrepare = "EventCreateTablePrepare"
+	eventCreateTableFailed  = "EventCreateTableFailed"
+	eventCreateTableSuccess = "EventCreateTableSuccess"
+
+	stateCreateTableBegin   = "StateCreateTableBegin"
+	stateCreateTableWaiting = "StateCreateTableWaiting"
+	stateCreateTableFinish  = "StateCreateTableFinish"
+	stateCreateTableFailed  = "StateCreateTableFailed"
+)
+
+var (
+	createTableEvents = fsm.Events{
+		{Name: eventCreateTablePrepare, Src: []string{stateCreateTableBegin}, Dst: stateCreateTableWaiting},
+		{Name: eventCreateTableSuccess, Src: []string{stateCreateTableWaiting}, Dst: stateCreateTableFinish},
+		{Name: eventCreateTableFailed, Src: []string{stateCreateTableWaiting}, Dst: stateCreateTableFailed},
+	}
+	createTableCallbacks = fsm.Callbacks{
+		eventCreateTablePrepare: createTablePrepareCallback,
+		eventCreateTableFailed:  createTableFailedCallback,
+		eventCreateTableSuccess: createTableSuccessCallback,
+	}
+)
+
+func createTablePrepareCallback(event *fsm.Event) {
+	req := event.Args[0].(*createTableCallbackRequest)
+
+	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), req.sourceReq.GetHeader().GetNode())
+	if err != nil {
+		cancelEventWithLog(event, err, "create table metadata")
+		return
+	}
+
+	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, createTableResult.ShardVersionUpdate.ShardID, buildCreateTableRequest(createTableResult, req.sourceReq)); err != nil {
+		cancelEventWithLog(event, err, "dispatch create table on shard")
+		return
+	}
+
+	req.createTableResult = createTableResult
+}
+
+func createTableSuccessCallback(event *fsm.Event) {
+	req := event.Args[0].(*createTableCallbackRequest)
+
+	if err := req.onSucceeded(req.createTableResult); err != nil {
+		log.Error("exec success callback failed")
+	}
+}
+
+func createTableFailedCallback(event *fsm.Event) {
+	req := event.Args[0].(*createTableCallbackRequest)
+
+	if err := req.onFailed(event.Err); err != nil {
+		log.Error("exec failed callback failed")
+	}
+}
+
+// createTableCallbackRequest is fsm callbacks param.
+type createTableCallbackRequest struct {
+	ctx      context.Context
+	cluster  *cluster.Cluster
+	dispatch eventdispatch.Dispatch
+
+	sourceReq *metaservicepb.CreateTableRequest
+
+	onSucceeded func(cluster.CreateTableResult) error
+	onFailed    func(error) error
+
+	createTableResult cluster.CreateTableResult
+}
+
+func NewCreateNormalTableProcedure(dispatch eventdispatch.Dispatch, cluster *cluster.Cluster, id uint64, req *metaservicepb.CreateTableRequest, onSucceeded func(cluster.CreateTableResult) error, onFailed func(error) error) Procedure {
+	fsm := fsm.NewFSM(
+		stateCreateTableBegin,
+		createTableEvents,
+		createTableCallbacks,
+	)
+	return &CreateNormalTableProcedure{id: id, fsm: fsm, cluster: cluster, dispatch: dispatch, req: req, state: StateInit, onSucceeded: onSucceeded, onFailed: onFailed}
+}
+
+type CreateNormalTableProcedure struct {
+	id       uint64
+	fsm      *fsm.FSM
+	cluster  *cluster.Cluster
+	dispatch eventdispatch.Dispatch
+
+	req *metaservicepb.CreateTableRequest
+
+	onSucceeded func(cluster.CreateTableResult) error
+	onFailed    func(error) error
+
+	lock  sync.RWMutex
+	state State
+}
+
+func (p *CreateNormalTableProcedure) ID() uint64 {
+	return p.id
+}
+
+func (p *CreateNormalTableProcedure) Typ() Typ {
+	return CreateTable
+}
+
+func (p *CreateNormalTableProcedure) Start(ctx context.Context) error {
+	p.updateState(StateRunning)
+
+	req := &createTableCallbackRequest{
+		cluster:     p.cluster,
+		ctx:         ctx,
+		dispatch:    p.dispatch,
+		sourceReq:   p.req,
+		onSucceeded: p.onSucceeded,
+		onFailed:    p.onFailed,
+	}
+
+	if err := p.fsm.Event(eventCreateTablePrepare, req); err != nil {
+		err1 := p.fsm.Event(eventCreateTableFailed, req)
+		p.updateState(StateFailed)
+		if err1 != nil {
+			err = errors.WithMessagef(err, "send eventCreateTableFailed, err:%v", err1)
+		}
+		return errors.WithMessage(err, "send eventCreateTablePrepare")
+	}
+
+	if err := p.fsm.Event(eventCreateTableSuccess, req); err != nil {
+		return errors.WithMessage(err, "send eventCreateTableSuccess")
+	}
+
+	p.updateState(StateFinished)
+	return nil
+}
+
+func (p *CreateNormalTableProcedure) Cancel(_ context.Context) error {
+	p.updateState(StateCancelled)
+	return nil
+}
+
+func (p *CreateNormalTableProcedure) State() State {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.state
+}
+
+func (p *CreateNormalTableProcedure) updateState(state State) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.state = state
+}

--- a/server/coordinator/procedure/create_normal_table.go
+++ b/server/coordinator/procedure/create_normal_table.go
@@ -41,13 +41,13 @@ var (
 func createTablePrepareCallback(event *fsm.Event) {
 	req := event.Args[0].(*createTableCallbackRequest)
 
-	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), req.sourceReq.GetHeader().GetNode())
+	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), req.sourceReq.GetHeader().GetNode(), false)
 	if err != nil {
 		cancelEventWithLog(event, err, "create table metadata")
 		return
 	}
 
-	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, createTableResult.ShardVersionUpdate.ShardID, buildCreateTableRequest(createTableResult, req.sourceReq)); err != nil {
+	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, createTableResult.ShardVersionUpdate.ShardID, buildCreateTableRequest(createTableResult, req.sourceReq, false)); err != nil {
 		cancelEventWithLog(event, err, "dispatch create table on shard")
 		return
 	}

--- a/server/coordinator/procedure/create_partition_table.go
+++ b/server/coordinator/procedure/create_partition_table.go
@@ -204,14 +204,14 @@ func createPartitionTableCallback(event *fsm.Event) {
 	// Select first shard to create partition table.
 	partitionTableShardNode := req.partitionTableShards[0]
 
-	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), partitionTableShardNode.ShardNode.NodeName)
+	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), partitionTableShardNode.ShardNode.NodeName, true)
 	if err != nil {
 		cancelEventWithLog(event, err, "create table metadata")
 		return
 	}
 	req.createTableResult = createTableResult
 
-	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, partitionTableShardNode.ShardInfo.ID, buildCreateTableRequest(createTableResult, req.sourceReq)); err != nil {
+	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, partitionTableShardNode.ShardInfo.ID, buildCreateTableRequest(createTableResult, req.sourceReq, true)); err != nil {
 		cancelEventWithLog(event, err, "dispatch create table on shard")
 		return
 	}
@@ -226,13 +226,13 @@ func createDataTablesCallback(event *fsm.Event) {
 	}
 
 	for i, dataTableShard := range req.dataTablesShards {
-		createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetPartitionInfo().Names[i], dataTableShard.ShardNode.NodeName)
+		createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetPartitionInfo().Names[i], dataTableShard.ShardNode.NodeName, false)
 		if err != nil {
 			cancelEventWithLog(event, err, "create table metadata")
 			return
 		}
 
-		if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, dataTableShard.ShardInfo.ID, buildCreateTableRequest(createTableResult, req.sourceReq)); err != nil {
+		if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, dataTableShard.ShardInfo.ID, buildCreateTableRequest(createTableResult, req.sourceReq, false)); err != nil {
 			cancelEventWithLog(event, err, "dispatch create table on shard")
 			return
 		}

--- a/server/coordinator/procedure/create_partition_table.go
+++ b/server/coordinator/procedure/create_partition_table.go
@@ -1,0 +1,337 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package procedure
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/CeresDB/ceresmeta/server/cluster"
+	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
+	"github.com/CeresDB/ceresmeta/server/storage"
+	"github.com/looplab/fsm"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+const (
+	eventCreatePartitionTable = "EventCreatePartitionTable"
+	eventCreateDataTables     = "EventCreateDataTables"
+	eventOpenPartitionTables  = "EventOpenPartitionTables"
+	eventFinish               = "EventSuccess"
+
+	stateBegin                = "StateCreatePartitionTableBegin"
+	stateCreatePartitionTable = "StateCreatePartitionTableCreateSuperTable"
+	stateCreateDataTables     = "StateCreatePartitionTableCreateDataTables"
+	stateOpenPartitionTables  = "StateCreatePartitionTableOpenSuperTables"
+	stateFinish               = "StateCreatePartitionTableFinish"
+)
+
+var (
+	createPartitionTableEvents = fsm.Events{
+		{Name: eventCreatePartitionTable, Src: []string{stateBegin}, Dst: stateCreatePartitionTable},
+		{Name: eventCreateDataTables, Src: []string{stateCreatePartitionTable}, Dst: stateCreateDataTables},
+		{Name: eventOpenPartitionTables, Src: []string{stateCreateDataTables}, Dst: stateOpenPartitionTables},
+		{Name: eventFinish, Src: []string{stateOpenPartitionTables}, Dst: stateFinish},
+	}
+	createPartitionTableCallbacks = fsm.Callbacks{
+		eventCreatePartitionTable: createPartitionTableCallback,
+		eventCreateDataTables:     createDataTablesCallback,
+		eventOpenPartitionTables:  openPartitionTablesCallback,
+		eventFinish:               finishCallback,
+	}
+)
+
+type CreatePartitionTableProcedure struct {
+	id       uint64
+	fsm      *fsm.FSM
+	cluster  *cluster.Cluster
+	dispatch eventdispatch.Dispatch
+	storage  Storage
+
+	req *metaservicepb.CreateTableRequest
+
+	partitionTableNum uint
+
+	partitionTableShards []cluster.ShardNodeWithVersion
+	dataTablesShards     []cluster.ShardNodeWithVersion
+
+	onSucceeded func(cluster.CreateTableResult) error
+	onFailed    func(error) error
+
+	lock  sync.RWMutex
+	state State
+}
+
+func NewCreatePartitionTableProcedure(id uint64, cluster *cluster.Cluster, dispatch eventdispatch.Dispatch, storage Storage, req *metaservicepb.CreateTableRequest, partitionTableShards []cluster.ShardNodeWithVersion, dataTablesShards []cluster.ShardNodeWithVersion, onSucceeded func(cluster.CreateTableResult) error, onFailed func(error) error) *CreatePartitionTableProcedure {
+	fsm := fsm.NewFSM(
+		stateBegin,
+		createPartitionTableEvents,
+		createPartitionTableCallbacks,
+	)
+	return &CreatePartitionTableProcedure{
+		id:                   id,
+		fsm:                  fsm,
+		cluster:              cluster,
+		dispatch:             dispatch,
+		storage:              storage,
+		req:                  req,
+		partitionTableShards: partitionTableShards,
+		dataTablesShards:     dataTablesShards,
+		onSucceeded:          onSucceeded,
+		onFailed:             onFailed,
+	}
+}
+
+func (p *CreatePartitionTableProcedure) ID() uint64 {
+	return p.id
+}
+
+func (p *CreatePartitionTableProcedure) Typ() Typ {
+	return CreatePartitionTable
+}
+
+func (p *CreatePartitionTableProcedure) Start(ctx context.Context) error {
+	p.updateStateWithLock(StateRunning)
+
+	createPartitionTableRequest := CreatePartitionTableCallbackRequest{
+		ctx:                  ctx,
+		cluster:              p.cluster,
+		dispatch:             p.dispatch,
+		sourceReq:            p.req,
+		partitionTableShards: p.partitionTableShards,
+		dataTablesShards:     p.dataTablesShards,
+		onSucceeded:          p.onSucceeded,
+		onFailed:             p.onFailed,
+	}
+
+	for {
+		switch p.fsm.Current() {
+		case stateBegin:
+			if err := p.persist(ctx); err != nil {
+				return errors.WithMessage(err, "create partition table procedure persist")
+			}
+			if err := p.fsm.Event(eventCreatePartitionTable, createPartitionTableRequest); err != nil {
+				p.updateStateWithLock(StateFailed)
+				return errors.WithMessagef(err, "create partition table procedure create new shard view")
+			}
+		case stateCreatePartitionTable:
+			if err := p.persist(ctx); err != nil {
+				return errors.WithMessage(err, "create partition table procedure persist")
+			}
+			if err := p.fsm.Event(eventCreateDataTables, createPartitionTableRequest); err != nil {
+				p.updateStateWithLock(StateFailed)
+				return errors.WithMessagef(err, "create partition table procedure create new shard")
+			}
+		case stateCreateDataTables:
+			if err := p.persist(ctx); err != nil {
+				return errors.WithMessage(err, "create partition table procedure persist")
+			}
+			if err := p.fsm.Event(eventOpenPartitionTables, createPartitionTableRequest); err != nil {
+				p.updateStateWithLock(StateFailed)
+				return errors.WithMessagef(err, "create partition table procedure create shard tables")
+			}
+		case stateOpenPartitionTables:
+			if err := p.persist(ctx); err != nil {
+				return errors.WithMessage(err, "create partition table procedure persist")
+			}
+			if err := p.fsm.Event(eventFinish, createPartitionTableRequest); err != nil {
+				p.updateStateWithLock(StateFailed)
+				return errors.WithMessagef(err, "create partition table procedure delete shard tables")
+			}
+		case stateFinish:
+			if err := p.persist(ctx); err != nil {
+				return errors.WithMessage(err, "create partition table procedure persist")
+			}
+			p.updateStateWithLock(StateFinished)
+			return nil
+		}
+	}
+}
+
+func (p *CreatePartitionTableProcedure) Cancel(_ context.Context) error {
+	p.updateStateWithLock(StateCancelled)
+	return nil
+}
+
+func (p *CreatePartitionTableProcedure) State() State {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.state
+}
+
+type CreatePartitionTableCallbackRequest struct {
+	ctx      context.Context
+	cluster  *cluster.Cluster
+	dispatch eventdispatch.Dispatch
+
+	sourceReq *metaservicepb.CreateTableRequest
+
+	onSucceeded func(cluster.CreateTableResult) error
+	onFailed    func(error) error
+
+	createTableResult    cluster.CreateTableResult
+	partitionTableShards []cluster.ShardNodeWithVersion
+	dataTablesShards     []cluster.ShardNodeWithVersion
+}
+
+// 1. Create super table in target node.
+func createPartitionTableCallback(event *fsm.Event) {
+	req, err := getRequestFromEvent[CreatePartitionTableCallbackRequest](event)
+	if err != nil {
+		cancelEventWithLog(event, err, "get request from event")
+		return
+	}
+	// Select first shard to create partition table.
+	partitionTableShardNode := req.partitionTableShards[0]
+
+	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), partitionTableShardNode.ShardNode.NodeName)
+	if err != nil {
+		cancelEventWithLog(event, err, "create table metadata")
+		return
+	}
+
+	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, partitionTableShardNode.ShardInfo.ID, buildCreateTableRequest(createTableResult, req.sourceReq)); err != nil {
+		cancelEventWithLog(event, err, "dispatch create table on shard")
+		return
+	}
+}
+
+// 2. Create data tables in target nodes.
+func createDataTablesCallback(event *fsm.Event) {
+	req, err := getRequestFromEvent[CreatePartitionTableCallbackRequest](event)
+	if err != nil {
+		cancelEventWithLog(event, err, "get request from event")
+		return
+	}
+
+	for i, dataTableShard := range req.dataTablesShards {
+		createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetPartitionInfo().Names[i], dataTableShard.ShardNode.NodeName)
+		if err != nil {
+			cancelEventWithLog(event, err, "create table metadata")
+			return
+		}
+
+		if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, dataTableShard.ShardInfo.ID, buildCreateTableRequest(createTableResult, req.sourceReq)); err != nil {
+			cancelEventWithLog(event, err, "dispatch create table on shard")
+			return
+		}
+	}
+}
+
+// 3. Open super table in target nodes.
+// TODO: Replace open table implementation, avoid reopening shard.
+func openPartitionTablesCallback(event *fsm.Event) {
+	req, err := getRequestFromEvent[CreatePartitionTableCallbackRequest](event)
+	if err != nil {
+		cancelEventWithLog(event, err, "get request from event")
+		return
+	}
+
+	partitionTable, _, err := req.cluster.GetTable(req.sourceReq.GetSchemaName(), req.sourceReq.GetName())
+	if err != nil {
+		cancelEventWithLog(event, err, "get table", zap.String("schemaName", req.sourceReq.GetSchemaName()), zap.String("tableName", req.sourceReq.GetName()))
+		return
+	}
+
+	req.partitionTableShards = append(req.partitionTableShards[:0], req.partitionTableShards[1:]...)
+	for _, partitionTableShard := range req.partitionTableShards {
+		// Update table shard mapping.
+		originShardTables := req.cluster.GetShardTables([]storage.ShardID{partitionTableShard.ShardInfo.ID}, partitionTableShard.ShardNode.NodeName)[partitionTableShard.ShardInfo.ID]
+		originShardTables.Shard.Version++
+		originShardTables.Tables = append(originShardTables.Tables, cluster.TableInfo{
+			ID:         partitionTable.ID,
+			Name:       partitionTable.Name,
+			SchemaID:   partitionTable.SchemaID,
+			SchemaName: req.sourceReq.GetSchemaName(),
+		})
+		if err := req.cluster.UpdateShardTables(req.ctx, []cluster.ShardTables{originShardTables}); err != nil {
+			cancelEventWithLog(event, err, "update shard tables")
+			return
+		}
+
+		// Reopen data table shard.
+		if err := req.dispatch.CloseShard(req.ctx, partitionTableShard.ShardNode.NodeName, eventdispatch.CloseShardRequest{
+			ShardID: uint32(partitionTableShard.ShardNode.ID),
+		}); err != nil {
+			cancelEventWithLog(event, err, "close shard")
+			return
+		}
+
+		if err := req.dispatch.OpenShard(req.ctx, partitionTableShard.ShardNode.NodeName, eventdispatch.OpenShardRequest{
+			Shard: partitionTableShard.ShardInfo,
+		}); err != nil {
+			cancelEventWithLog(event, err, "open shard")
+			return
+		}
+	}
+}
+
+func finishCallback(event *fsm.Event) {
+	req, err := getRequestFromEvent[CreatePartitionTableCallbackRequest](event)
+	if err != nil {
+		cancelEventWithLog(event, err, "get request from event")
+		return
+	}
+	log.Info("create partition table finish")
+
+	if err := req.onSucceeded(req.createTableResult); err != nil {
+		cancelEventWithLog(event, err, "create partition table on succeeded")
+		return
+	}
+}
+
+func (p *CreatePartitionTableProcedure) updateStateWithLock(state State) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.state = state
+}
+
+func (p *CreatePartitionTableProcedure) persist(ctx context.Context) error {
+	meta, err := p.convertToMeta()
+	if err != nil {
+		return errors.WithMessage(err, "convert to meta")
+	}
+	err = p.storage.CreateOrUpdate(ctx, meta)
+	if err != nil {
+		return errors.WithMessage(err, "createOrUpdate procedure storage")
+	}
+	return nil
+}
+
+type CreatePartitionTableRawData struct {
+	CreateTableResult    cluster.CreateTableResult
+	PartitionTableNum    uint
+	PartitionTableShards []cluster.ShardNodeWithVersion
+	DataTablesShards     []cluster.ShardNodeWithVersion
+}
+
+func (p *CreatePartitionTableProcedure) convertToMeta() (Meta, error) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	rawData := CreatePartitionTableRawData{
+		PartitionTableNum:    p.partitionTableNum,
+		PartitionTableShards: p.partitionTableShards,
+		DataTablesShards:     p.dataTablesShards,
+	}
+	rawDataBytes, err := json.Marshal(rawData)
+	if err != nil {
+		return Meta{}, ErrEncodeRawData.WithCausef("marshal raw data, procedureID:%v, err:%v", p.id, err)
+	}
+
+	meta := Meta{
+		ID:    p.id,
+		Typ:   CreatePartitionTable,
+		State: p.state,
+
+		RawData: rawDataBytes,
+	}
+
+	return meta, nil
+}

--- a/server/coordinator/procedure/create_partition_table_test.go
+++ b/server/coordinator/procedure/create_partition_table_test.go
@@ -32,15 +32,17 @@ func TestCreatePartitionTable(t *testing.T) {
 		Name:       testTableName0,
 	}
 
-	partitionTableShards, err := shardPicker.PickShards(ctx, c.Name(), defaultPartitionNum)
+	partitionTableShards, err := shardPicker.PickShards(ctx, c.Name(), defaultTablePartitionNum)
 	re.NoError(err)
 	dataTableShards, err := shardPicker.PickShards(ctx, c.Name(), len(request.PartitionInfo.Names))
 	re.NoError(err)
 
-	procedure := NewCreatePartitionTableProcedure(1, c, dispatch, s, request, partitionTableShards, dataTableShards, func(_ cluster.CreateTableResult) error {
-		return nil
-	}, func(_ error) error {
-		return nil
+	procedure := NewCreatePartitionTableProcedure(CreatePartitionTableProcedureRequest{
+		1, c, dispatch, s, request, partitionTableShards, dataTableShards, func(_ cluster.CreateTableResult) error {
+			return nil
+		}, func(_ error) error {
+			return nil
+		},
 	})
 
 	err = procedure.Start(ctx)

--- a/server/coordinator/procedure/create_partition_table_test.go
+++ b/server/coordinator/procedure/create_partition_table_test.go
@@ -32,7 +32,7 @@ func TestCreatePartitionTable(t *testing.T) {
 		Name:       testTableName0,
 	}
 
-	partitionTableShards, err := shardPicker.PickShards(ctx, c.Name(), defaultTablePartitionNum)
+	partitionTableShards, err := shardPicker.PickShards(ctx, c.Name(), defaultPartitionTableRatioOfNodes)
 	re.NoError(err)
 	dataTableShards, err := shardPicker.PickShards(ctx, c.Name(), len(request.PartitionInfo.Names))
 	re.NoError(err)

--- a/server/coordinator/procedure/create_partition_table_test.go
+++ b/server/coordinator/procedure/create_partition_table_test.go
@@ -1,0 +1,48 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package procedure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
+	"github.com/CeresDB/ceresmeta/server/cluster"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreatePartitionTable(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+	dispatch := MockDispatch{}
+	manager, c := prepare(t)
+	s := NewTestStorage(t)
+
+	shardPicker := NewRandomShardPicker(manager)
+
+	request := &metaservicepb.CreateTableRequest{
+		Header: &metaservicepb.RequestHeader{
+			Node:        nodeName0,
+			ClusterName: clusterName,
+		},
+		PartitionInfo: &metaservicepb.PartitionInfo{
+			Names: []string{"p1", "p2"},
+		},
+		SchemaName: testSchemaName,
+		Name:       testTableName0,
+	}
+
+	partitionTableShards, err := shardPicker.PickShards(ctx, c.Name(), defaultPartitionNum)
+	re.NoError(err)
+	dataTableShards, err := shardPicker.PickShards(ctx, c.Name(), len(request.PartitionInfo.Names))
+	re.NoError(err)
+
+	procedure := NewCreatePartitionTableProcedure(1, c, dispatch, s, request, partitionTableShards, dataTableShards, func(_ cluster.CreateTableResult) error {
+		return nil
+	}, func(_ error) error {
+		return nil
+	})
+
+	err = procedure.Start(ctx)
+	re.NoError(err)
+}

--- a/server/coordinator/procedure/create_partition_table_test.go
+++ b/server/coordinator/procedure/create_partition_table_test.go
@@ -32,7 +32,17 @@ func TestCreatePartitionTable(t *testing.T) {
 		Name:       testTableName0,
 	}
 
-	partitionTableShards, err := shardPicker.PickShards(ctx, c.Name(), defaultPartitionTableRatioOfNodes)
+	getNodeShardResult, err := c.GetNodeShards(ctx)
+	re.NoError(err)
+
+	nodeNames := make(map[string]int)
+	for _, nodeShard := range getNodeShardResult.NodeShards {
+		nodeNames[nodeShard.ShardNode.NodeName] = 1
+	}
+
+	partitionTableNum := Max(1, int(float32(len(nodeNames))*defaultPartitionTableProportionOfNodes))
+
+	partitionTableShards, err := shardPicker.PickShards(ctx, c.Name(), partitionTableNum)
 	re.NoError(err)
 	dataTableShards, err := shardPicker.PickShards(ctx, c.Name(), len(request.PartitionInfo.Names))
 	re.NoError(err)

--- a/server/coordinator/procedure/create_table.go
+++ b/server/coordinator/procedure/create_table.go
@@ -4,163 +4,71 @@ package procedure
 
 import (
 	"context"
-	"sync"
 
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
-	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
-	"github.com/looplab/fsm"
-	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
-const (
-	eventCreateTablePrepare = "EventCreateTablePrepare"
-	eventCreateTableFailed  = "EventCreateTableFailed"
-	eventCreateTableSuccess = "EventCreateTableSuccess"
-
-	stateCreateTableBegin   = "StateCreateTableBegin"
-	stateCreateTableWaiting = "StateCreateTableWaiting"
-	stateCreateTableFinish  = "StateCreateTableFinish"
-	stateCreateTableFailed  = "StateCreateTableFailed"
-)
-
-var (
-	createTableEvents = fsm.Events{
-		{Name: eventCreateTablePrepare, Src: []string{stateCreateTableBegin}, Dst: stateCreateTableWaiting},
-		{Name: eventCreateTableSuccess, Src: []string{stateCreateTableWaiting}, Dst: stateCreateTableFinish},
-		{Name: eventCreateTableFailed, Src: []string{stateCreateTableWaiting}, Dst: stateCreateTableFailed},
-	}
-	createTableCallbacks = fsm.Callbacks{
-		eventCreateTablePrepare: createTablePrepareCallback,
-		eventCreateTableFailed:  createTableFailedCallback,
-		eventCreateTableSuccess: createTableSuccessCallback,
-	}
-)
-
-func createTablePrepareCallback(event *fsm.Event) {
-	req := event.Args[0].(*createTableCallbackRequest)
-
-	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), req.sourceReq.GetHeader().GetNode())
-	if err != nil {
-		cancelEventWithLog(event, err, "create table metadata")
-		return
-	}
-
-	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, createTableResult.ShardVersionUpdate.ShardID, buildCreateTableRequest(createTableResult, req.sourceReq)); err != nil {
-		cancelEventWithLog(event, err, "dispatch create table on shard")
-		return
-	}
-
-	req.createTableResult = createTableResult
-}
-
-func createTableSuccessCallback(event *fsm.Event) {
-	req := event.Args[0].(*createTableCallbackRequest)
-
-	if err := req.onSucceeded(req.createTableResult); err != nil {
-		log.Error("exec success callback failed")
-	}
-}
-
-func createTableFailedCallback(event *fsm.Event) {
-	req := event.Args[0].(*createTableCallbackRequest)
-
-	if err := req.onFailed(event.Err); err != nil {
-		log.Error("exec failed callback failed")
-	}
-}
-
-// createTableCallbackRequest is fsm callbacks param.
-type createTableCallbackRequest struct {
-	ctx      context.Context
-	cluster  *cluster.Cluster
-	dispatch eventdispatch.Dispatch
-
-	sourceReq *metaservicepb.CreateTableRequest
-
-	onSucceeded func(cluster.CreateTableResult) error
-	onFailed    func(error) error
-
-	createTableResult cluster.CreateTableResult
-}
-
-func NewCreateTableProcedure(dispatch eventdispatch.Dispatch, cluster *cluster.Cluster, id uint64, req *metaservicepb.CreateTableRequest, onSucceeded func(cluster.CreateTableResult) error, onFailed func(error) error) Procedure {
-	fsm := fsm.NewFSM(
-		stateCreateTableBegin,
-		createTableEvents,
-		createTableCallbacks,
-	)
-	return &CreateTableProcedure{id: id, fsm: fsm, cluster: cluster, dispatch: dispatch, req: req, state: StateInit, onSucceeded: onSucceeded, onFailed: onFailed}
-}
-
+// CreateTableProcedure is a proxy procedure, it determines the actual procedure created according to the request type.
 type CreateTableProcedure struct {
-	id       uint64
-	fsm      *fsm.FSM
-	cluster  *cluster.Cluster
-	dispatch eventdispatch.Dispatch
-
-	req *metaservicepb.CreateTableRequest
-
-	onSucceeded func(cluster.CreateTableResult) error
-	onFailed    func(error) error
-
-	lock  sync.RWMutex
-	state State
+	realProcedure Procedure
 }
 
-func (p *CreateTableProcedure) ID() uint64 {
-	return p.id
-}
-
-func (p *CreateTableProcedure) Typ() Typ {
-	return CreateTable
-}
-
-func (p *CreateTableProcedure) Start(ctx context.Context) error {
-	p.updateState(StateRunning)
-
-	req := &createTableCallbackRequest{
-		cluster:     p.cluster,
-		ctx:         ctx,
-		dispatch:    p.dispatch,
-		sourceReq:   p.req,
-		onSucceeded: p.onSucceeded,
-		onFailed:    p.onFailed,
+func NewCreateTableProcedure(ctx context.Context, factory *Factory, c *cluster.Cluster, sourceReq *metaservicepb.CreateTableRequest, onSucceeded func(cluster.CreateTableResult) error, onFailed func(error) error) (Procedure, error) {
+	if sourceReq.PartitionInfo != nil && len(sourceReq.PartitionInfo.GetNames()) == 0 {
+		log.Error("fail to create table", zap.Error(ErrEmptyPartitionNames))
+		return CreateTableProcedure{}, ErrEmptyPartitionNames
 	}
-
-	if err := p.fsm.Event(eventCreateTablePrepare, req); err != nil {
-		err1 := p.fsm.Event(eventCreateTableFailed, req)
-		p.updateState(StateFailed)
-		if err1 != nil {
-			err = errors.WithMessagef(err, "send eventCreateTableFailed, err:%v", err1)
+	var realProcedure Procedure
+	if sourceReq.PartitionInfo != nil && len(sourceReq.PartitionInfo.GetNames()) != 0 {
+		p, err := factory.makeCreatePartitionTableProcedure(ctx, CreatePartitionTableRequest{
+			ClusterName:       c.Name(),
+			SourceReq:         sourceReq,
+			TablePartitionNum: uint(c.GetTablePartitionNum()),
+			OnSucceeded:       onSucceeded,
+			OnFailed:          onFailed,
+		})
+		if err != nil {
+			log.Error("fail to create partition table", zap.Error(err))
+			return CreateTableProcedure{}, err
 		}
-		return errors.WithMessage(err, "send eventCreateTablePrepare")
+		realProcedure = p
+	} else {
+		p, err := factory.makeCreateNormalTableProcedure(ctx, CreateTableRequest{
+			Cluster:     c,
+			SourceReq:   sourceReq,
+			OnSucceeded: onSucceeded,
+			OnFailed:    onFailed,
+		})
+		if err != nil {
+			log.Error("fail to create table", zap.Error(err))
+			return CreateTableProcedure{}, err
+		}
+		realProcedure = p
 	}
-
-	if err := p.fsm.Event(eventCreateTableSuccess, req); err != nil {
-		return errors.WithMessage(err, "send eventCreateTableSuccess")
-	}
-
-	p.updateState(StateFinished)
-	return nil
+	return CreateTableProcedure{
+		realProcedure: realProcedure,
+	}, nil
 }
 
-func (p *CreateTableProcedure) Cancel(_ context.Context) error {
-	p.updateState(StateCancelled)
-	return nil
+func (p CreateTableProcedure) ID() uint64 {
+	return p.realProcedure.ID()
 }
 
-func (p *CreateTableProcedure) State() State {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-
-	return p.state
+func (p CreateTableProcedure) Typ() Typ {
+	return p.realProcedure.Typ()
 }
 
-func (p *CreateTableProcedure) updateState(state State) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+func (p CreateTableProcedure) Start(ctx context.Context) error {
+	return p.realProcedure.Start(ctx)
+}
 
-	p.state = state
+func (p CreateTableProcedure) Cancel(ctx context.Context) error {
+	return p.realProcedure.Cancel(ctx)
+}
+
+func (p CreateTableProcedure) State() State {
+	return p.realProcedure.State()
 }

--- a/server/coordinator/procedure/create_table.go
+++ b/server/coordinator/procedure/create_table.go
@@ -25,11 +25,10 @@ func NewCreateTableProcedure(ctx context.Context, factory *Factory, c *cluster.C
 	var realProcedure Procedure
 	if sourceReq.PartitionInfo != nil && len(sourceReq.PartitionInfo.GetNames()) != 0 {
 		p, err := factory.makeCreatePartitionTableProcedure(ctx, CreatePartitionTableRequest{
-			ClusterName:                c.Name(),
-			SourceReq:                  sourceReq,
-			PartitionTableRatioOfNodes: uint(c.GetPartitionTableRatioOfNodes()),
-			OnSucceeded:                onSucceeded,
-			OnFailed:                   onFailed,
+			ClusterName: c.Name(),
+			SourceReq:   sourceReq,
+			OnSucceeded: onSucceeded,
+			OnFailed:    onFailed,
 		})
 		if err != nil {
 			log.Error("fail to create partition table", zap.Error(err))

--- a/server/coordinator/procedure/create_table.go
+++ b/server/coordinator/procedure/create_table.go
@@ -21,14 +21,15 @@ func NewCreateTableProcedure(ctx context.Context, factory *Factory, c *cluster.C
 		log.Error("fail to create table", zap.Error(ErrEmptyPartitionNames))
 		return CreateTableProcedure{}, ErrEmptyPartitionNames
 	}
+
 	var realProcedure Procedure
 	if sourceReq.PartitionInfo != nil && len(sourceReq.PartitionInfo.GetNames()) != 0 {
 		p, err := factory.makeCreatePartitionTableProcedure(ctx, CreatePartitionTableRequest{
-			ClusterName:       c.Name(),
-			SourceReq:         sourceReq,
-			TablePartitionNum: uint(c.GetTablePartitionNum()),
-			OnSucceeded:       onSucceeded,
-			OnFailed:          onFailed,
+			ClusterName:                c.Name(),
+			SourceReq:                  sourceReq,
+			PartitionTableRatioOfNodes: uint(c.GetPartitionTableRatioOfNodes()),
+			OnSucceeded:                onSucceeded,
+			OnFailed:                   onFailed,
 		})
 		if err != nil {
 			log.Error("fail to create partition table", zap.Error(err))
@@ -48,6 +49,7 @@ func NewCreateTableProcedure(ctx context.Context, factory *Factory, c *cluster.C
 		}
 		realProcedure = p
 	}
+
 	return CreateTableProcedure{
 		realProcedure: realProcedure,
 	}, nil

--- a/server/coordinator/procedure/create_table_common_util.go
+++ b/server/coordinator/procedure/create_table_common_util.go
@@ -1,0 +1,80 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package procedure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
+	"github.com/CeresDB/ceresmeta/server/cluster"
+	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
+	"github.com/CeresDB/ceresmeta/server/storage"
+	"github.com/pkg/errors"
+)
+
+func createTableMetadata(ctx context.Context, c *cluster.Cluster, schemaName string, tableName string, nodeName string) (cluster.CreateTableResult, error) {
+	_, exists, err := c.GetTable(schemaName, tableName)
+	if err != nil {
+		return cluster.CreateTableResult{}, errors.WithMessage(err, "cluster get table")
+	}
+	if exists {
+		return cluster.CreateTableResult{}, errors.WithMessage(ErrTableAlreadyExists, fmt.Sprintf("create an existing table, schemaName:%s, tableName:%s", schemaName, tableName))
+	}
+
+	createTableResult, err := c.CreateTable(ctx, nodeName, schemaName, tableName)
+	if err != nil {
+		return cluster.CreateTableResult{}, errors.WithMessage(err, "create table")
+	}
+	return createTableResult, nil
+}
+
+func createTableOnShard(ctx context.Context, c *cluster.Cluster, dispatch eventdispatch.Dispatch, shardID storage.ShardID, request eventdispatch.CreateTableOnShardRequest) error {
+	shardNodes, err := c.GetShardNodesByShardID(shardID)
+	if err != nil {
+		return errors.WithMessage(err, "cluster get shardNode by id")
+	}
+	// TODO: consider followers
+	leader := storage.ShardNode{}
+	found := false
+	for _, shardNode := range shardNodes {
+		if shardNode.ShardRole == storage.ShardRoleLeader {
+			found = true
+			leader = shardNode
+			break
+		}
+	}
+	if !found {
+		return errors.WithMessage(ErrShardLeaderNotFound, fmt.Sprintf("shard node can't find leader, shardID:%d", shardID))
+	}
+
+	err = dispatch.CreateTableOnShard(ctx, leader.NodeName, request)
+	if err != nil {
+		return errors.WithMessage(err, "create table on shard")
+	}
+	return nil
+}
+
+func buildCreateTableRequest(createTableResult cluster.CreateTableResult, req *metaservicepb.CreateTableRequest) eventdispatch.CreateTableOnShardRequest {
+	return eventdispatch.CreateTableOnShardRequest{
+		UpdateShardInfo: eventdispatch.UpdateShardInfo{
+			CurrShardInfo: cluster.ShardInfo{
+				ID: createTableResult.ShardVersionUpdate.ShardID,
+				// TODO: dispatch CreateTableOnShard to followers?
+				Role:    storage.ShardRoleLeader,
+				Version: createTableResult.ShardVersionUpdate.CurrVersion,
+			},
+			PrevVersion: createTableResult.ShardVersionUpdate.PrevVersion,
+		},
+		TableInfo: cluster.TableInfo{
+			ID:         createTableResult.Table.ID,
+			Name:       createTableResult.Table.Name,
+			SchemaID:   createTableResult.Table.SchemaID,
+			SchemaName: req.GetSchemaName(),
+		},
+		EncodedSchema:    req.EncodedSchema,
+		Engine:           req.Engine,
+		CreateIfNotExist: req.CreateIfNotExist,
+		Options:          req.Options,
+	}
+}

--- a/server/coordinator/procedure/error.go
+++ b/server/coordinator/procedure/error.go
@@ -13,4 +13,5 @@ var (
 	ErrDecodeRawData         = coderr.NewCodeError(coderr.Internal, "decode raw data")
 	ErrEncodeRawData         = coderr.NewCodeError(coderr.Internal, "encode raw data")
 	ErrGetRequest            = coderr.NewCodeError(coderr.Internal, "get request from event")
+	ErrNodeNumberNotEnough   = coderr.NewCodeError(coderr.Internal, "node number not enough")
 )

--- a/server/coordinator/procedure/error.go
+++ b/server/coordinator/procedure/error.go
@@ -14,4 +14,5 @@ var (
 	ErrEncodeRawData         = coderr.NewCodeError(coderr.Internal, "encode raw data")
 	ErrGetRequest            = coderr.NewCodeError(coderr.Internal, "get request from event")
 	ErrNodeNumberNotEnough   = coderr.NewCodeError(coderr.Internal, "node number not enough")
+	ErrEmptyPartitionNames   = coderr.NewCodeError(coderr.Internal, "partition names is empty")
 )

--- a/server/coordinator/procedure/factory.go
+++ b/server/coordinator/procedure/factory.go
@@ -23,7 +23,7 @@ type Factory struct {
 	shardPicker    ShardPicker
 
 	// TODO: This is a temporary implementation version, which needs to be refined to the table level later.
-	PartitionTableProportionOfNodes float32
+	partitionTableProportionOfNodes float32
 }
 
 type ScatterRequest struct {
@@ -82,7 +82,7 @@ func NewFactory(allocator id.Allocator, dispatch eventdispatch.Dispatch, storage
 		storage:                         storage,
 		clusterManager:                  manager,
 		shardPicker:                     NewRandomShardPicker(manager),
-		PartitionTableProportionOfNodes: partitionTableProportionOfNodes,
+		partitionTableProportionOfNodes: partitionTableProportionOfNodes,
 	}
 }
 

--- a/server/coordinator/procedure/procedure.go
+++ b/server/coordinator/procedure/procedure.go
@@ -28,6 +28,7 @@ const (
 	Scatter
 	CreateTable
 	DropTable
+	CreatePartitionTable
 )
 
 // Procedure is used to describe how to execute a set of operations from the scheduler, e.g. SwitchLeaderProcedure, MergeShardProcedure.

--- a/server/coordinator/procedure/scatter_test.go
+++ b/server/coordinator/procedure/scatter_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newClusterAndRegisterNode(t *testing.T) *cluster.Cluster {
+func newClusterAndRegisterNode(t *testing.T) (cluster.Manager, *cluster.Cluster) {
 	re := require.New(t)
 	ctx := context.Background()
 	dispatch := MockDispatch{}
-	c := newTestCluster(ctx, t)
+	m, c := newTestCluster(ctx, t)
 
 	totalShardNum := c.GetTotalShardNum()
 	shardIDs := make([]storage.ShardID, 0, totalShardNum)
@@ -48,7 +48,7 @@ func newClusterAndRegisterNode(t *testing.T) *cluster.Cluster {
 		}, ShardInfos: []cluster.ShardInfo{},
 	})
 	re.NoError(err)
-	return c
+	return m, c
 }
 
 func checkScatterWithCluster(t *testing.T, cluster *cluster.Cluster) {
@@ -74,7 +74,7 @@ func checkScatterWithCluster(t *testing.T, cluster *cluster.Cluster) {
 }
 
 func TestScatter(t *testing.T) {
-	cluster := newClusterAndRegisterNode(t)
+	_, cluster := newClusterAndRegisterNode(t)
 	time.Sleep(time.Second * 5)
 	checkScatterWithCluster(t, cluster)
 }

--- a/server/coordinator/procedure/shard_picker.go
+++ b/server/coordinator/procedure/shard_picker.go
@@ -14,10 +14,10 @@ import (
 
 // ShardPicker is used to pick up the shards suitable for scheduling in the cluster.
 type ShardPicker interface {
-	PickShards(ctx context.Context, clusterName string, num int) ([]cluster.ShardNodeWithVersion, error)
+	PickShards(ctx context.Context, clusterName string, expectShardNum int) ([]cluster.ShardNodeWithVersion, error)
 }
 
-// RandomShardPicker randomly pick up shards not on the same node exists in current cluster.
+// RandomShardPicker randomly pick up shards that are not on the same node in the current cluster.
 type RandomShardPicker struct {
 	clusterManager cluster.Manager
 }
@@ -28,7 +28,8 @@ func NewRandomShardPicker(manager cluster.Manager) ShardPicker {
 	}
 }
 
-func (p *RandomShardPicker) PickShards(ctx context.Context, clusterName string, num int) ([]cluster.ShardNodeWithVersion, error) {
+// PickShards will pick a specified number of shards as expectShardNum.
+func (p *RandomShardPicker) PickShards(ctx context.Context, clusterName string, expectShardNum int) ([]cluster.ShardNodeWithVersion, error) {
 	getNodeShardResult, err := p.clusterManager.GetNodeShards(ctx, clusterName)
 	if err != nil {
 		return []cluster.ShardNodeWithVersion{}, errors.WithMessage(err, "get node shards")
@@ -44,18 +45,19 @@ func (p *RandomShardPicker) PickShards(ctx context.Context, clusterName string, 
 		}
 		nodeShardsMapping[nodeShard.ShardNode.NodeName] = append(nodeShardsMapping[nodeShard.ShardNode.NodeName], nodeShard)
 	}
-	if len(nodeShardsMapping) < num {
-		return []cluster.ShardNodeWithVersion{}, errors.WithMessage(ErrNodeNumberNotEnough, fmt.Sprintf("number of nodes is: %d, expecet number of shards is: %d", len(nodeShardsMapping), num))
+	if len(nodeShardsMapping) < expectShardNum {
+		return []cluster.ShardNodeWithVersion{}, errors.WithMessage(ErrNodeNumberNotEnough, fmt.Sprintf("number of nodes is:%d, expecet number of shards is:%d", len(nodeShardsMapping), expectShardNum))
 	}
 
 	var selectNodeNames []string
-	for i := 0; i < num; i++ {
+	for i := 0; i < expectShardNum; i++ {
 		selectNodeIndex, err := rand.Int(rand.Reader, big.NewInt(int64(len(nodeNames))))
 		if err != nil {
 			return []cluster.ShardNodeWithVersion{}, errors.WithMessage(err, "generate random node index")
 		}
 		selectNodeNames = append(selectNodeNames, nodeNames[selectNodeIndex.Int64()])
-		nodeNames = append(nodeNames[:selectNodeIndex.Int64()], nodeNames[selectNodeIndex.Int64()+1:]...)
+		nodeNames[selectNodeIndex.Int64()] = nodeNames[len(nodeNames)-1]
+		nodeNames = nodeNames[:len(nodeNames)-1]
 	}
 
 	result := []cluster.ShardNodeWithVersion{}

--- a/server/coordinator/procedure/shard_picker_test.go
+++ b/server/coordinator/procedure/shard_picker_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package procedure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandomShardPicker(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+	manager, _ := prepare(t)
+
+	randomShardPicker := NewRandomShardPicker(manager)
+	nodeShards, err := randomShardPicker.PickShards(ctx, clusterName, 2)
+	re.NoError(err)
+
+	// Verify the number of shards and ensure that they are not on the same node.
+	re.Equal(len(nodeShards), 2)
+	re.NotEqual(nodeShards[0].ShardNode.NodeName, nodeShards[1].ShardNode.NodeName)
+}

--- a/server/coordinator/procedure/split_test.go
+++ b/server/coordinator/procedure/split_test.go
@@ -15,7 +15,7 @@ func TestSplit(t *testing.T) {
 	re := require.New(t)
 	ctx := context.Background()
 	dispatch := MockDispatch{}
-	c := prepare(t)
+	_, c := prepare(t)
 	s := NewTestStorage(t)
 
 	getNodeShardsResult, err := c.GetNodeShards(ctx)

--- a/server/coordinator/procedure/split_test.go
+++ b/server/coordinator/procedure/split_test.go
@@ -25,9 +25,9 @@ func TestSplit(t *testing.T) {
 	targetShardNode := getNodeShardsResult.NodeShards[0].ShardNode
 
 	// Create some tables in this shard.
-	_, err = c.CreateTable(ctx, targetShardNode.NodeName, testSchemaName, testTableName0)
+	_, err = c.CreateTable(ctx, targetShardNode.NodeName, testSchemaName, testTableName0, false)
 	re.NoError(err)
-	_, err = c.CreateTable(ctx, targetShardNode.NodeName, testSchemaName, testTableName1)
+	_, err = c.CreateTable(ctx, targetShardNode.NodeName, testSchemaName, testTableName1, false)
 	re.NoError(err)
 
 	// Split one table from this shard.

--- a/server/coordinator/procedure/transfer_leader.go
+++ b/server/coordinator/procedure/transfer_leader.go
@@ -65,12 +65,13 @@ type TransferLeaderProcedure struct {
 
 // TransferLeaderProcedurePersistRawData used for storage, procedure will be converted to persist raw data before saved in storage.
 type TransferLeaderProcedurePersistRawData struct {
-	ID                uint64
-	FsmState          string
+	ID       uint64
+	FsmState string
+	State    State
+
 	ShardID           storage.ShardID
 	OldLeaderNodeName string
 	NewLeaderNodeName string
-	State             State
 }
 
 // TransferLeaderCallbackRequest is fsm callbacks param.

--- a/server/coordinator/procedure/trasnfer_leader_test.go
+++ b/server/coordinator/procedure/trasnfer_leader_test.go
@@ -14,7 +14,7 @@ func TestTransferLeader(t *testing.T) {
 	re := require.New(t)
 	ctx := context.Background()
 	dispatch := MockDispatch{}
-	c := prepare(t)
+	_, c := prepare(t)
 	s := NewTestStorage(t)
 
 	getNodeShardsResult, err := c.GetNodeShards(ctx)

--- a/server/coordinator/procedure/util.go
+++ b/server/coordinator/procedure/util.go
@@ -53,3 +53,10 @@ func IsSubSlice(subSlice []string, slice []string) bool {
 	}
 	return true
 }
+
+func Max(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
+}

--- a/server/server.go
+++ b/server/server.go
@@ -181,7 +181,7 @@ func (srv *Server) startServer(_ context.Context) error {
 	}
 	srv.procedureManager = procedureManager
 	dispatch := eventdispatch.NewDispatchImpl()
-	procedureFactory := procedure.NewFactory(id.NewAllocatorImpl(srv.etcdCli, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage, manager)
+	procedureFactory := procedure.NewFactory(id.NewAllocatorImpl(srv.etcdCli, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage, manager, srv.cfg.DefaultPartitionTableProportionOfNodes)
 	srv.procedureFactory = procedureFactory
 	srv.scheduler = coordinator.NewScheduler(manager, procedureManager, procedureFactory, dispatch)
 
@@ -245,10 +245,9 @@ func (srv *Server) createDefaultCluster(ctx context.Context) error {
 	if leaderResp.IsLocal {
 		defaultCluster, err := srv.clusterManager.CreateCluster(ctx, srv.cfg.DefaultClusterName,
 			cluster.CreateClusterOpts{
-				NodeCount:                  uint32(srv.cfg.DefaultClusterNodeCount),
-				ReplicationFactor:          uint32(srv.cfg.DefaultClusterReplicationFactor),
-				ShardTotal:                 uint32(srv.cfg.DefaultClusterShardTotal),
-				PartitionTableRatioOfNodes: uint32(srv.cfg.DefaultClusterPartitionTableRatioOfNodes),
+				NodeCount:         uint32(srv.cfg.DefaultClusterNodeCount),
+				ReplicationFactor: uint32(srv.cfg.DefaultClusterReplicationFactor),
+				ShardTotal:        uint32(srv.cfg.DefaultClusterShardTotal),
 			})
 		if err != nil {
 			log.Warn("create default cluster failed", zap.Error(err))

--- a/server/server.go
+++ b/server/server.go
@@ -243,7 +243,13 @@ func (srv *Server) createDefaultCluster(ctx context.Context) error {
 
 	// Create default cluster by the leader.
 	if leaderResp.IsLocal {
-		defaultCluster, err := srv.clusterManager.CreateCluster(ctx, srv.cfg.DefaultClusterName, uint32(srv.cfg.DefaultClusterNodeCount), uint32(srv.cfg.DefaultClusterReplicationFactor), uint32(srv.cfg.DefaultClusterShardTotal), uint32(srv.cfg.DefaultClusterPartitionTableNum))
+		defaultCluster, err := srv.clusterManager.CreateCluster(ctx, srv.cfg.DefaultClusterName,
+			cluster.CreateClusterOpts{
+				NodeCount:         uint32(srv.cfg.DefaultClusterNodeCount),
+				ReplicationFactor: uint32(srv.cfg.DefaultClusterReplicationFactor),
+				ShardTotal:        uint32(srv.cfg.DefaultClusterShardTotal),
+				TablePartitionNum: uint32(srv.cfg.DefaultClusterTablePartitionNum),
+			})
 		if err != nil {
 			log.Warn("create default cluster failed", zap.Error(err))
 			if coderr.Is(err, cluster.ErrClusterAlreadyExists.Code()) {

--- a/server/server.go
+++ b/server/server.go
@@ -243,7 +243,7 @@ func (srv *Server) createDefaultCluster(ctx context.Context) error {
 
 	// Create default cluster by the leader.
 	if leaderResp.IsLocal {
-		defaultCluster, err := srv.clusterManager.CreateCluster(ctx, srv.cfg.DefaultClusterName, uint32(srv.cfg.DefaultClusterNodeCount), uint32(srv.cfg.DefaultClusterReplicationFactor), uint32(srv.cfg.DefaultClusterShardTotal))
+		defaultCluster, err := srv.clusterManager.CreateCluster(ctx, srv.cfg.DefaultClusterName, uint32(srv.cfg.DefaultClusterNodeCount), uint32(srv.cfg.DefaultClusterReplicationFactor), uint32(srv.cfg.DefaultClusterShardTotal), uint32(srv.cfg.DefaultClusterPartitionTableNum))
 		if err != nil {
 			log.Warn("create default cluster failed", zap.Error(err))
 			if coderr.Is(err, cluster.ErrClusterAlreadyExists.Code()) {

--- a/server/server.go
+++ b/server/server.go
@@ -245,10 +245,10 @@ func (srv *Server) createDefaultCluster(ctx context.Context) error {
 	if leaderResp.IsLocal {
 		defaultCluster, err := srv.clusterManager.CreateCluster(ctx, srv.cfg.DefaultClusterName,
 			cluster.CreateClusterOpts{
-				NodeCount:         uint32(srv.cfg.DefaultClusterNodeCount),
-				ReplicationFactor: uint32(srv.cfg.DefaultClusterReplicationFactor),
-				ShardTotal:        uint32(srv.cfg.DefaultClusterShardTotal),
-				TablePartitionNum: uint32(srv.cfg.DefaultClusterTablePartitionNum),
+				NodeCount:                  uint32(srv.cfg.DefaultClusterNodeCount),
+				ReplicationFactor:          uint32(srv.cfg.DefaultClusterReplicationFactor),
+				ShardTotal:                 uint32(srv.cfg.DefaultClusterShardTotal),
+				PartitionTableRatioOfNodes: uint32(srv.cfg.DefaultClusterPartitionTableRatioOfNodes),
 			})
 		if err != nil {
 			log.Warn("create default cluster failed", zap.Error(err))

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -139,7 +139,7 @@ type Cluster struct {
 	MinNodeCount      uint32
 	ReplicationFactor uint32
 	ShardTotal        uint32
-	PartitionTableNum uint32
+	TablePartitionNum uint32
 	CreatedAt         uint64
 }
 

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -139,6 +139,7 @@ type Cluster struct {
 	MinNodeCount      uint32
 	ReplicationFactor uint32
 	ShardTotal        uint32
+	PartitionTableNum uint32
 	CreatedAt         uint64
 }
 

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -134,13 +134,13 @@ type CreateOrUpdateNodeRequest struct {
 }
 
 type Cluster struct {
-	ID                ClusterID
-	Name              string
-	MinNodeCount      uint32
-	ReplicationFactor uint32
-	ShardTotal        uint32
-	TablePartitionNum uint32
-	CreatedAt         uint64
+	ID                         ClusterID
+	Name                       string
+	MinNodeCount               uint32
+	ReplicationFactor          uint32
+	ShardTotal                 uint32
+	PartitionTableRatioOfNodes uint32
+	CreatedAt                  uint64
 }
 
 type ShardNode struct {

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -165,10 +165,11 @@ type Schema struct {
 }
 
 type Table struct {
-	ID        TableID
-	Name      string
-	SchemaID  SchemaID
-	CreatedAt uint64
+	ID          TableID
+	Name        string
+	SchemaID    SchemaID
+	CreatedAt   uint64
+	Partitioned bool
 }
 
 type ShardView struct {
@@ -332,20 +333,22 @@ func convertSchemaPB(schema *clusterpb.Schema) Schema {
 
 func convertTableToPB(table Table) clusterpb.Table {
 	return clusterpb.Table{
-		Id:        uint64(table.ID),
-		Name:      table.Name,
-		SchemaId:  uint32(table.SchemaID),
-		Desc:      "",
-		CreatedAt: table.CreatedAt,
+		Id:          uint64(table.ID),
+		Name:        table.Name,
+		SchemaId:    uint32(table.SchemaID),
+		Desc:        "",
+		CreatedAt:   table.CreatedAt,
+		Partitioned: table.Partitioned,
 	}
 }
 
 func convertTablePB(table *clusterpb.Table) Table {
 	return Table{
-		ID:        TableID(table.Id),
-		Name:      table.Name,
-		SchemaID:  SchemaID(table.SchemaId),
-		CreatedAt: table.CreatedAt,
+		ID:          TableID(table.Id),
+		Name:        table.Name,
+		SchemaID:    SchemaID(table.SchemaId),
+		CreatedAt:   table.CreatedAt,
+		Partitioned: table.Partitioned,
 	}
 }
 

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -134,13 +134,12 @@ type CreateOrUpdateNodeRequest struct {
 }
 
 type Cluster struct {
-	ID                         ClusterID
-	Name                       string
-	MinNodeCount               uint32
-	ReplicationFactor          uint32
-	ShardTotal                 uint32
-	PartitionTableRatioOfNodes uint32
-	CreatedAt                  uint64
+	ID                ClusterID
+	Name              string
+	MinNodeCount      uint32
+	ReplicationFactor uint32
+	ShardTotal        uint32
+	CreatedAt         uint64
 }
 
 type ShardNode struct {


### PR DESCRIPTION
# Which issue does this PR close?

(https://github.com/CeresDB/ceresdb/issues/492)

# Rationale for this change
Support create partition table in CeresDB.

# What changes are included in this PR?
* Add implementation of `CreatePartitionTableProcedure`.
* Add `ShardPicker` for picking up the shards suitable for scheduling in the cluster.

# Are there any user-facing changes?
None.

# How does this change test
Pass unit test.