### PR TITLE
feat: support alloc shard on same node

### DIFF
--- a/config/example-cluster1.toml
+++ b/config/example-cluster1.toml
@@ -1,5 +1,5 @@
 etcd-start-timeout-ms = 30000
-peer-urls = "http://{HostIP1}:2380"
+peer-urls = "http://{HostIP1}:12380"
 advertise-client-urls = "http://{HostIP1}:12379"
 advertise-peer-urls = "http://{HostIP1}:12380"
 client-urls = "http://{HostIP1}:12379"

--- a/config/example-cluster2.toml
+++ b/config/example-cluster2.toml
@@ -1,8 +1,8 @@
 etcd-start-timeout-ms = 30000
-peer-urls = "http://{HostIP2}:2380"
-advertise-client-urls = "http://{HostIP2}:12379"
-advertise-peer-urls = "http://{HostIP2}:12380"
-client-urls = "http://{HostIP2}:12379"
+peer-urls = "http://{HostIP2}:22380"
+advertise-client-urls = "http://{HostIP2}:22379"
+advertise-peer-urls = "http://{HostIP2}:22380"
+client-urls = "http://{HostIP2}:22379"
 wal-dir = "/tmp/ceresmeta2/wal"
 data-dir = "/tmp/ceresmeta2/data"
 node-name = "meta2"

--- a/server/coordinator/procedure/common_test.go
+++ b/server/coordinator/procedure/common_test.go
@@ -27,7 +27,7 @@ const (
 	defaultNodeCount                       = 2
 	defaultReplicationFactor               = 1
 	defaultPartitionTableProportionOfNodes = 0.5
-	defaultShardTotal                      = 2
+	defaultShardTotal                      = 4
 )
 
 type MockDispatch struct{}

