### PR TITLE
chore: update ceresdbproto & adapter to partition info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
-	github.com/CeresDB/ceresdbproto/golang v0.0.0-20221223085501-cfa70e972d3d
+	github.com/CeresDB/ceresdbproto/golang v0.0.0-20221227065032-1ea76ec99beb
 	github.com/axw/gocov v1.1.0
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/json-iterator/go v1.1.11

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CeresDB/ceresdbproto/golang v0.0.0-20221223085501-cfa70e972d3d h1:ItxqVqy0v74qMyLl3qv0Tp7Z54Kb9NNrVS6P/Y2IQ/8=
-github.com/CeresDB/ceresdbproto/golang v0.0.0-20221223085501-cfa70e972d3d/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20221227065032-1ea76ec99beb h1:EsuLqjwg4vA7VpxBwZBg+WBwHhrbtaxe/LyiBRyt+LI=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20221227065032-1ea76ec99beb/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/server/coordinator/eventdispatch/dispatch.go
+++ b/server/coordinator/eventdispatch/dispatch.go
@@ -29,12 +29,13 @@ type UpdateShardInfo struct {
 }
 
 type CreateTableOnShardRequest struct {
-	UpdateShardInfo  UpdateShardInfo
-	TableInfo        cluster.TableInfo
-	EncodedSchema    []byte
-	Engine           string
-	CreateIfNotExist bool
-	Options          map[string]string
+	UpdateShardInfo      UpdateShardInfo
+	TableInfo            cluster.TableInfo
+	EncodedSchema        []byte
+	Engine               string
+	CreateIfNotExist     bool
+	Options              map[string]string
+	EncodedPartitionInfo []byte
 }
 
 type DropTableOnShardRequest struct {

--- a/server/coordinator/eventdispatch/dispatch_impl.go
+++ b/server/coordinator/eventdispatch/dispatch_impl.go
@@ -111,12 +111,13 @@ func (d *DispatchImpl) getMetaEventClient(ctx context.Context, addr string) (met
 
 func convertCreateTableOnShardRequestToPB(request CreateTableOnShardRequest) *metaeventpb.CreateTableOnShardRequest {
 	return &metaeventpb.CreateTableOnShardRequest{
-		UpdateShardInfo:  convertUpdateShardInfoToPB(request.UpdateShardInfo),
-		TableInfo:        cluster.ConvertTableInfoToPB(request.TableInfo),
-		EncodedSchema:    request.EncodedSchema,
-		Engine:           request.Engine,
-		CreateIfNotExist: request.CreateIfNotExist,
-		Options:          request.Options,
+		UpdateShardInfo:      convertUpdateShardInfoToPB(request.UpdateShardInfo),
+		TableInfo:            cluster.ConvertTableInfoToPB(request.TableInfo),
+		EncodedSchema:        request.EncodedSchema,
+		Engine:               request.Engine,
+		CreateIfNotExist:     request.CreateIfNotExist,
+		Options:              request.Options,
+		EncodedPartitionInfo: request.EncodedPartitionInfo,
 	}
 }
 

--- a/server/coordinator/procedure/create_partition_table.go
+++ b/server/coordinator/procedure/create_partition_table.go
@@ -226,7 +226,7 @@ func createDataTablesCallback(event *fsm.Event) {
 	}
 
 	for i, dataTableShard := range req.dataTablesShards {
-		createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetPartitionInfo().Names[i], dataTableShard.ShardNode.NodeName, false)
+		createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetPartitionTableInfo().SubTableNames[i], dataTableShard.ShardNode.NodeName, false)
 		if err != nil {
 			cancelEventWithLog(event, err, "create table metadata")
 			return

--- a/server/coordinator/procedure/create_partition_table_test.go
+++ b/server/coordinator/procedure/create_partition_table_test.go
@@ -25,8 +25,8 @@ func TestCreatePartitionTable(t *testing.T) {
 			Node:        nodeName0,
 			ClusterName: clusterName,
 		},
-		PartitionInfo: &metaservicepb.PartitionInfo{
-			Names: []string{"p1", "p2"},
+		PartitionTableInfo: &metaservicepb.PartitionTableInfo{
+			SubTableNames: []string{"p1", "p2"},
 		},
 		SchemaName: testSchemaName,
 		Name:       testTableName0,
@@ -44,7 +44,7 @@ func TestCreatePartitionTable(t *testing.T) {
 
 	partitionTableShards, err := shardPicker.PickShards(ctx, c.Name(), partitionTableNum)
 	re.NoError(err)
-	dataTableShards, err := shardPicker.PickShards(ctx, c.Name(), len(request.PartitionInfo.Names))
+	dataTableShards, err := shardPicker.PickShards(ctx, c.Name(), len(request.GetPartitionTableInfo().SubTableNames))
 	re.NoError(err)
 
 	procedure := NewCreatePartitionTableProcedure(CreatePartitionTableProcedureRequest{

--- a/server/coordinator/procedure/create_table.go
+++ b/server/coordinator/procedure/create_table.go
@@ -17,13 +17,13 @@ type CreateTableProcedure struct {
 }
 
 func NewCreateTableProcedure(ctx context.Context, factory *Factory, c *cluster.Cluster, sourceReq *metaservicepb.CreateTableRequest, onSucceeded func(cluster.CreateTableResult) error, onFailed func(error) error) (Procedure, error) {
-	if sourceReq.PartitionInfo != nil && len(sourceReq.PartitionInfo.GetNames()) == 0 {
+	if sourceReq.PartitionTableInfo != nil && len(sourceReq.PartitionTableInfo.SubTableNames) == 0 {
 		log.Error("fail to create table", zap.Error(ErrEmptyPartitionNames))
 		return CreateTableProcedure{}, ErrEmptyPartitionNames
 	}
 
 	var realProcedure Procedure
-	if sourceReq.PartitionInfo != nil && len(sourceReq.PartitionInfo.GetNames()) != 0 {
+	if sourceReq.PartitionTableInfo != nil && len(sourceReq.PartitionTableInfo.SubTableNames) != 0 {
 		p, err := factory.makeCreatePartitionTableProcedure(ctx, CreatePartitionTableRequest{
 			ClusterName: c.Name(),
 			SourceReq:   sourceReq,

--- a/server/coordinator/procedure/create_table.go
+++ b/server/coordinator/procedure/create_table.go
@@ -17,25 +17,7 @@ type CreateTableProcedure struct {
 }
 
 func NewCreateTableProcedure(ctx context.Context, factory *Factory, c *cluster.Cluster, sourceReq *metaservicepb.CreateTableRequest, onSucceeded func(cluster.CreateTableResult) error, onFailed func(error) error) (Procedure, error) {
-	if sourceReq.PartitionTableInfo != nil && len(sourceReq.PartitionTableInfo.SubTableNames) == 0 {
-		log.Error("fail to create table", zap.Error(ErrEmptyPartitionNames))
-		return CreateTableProcedure{}, ErrEmptyPartitionNames
-	}
-
-	var realProcedure Procedure
-	if sourceReq.PartitionTableInfo != nil && len(sourceReq.PartitionTableInfo.SubTableNames) != 0 {
-		p, err := factory.makeCreatePartitionTableProcedure(ctx, CreatePartitionTableRequest{
-			ClusterName: c.Name(),
-			SourceReq:   sourceReq,
-			OnSucceeded: onSucceeded,
-			OnFailed:    onFailed,
-		})
-		if err != nil {
-			log.Error("fail to create partition table", zap.Error(err))
-			return CreateTableProcedure{}, err
-		}
-		realProcedure = p
-	} else {
+	if sourceReq.PartitionTableInfo == nil {
 		p, err := factory.makeCreateNormalTableProcedure(ctx, CreateTableRequest{
 			Cluster:     c,
 			SourceReq:   sourceReq,
@@ -46,11 +28,29 @@ func NewCreateTableProcedure(ctx context.Context, factory *Factory, c *cluster.C
 			log.Error("fail to create table", zap.Error(err))
 			return CreateTableProcedure{}, err
 		}
-		realProcedure = p
+		return CreateTableProcedure{
+			realProcedure: p,
+		}, nil
+	}
+
+	if len(sourceReq.PartitionTableInfo.SubTableNames) == 0 {
+		log.Error("fail to create table", zap.Error(ErrEmptyPartitionNames))
+		return CreateTableProcedure{}, ErrEmptyPartitionNames
+	}
+
+	p, err := factory.makeCreatePartitionTableProcedure(ctx, CreatePartitionTableRequest{
+		ClusterName: c.Name(),
+		SourceReq:   sourceReq,
+		OnSucceeded: onSucceeded,
+		OnFailed:    onFailed,
+	})
+	if err != nil {
+		log.Error("fail to create partition table", zap.Error(err))
+		return CreateTableProcedure{}, err
 	}
 
 	return CreateTableProcedure{
-		realProcedure: realProcedure,
+		realProcedure: p,
 	}, nil
 }
 

--- a/server/coordinator/procedure/create_table_common_util.go
+++ b/server/coordinator/procedure/create_table_common_util.go
@@ -56,6 +56,10 @@ func createTableOnShard(ctx context.Context, c *cluster.Cluster, dispatch eventd
 }
 
 func buildCreateTableRequest(createTableResult cluster.CreateTableResult, req *metaservicepb.CreateTableRequest, partitioned bool) eventdispatch.CreateTableOnShardRequest {
+	var encodedPartitionInfo []byte
+	if partitioned {
+		encodedPartitionInfo = req.EncodedPartitionInfo
+	}
 	return eventdispatch.CreateTableOnShardRequest{
 		UpdateShardInfo: eventdispatch.UpdateShardInfo{
 			CurrShardInfo: cluster.ShardInfo{
@@ -73,9 +77,10 @@ func buildCreateTableRequest(createTableResult cluster.CreateTableResult, req *m
 			SchemaName:  req.GetSchemaName(),
 			Partitioned: partitioned,
 		},
-		EncodedSchema:    req.EncodedSchema,
-		Engine:           req.Engine,
-		CreateIfNotExist: req.CreateIfNotExist,
-		Options:          req.Options,
+		EncodedSchema:        req.EncodedSchema,
+		Engine:               req.Engine,
+		CreateIfNotExist:     req.CreateIfNotExist,
+		Options:              req.Options,
+		EncodedPartitionInfo: encodedPartitionInfo,
 	}
 }

--- a/server/coordinator/procedure/factory.go
+++ b/server/coordinator/procedure/factory.go
@@ -144,7 +144,7 @@ func (f *Factory) makeCreatePartitionTableProcedure(ctx context.Context, request
 		return nil, errors.WithMessage(err, "pick partition table shards")
 	}
 
-	dataTableShards, err := f.shardPicker.PickShards(ctx, request.ClusterName, len(request.SourceReq.PartitionInfo.Names))
+	dataTableShards, err := f.shardPicker.PickShards(ctx, request.ClusterName, len(request.SourceReq.PartitionTableInfo.SubTableNames))
 	if err != nil {
 		return nil, errors.WithMessage(err, "pick data table shards")
 	}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
To support creation of partition tables, we have updated the data structure in `ceresdbproto` and added `encodedPartitionInfo`. CeresMeta also needs to adapt to this adjustment.

# What changes are included in this PR?
* Update `ceresdbproto`
* Adapt to new data structures.

# Are there any user-facing changes?
None.

# How does this change test
Pass the existing unit test.