--- a/server/coordinator/procedure/create_partition_table_test.go
+++ b/server/coordinator/procedure/create_partition_table_test.go
@@ -42,9 +42,9 @@ func TestCreatePartitionTable(t *testing.T) {
 
 	partitionTableNum := Max(1, int(float32(len(nodeNames))*defaultPartitionTableProportionOfNodes))
 
-	partitionTableShards, err := shardPicker.PickShards(ctx, c.Name(), partitionTableNum)
+	partitionTableShards, err := shardPicker.PickShards(ctx, c.Name(), partitionTableNum, false)
 	re.NoError(err)
-	dataTableShards, err := shardPicker.PickShards(ctx, c.Name(), len(request.GetPartitionTableInfo().SubTableNames))
+	dataTableShards, err := shardPicker.PickShards(ctx, c.Name(), len(request.GetPartitionTableInfo().SubTableNames), true)
 	re.NoError(err)
 
 	procedure := NewCreatePartitionTableProcedure(CreatePartitionTableProcedureRequest{

--- a/server/coordinator/procedure/error.go
+++ b/server/coordinator/procedure/error.go
@@ -15,4 +15,5 @@ var (
 	ErrGetRequest            = coderr.NewCodeError(coderr.Internal, "get request from event")
 	ErrNodeNumberNotEnough   = coderr.NewCodeError(coderr.Internal, "node number not enough")
 	ErrEmptyPartitionNames   = coderr.NewCodeError(coderr.Internal, "partition names is empty")
+	ErrShardNumberNotEnough  = coderr.NewCodeError(coderr.Internal, "shard number not enough")
 )

--- a/server/coordinator/procedure/factory.go
+++ b/server/coordinator/procedure/factory.go
@@ -139,12 +139,12 @@ func (f *Factory) makeCreatePartitionTableProcedure(ctx context.Context, request
 
 	partitionTableNum := Max(1, int(float32(len(nodeNames))*request.PartitionTableRatioOfNodes))
 
-	partitionTableShards, err := f.shardPicker.PickShards(ctx, request.ClusterName, partitionTableNum)
+	partitionTableShards, err := f.shardPicker.PickShards(ctx, request.ClusterName, partitionTableNum, false)
 	if err != nil {
 		return nil, errors.WithMessage(err, "pick partition table shards")
 	}
 
-	dataTableShards, err := f.shardPicker.PickShards(ctx, request.ClusterName, len(request.SourceReq.PartitionTableInfo.SubTableNames))
+	dataTableShards, err := f.shardPicker.PickShards(ctx, request.ClusterName, len(request.SourceReq.PartitionTableInfo.SubTableNames), true)
 	if err != nil {
 		return nil, errors.WithMessage(err, "pick data table shards")
 	}

--- a/server/coordinator/procedure/shard_picker_test.go
+++ b/server/coordinator/procedure/shard_picker_test.go
@@ -15,10 +15,25 @@ func TestRandomShardPicker(t *testing.T) {
 	manager, _ := prepare(t)
 
 	randomShardPicker := NewRandomShardPicker(manager)
-	nodeShards, err := randomShardPicker.PickShards(ctx, clusterName, 2)
+	nodeShards, err := randomShardPicker.PickShards(ctx, clusterName, 2, false)
 	re.NoError(err)
 
 	// Verify the number of shards and ensure that they are not on the same node.
 	re.Equal(len(nodeShards), 2)
 	re.NotEqual(nodeShards[0].ShardNode.NodeName, nodeShards[1].ShardNode.NodeName)
+
+	// ExpectShardNum is bigger than node number and enableDuplicateNode is false, it should be throw error.
+	_, err = randomShardPicker.PickShards(ctx, clusterName, 3, false)
+	re.Error(err)
+
+	// ExpectShardNum is bigger than node number and enableDuplicateNode is true, it should return correct shards.
+	nodeShards, err = randomShardPicker.PickShards(ctx, clusterName, 3, true)
+	re.NoError(err)
+	re.Equal(len(nodeShards), 3)
+	nodeShards, err = randomShardPicker.PickShards(ctx, clusterName, 4, true)
+	re.NoError(err)
+	re.Equal(len(nodeShards), 4)
+	// ExpectShardNum is bigger than shard number.
+	_, err = randomShardPicker.PickShards(ctx, clusterName, 5, true)
+	re.Error(err)
 }

--- a/server/coordinator/procedure/split_test.go
+++ b/server/coordinator/procedure/split_test.go
@@ -22,15 +22,18 @@ func TestSplit(t *testing.T) {
 	re.NoError(err)
 
 	// Randomly select a shardNode to split.
-	targetShardNode := getNodeShardsResult.NodeShards[0].ShardNode
+	createTableNodeShard := getNodeShardsResult.NodeShards[0].ShardNode
 
 	// Create some tables in this shard.
-	_, err = c.CreateTable(ctx, targetShardNode.NodeName, testSchemaName, testTableName0, false)
+	createTableResult, err := c.CreateTable(ctx, createTableNodeShard.NodeName, testSchemaName, testTableName0, false)
 	re.NoError(err)
-	_, err = c.CreateTable(ctx, targetShardNode.NodeName, testSchemaName, testTableName1, false)
+	_, err = c.CreateTable(ctx, createTableNodeShard.NodeName, testSchemaName, testTableName1, false)
 	re.NoError(err)
 
 	// Split one table from this shard.
+	getNodeShardResult, err := c.GetShardNodeByTableIDs([]storage.TableID{createTableResult.Table.ID})
+	targetShardNode := getNodeShardResult.ShardNodes[createTableResult.Table.ID][0]
+	re.NoError(err)
 	newShardID, err := c.AllocShardID(ctx)
 	re.NoError(err)
 	procedure := NewSplitProcedure(1, dispatch, s, c, testSchemaName, targetShardNode.ID, storage.ShardID(newShardID), []string{testTableName0}, targetShardNode.NodeName)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Support the creation of sub tables on the same node. 

# What changes are included in this PR?
* Update `shardPicker` interface, add `allowSameNode` param, it enable pick shards on the same node.
* Fix server start config.

# Are there any user-facing changes?
* Partition table could be created when partition number is bigger than node number. 

# How does this change test
Pass unit test.