### PR TITLE
feat: store partition info in ceresmeta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
-	github.com/CeresDB/ceresdbproto/golang v0.0.0-20230106033057-6cc1754ffc31
+	github.com/CeresDB/ceresdbproto/golang v0.0.0-20230116070525-9430fe7d3219
 	github.com/axw/gocov v1.1.0
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/json-iterator/go v1.1.11
@@ -101,5 +101,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
-
-replace github.com/CeresDB/ceresdbproto/golang v0.0.0-20230106033057-6cc1754ffc31 => github.com/chunshao90/ceresdbproto/golang v0.0.0-20230113071108-9bffa8aa977f

--- a/go.mod
+++ b/go.mod
@@ -101,3 +101,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
+
+replace github.com/CeresDB/ceresdbproto/golang v0.0.0-20230106033057-6cc1754ffc31 => github.com/chunshao90/ceresdbproto/golang v0.0.0-20230113071108-9bffa8aa977f

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20230116070525-9430fe7d3219 h1:xI3o/UcsSX0S15+NXhhOnoY0tNvlxgBo3g1inXxhmrU=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20230116070525-9430fe7d3219/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -51,8 +53,6 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chavacava/garif v0.0.0-20220316182200-5cad0b5181d4 h1:tFXjAxje9thrTF4h57Ckik+scJjTWdwAtZqZPtOT48M=
 github.com/chavacava/garif v0.0.0-20220316182200-5cad0b5181d4/go.mod h1:W8EnPSQ8Nv4fUjc/v1/8tHFqhuOJXnRub0dTfuAQktU=
-github.com/chunshao90/ceresdbproto/golang v0.0.0-20230113071108-9bffa8aa977f h1:qw8DoDFvY5Gb/xACNi19fSv7Yt1ROpznnMyKK7RNFjg=
-github.com/chunshao90/ceresdbproto/golang v0.0.0-20230113071108-9bffa8aa977f/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CeresDB/ceresdbproto/golang v0.0.0-20230106033057-6cc1754ffc31 h1:34yMmMaN3cW41a6GAPjXMWlk9Ql2RoyyodfQD6DLh40=
-github.com/CeresDB/ceresdbproto/golang v0.0.0-20230106033057-6cc1754ffc31/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -53,6 +51,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chavacava/garif v0.0.0-20220316182200-5cad0b5181d4 h1:tFXjAxje9thrTF4h57Ckik+scJjTWdwAtZqZPtOT48M=
 github.com/chavacava/garif v0.0.0-20220316182200-5cad0b5181d4/go.mod h1:W8EnPSQ8Nv4fUjc/v1/8tHFqhuOJXnRub0dTfuAQktU=
+github.com/chunshao90/ceresdbproto/golang v0.0.0-20230113071108-9bffa8aa977f h1:qw8DoDFvY5Gb/xACNi19fSv7Yt1ROpznnMyKK7RNFjg=
+github.com/chunshao90/ceresdbproto/golang v0.0.0-20230113071108-9bffa8aa977f/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -161,7 +161,7 @@ func (c *Cluster) OpenTable(ctx context.Context, request OpenTableRequest) (Shar
 		return ShardVersionUpdate{}, errors.WithMessagef(ErrTableNotFound, "table not exists, shcemaName:%s,tableName:%s", request.SchemaName, request.TableName)
 	}
 
-	if table.PartitionInfo == nil {
+	if !table.IsPartitioned() {
 		log.Error("normal table cannot be opened on multiple shards", zap.String("schemaName", request.SchemaName), zap.String("tableName", request.TableName))
 		return ShardVersionUpdate{}, errors.WithMessagef(ErrOpenTable, "normal table cannot be opened on multiple shards, schemaName:%s, tableName:%s", request.SchemaName, request.TableName)
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -85,10 +85,11 @@ func (c *Cluster) GetShardTables(shardIDs []storage.ShardID, nodeName string) ma
 				log.Warn("schema not exits", zap.Uint64("schemaID", uint64(table.SchemaID)))
 			}
 			tableInfos = append(tableInfos, TableInfo{
-				ID:         table.ID,
-				Name:       table.Name,
-				SchemaID:   table.SchemaID,
-				SchemaName: schema.Name,
+				ID:            table.ID,
+				Name:          table.Name,
+				SchemaID:      table.SchemaID,
+				SchemaName:    schema.Name,
+				PartitionInfo: table.PartitionInfo,
 			})
 		}
 		result[shardID] = ShardTables{
@@ -160,7 +161,7 @@ func (c *Cluster) OpenTable(ctx context.Context, request OpenTableRequest) (Shar
 		return ShardVersionUpdate{}, errors.WithMessagef(ErrTableNotFound, "table not exists, shcemaName:%s,tableName:%s", request.SchemaName, request.TableName)
 	}
 
-	if !table.Partitioned {
+	if table.PartitionInfo == nil {
 		log.Error("normal table cannot be opened on multiple shards", zap.String("schemaName", request.SchemaName), zap.String("tableName", request.TableName))
 		return ShardVersionUpdate{}, errors.WithMessagef(ErrOpenTable, "normal table cannot be opened on multiple shards, schemaName:%s, tableName:%s", request.SchemaName, request.TableName)
 	}
@@ -245,10 +246,10 @@ func (c *Cluster) GetTable(schemaName, tableName string) (storage.Table, bool, e
 	return c.tableManager.GetTable(schemaName, tableName)
 }
 
-func (c *Cluster) CreateTable(ctx context.Context, shardID storage.ShardID, schemaName string, tableName string, partitioned bool) (CreateTableResult, error) {
-	log.Info("create table start", zap.String("cluster", c.Name()), zap.String("schemaName", schemaName), zap.String("tableName", tableName))
+func (c *Cluster) CreateTable(ctx context.Context, request CreateTableRequest) (CreateTableResult, error) {
+	log.Info("create table start", zap.String("cluster", c.Name()), zap.String("schemaName", request.SchemaName), zap.String("tableName", request.TableName))
 
-	_, exists, err := c.tableManager.GetTable(schemaName, tableName)
+	_, exists, err := c.tableManager.GetTable(request.SchemaName, request.TableName)
 	if err != nil {
 		return CreateTableResult{}, err
 	}
@@ -258,13 +259,13 @@ func (c *Cluster) CreateTable(ctx context.Context, shardID storage.ShardID, sche
 	}
 
 	// Create table in table manager.
-	table, err := c.tableManager.CreateTable(ctx, schemaName, tableName, partitioned)
+	table, err := c.tableManager.CreateTable(ctx, request.SchemaName, request.TableName, request.PartitionInfo)
 	if err != nil {
 		return CreateTableResult{}, errors.WithMessage(err, "table manager create table")
 	}
 
 	// Add table to topology manager.
-	result, err := c.topologyManager.AddTable(ctx, shardID, []storage.Table{table})
+	result, err := c.topologyManager.AddTable(ctx, request.ShardID, []storage.Table{table})
 	if err != nil {
 		return CreateTableResult{}, errors.WithMessage(err, "topology manager add table")
 	}

--- a/server/cluster/table_manager.go
+++ b/server/cluster/table_manager.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/id"
 	"github.com/CeresDB/ceresmeta/server/storage"
@@ -25,7 +24,7 @@ type TableManager interface {
 	// GetTablesByIDs get tables with tableIDs.
 	GetTablesByIDs(tableIDs []storage.TableID) []storage.Table
 	// CreateTable create table with schemaName and tableName.
-	CreateTable(ctx context.Context, schemaName string, tableName string, partitionInfo *clusterpb.PartitionInfo) (storage.Table, error)
+	CreateTable(ctx context.Context, schemaName string, tableName string, partitionInfo storage.PartitionInfo) (storage.Table, error)
 	// DropTable drop table with schemaName and tableName.
 	DropTable(ctx context.Context, schemaName string, tableName string) error
 	// GetSchemaByName get schema with schemaName.
@@ -103,7 +102,7 @@ func (m *TableManagerImpl) GetTablesByIDs(tableIDs []storage.TableID) []storage.
 	return result
 }
 
-func (m *TableManagerImpl) CreateTable(ctx context.Context, schemaName string, tableName string, partitionInfo *clusterpb.PartitionInfo) (storage.Table, error) {
+func (m *TableManagerImpl) CreateTable(ctx context.Context, schemaName string, tableName string, partitionInfo storage.PartitionInfo) (storage.Table, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	_, exists, err := m.getTable(schemaName, tableName)

--- a/server/cluster/table_manager.go
+++ b/server/cluster/table_manager.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/id"
 	"github.com/CeresDB/ceresmeta/server/storage"
@@ -24,7 +25,7 @@ type TableManager interface {
 	// GetTablesByIDs get tables with tableIDs.
 	GetTablesByIDs(tableIDs []storage.TableID) []storage.Table
 	// CreateTable create table with schemaName and tableName.
-	CreateTable(ctx context.Context, schemaName string, tableName string, partitioned bool) (storage.Table, error)
+	CreateTable(ctx context.Context, schemaName string, tableName string, partitionInfo *clusterpb.PartitionInfo) (storage.Table, error)
 	// DropTable drop table with schemaName and tableName.
 	DropTable(ctx context.Context, schemaName string, tableName string) error
 	// GetSchemaByName get schema with schemaName.
@@ -102,7 +103,7 @@ func (m *TableManagerImpl) GetTablesByIDs(tableIDs []storage.TableID) []storage.
 	return result
 }
 
-func (m *TableManagerImpl) CreateTable(ctx context.Context, schemaName string, tableName string, partitioned bool) (storage.Table, error) {
+func (m *TableManagerImpl) CreateTable(ctx context.Context, schemaName string, tableName string, partitionInfo *clusterpb.PartitionInfo) (storage.Table, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	_, exists, err := m.getTable(schemaName, tableName)
@@ -126,11 +127,11 @@ func (m *TableManagerImpl) CreateTable(ctx context.Context, schemaName string, t
 	}
 
 	table := storage.Table{
-		ID:          storage.TableID(id),
-		Name:        tableName,
-		SchemaID:    schema.ID,
-		CreatedAt:   uint64(time.Now().UnixMilli()),
-		Partitioned: partitioned,
+		ID:            storage.TableID(id),
+		Name:          tableName,
+		SchemaID:      schema.ID,
+		CreatedAt:     uint64(time.Now().UnixMilli()),
+		PartitionInfo: partitionInfo,
 	}
 	err = m.storage.CreateTable(ctx, storage.CreateTableRequest{
 		ClusterID: m.clusterID,

--- a/server/cluster/table_manager_test.go
+++ b/server/cluster/table_manager_test.go
@@ -191,7 +191,12 @@ func testCreateTable(ctx context.Context, re *require.Assertions, manager Manage
 ) {
 	c, err := manager.GetCluster(ctx, clusterName)
 	re.NoError(err)
-	table, err := c.CreateTable(ctx, shardID, schema, tableName, false)
+	table, err := c.CreateTable(ctx, CreateTableRequest{
+		ShardID:       shardID,
+		SchemaName:    schema,
+		TableName:     tableName,
+		PartitionInfo: storage.PartitionInfo{},
+	})
 	re.NoError(err)
 	re.Equal(tableID, table.Table.ID)
 }

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -3,7 +3,6 @@
 package cluster
 
 import (
-	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/server/storage"
 )
@@ -17,7 +16,7 @@ type TableInfo struct {
 	Name          string
 	SchemaID      storage.SchemaID
 	SchemaName    string
-	PartitionInfo *clusterpb.PartitionInfo
+	PartitionInfo storage.PartitionInfo
 }
 
 type ShardTables struct {
@@ -47,7 +46,7 @@ type CreateTableRequest struct {
 	ShardID       storage.ShardID
 	SchemaName    string
 	TableName     string
-	PartitionInfo *clusterpb.PartitionInfo
+	PartitionInfo storage.PartitionInfo
 }
 
 type CreateTableResult struct {

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -3,6 +3,7 @@
 package cluster
 
 import (
+	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/server/storage"
 )
@@ -12,11 +13,11 @@ const (
 )
 
 type TableInfo struct {
-	ID          storage.TableID
-	Name        string
-	SchemaID    storage.SchemaID
-	SchemaName  string
-	Partitioned bool
+	ID            storage.TableID
+	Name          string
+	SchemaID      storage.SchemaID
+	SchemaName    string
+	PartitionInfo *clusterpb.PartitionInfo
 }
 
 type ShardTables struct {
@@ -40,6 +41,13 @@ type CreateClusterOpts struct {
 	NodeCount         uint32
 	ReplicationFactor uint32
 	ShardTotal        uint32
+}
+
+type CreateTableRequest struct {
+	ShardID       storage.ShardID
+	SchemaName    string
+	TableName     string
+	PartitionInfo *clusterpb.PartitionInfo
 }
 
 type CreateTableResult struct {

--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -138,9 +138,10 @@ func ConvertShardsInfoPB(shard *metaservicepb.ShardInfo) ShardInfo {
 
 func ConvertTableInfoToPB(table TableInfo) *metaservicepb.TableInfo {
 	return &metaservicepb.TableInfo{
-		Id:         uint64(table.ID),
-		Name:       table.Name,
-		SchemaId:   uint32(table.SchemaID),
-		SchemaName: table.SchemaName,
+		Id:            uint64(table.ID),
+		Name:          table.Name,
+		SchemaId:      uint32(table.SchemaID),
+		SchemaName:    table.SchemaName,
+		PartitionInfo: table.PartitionInfo.Info,
 	}
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -48,7 +48,7 @@ const (
 	defaultClusterNodeCount                = 2
 	defaultClusterReplicationFactor        = 1
 	defaultClusterShardTotal               = 8
-	defaultPartitionTableProportionOfNodes = 0.5
+	defaultPartitionTableProportionOfNodes = 0
 
 	defaultHTTPPort = 8080
 )

--- a/server/coordinator/eventdispatch/dispatch.go
+++ b/server/coordinator/eventdispatch/dispatch.go
@@ -5,6 +5,7 @@ package eventdispatch
 import (
 	"context"
 
+	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 )
 
@@ -31,13 +32,13 @@ type UpdateShardInfo struct {
 }
 
 type CreateTableOnShardRequest struct {
-	UpdateShardInfo      UpdateShardInfo
-	TableInfo            cluster.TableInfo
-	EncodedSchema        []byte
-	Engine               string
-	CreateIfNotExist     bool
-	Options              map[string]string
-	EncodedPartitionInfo []byte
+	UpdateShardInfo  UpdateShardInfo
+	TableInfo        cluster.TableInfo
+	EncodedSchema    []byte
+	Engine           string
+	CreateIfNotExist bool
+	Options          map[string]string
+	PartitionInfo    *clusterpb.PartitionInfo
 }
 
 type DropTableOnShardRequest struct {

--- a/server/coordinator/eventdispatch/dispatch.go
+++ b/server/coordinator/eventdispatch/dispatch.go
@@ -5,7 +5,6 @@ package eventdispatch
 import (
 	"context"
 
-	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 )
 
@@ -38,7 +37,6 @@ type CreateTableOnShardRequest struct {
 	Engine           string
 	CreateIfNotExist bool
 	Options          map[string]string
-	PartitionInfo    *clusterpb.PartitionInfo
 }
 
 type DropTableOnShardRequest struct {

--- a/server/coordinator/eventdispatch/dispatch_impl.go
+++ b/server/coordinator/eventdispatch/dispatch_impl.go
@@ -149,7 +149,7 @@ func convertCreateTableOnShardRequestToPB(request CreateTableOnShardRequest) *me
 		Engine:           request.Engine,
 		CreateIfNotExist: request.CreateIfNotExist,
 		Options:          request.Options,
-		PartitionInfo:    request.PartitionInfo,
+		PartitionInfo:    request.TableInfo.PartitionInfo.Info,
 	}
 }
 

--- a/server/coordinator/eventdispatch/dispatch_impl.go
+++ b/server/coordinator/eventdispatch/dispatch_impl.go
@@ -149,7 +149,6 @@ func convertCreateTableOnShardRequestToPB(request CreateTableOnShardRequest) *me
 		Engine:           request.Engine,
 		CreateIfNotExist: request.CreateIfNotExist,
 		Options:          request.Options,
-		PartitionInfo:    request.TableInfo.PartitionInfo.Info,
 	}
 }
 

--- a/server/coordinator/eventdispatch/dispatch_impl.go
+++ b/server/coordinator/eventdispatch/dispatch_impl.go
@@ -143,13 +143,13 @@ func (d *DispatchImpl) getMetaEventClient(ctx context.Context, addr string) (met
 
 func convertCreateTableOnShardRequestToPB(request CreateTableOnShardRequest) *metaeventpb.CreateTableOnShardRequest {
 	return &metaeventpb.CreateTableOnShardRequest{
-		UpdateShardInfo:      convertUpdateShardInfoToPB(request.UpdateShardInfo),
-		TableInfo:            cluster.ConvertTableInfoToPB(request.TableInfo),
-		EncodedSchema:        request.EncodedSchema,
-		Engine:               request.Engine,
-		CreateIfNotExist:     request.CreateIfNotExist,
-		Options:              request.Options,
-		EncodedPartitionInfo: request.EncodedPartitionInfo,
+		UpdateShardInfo:  convertUpdateShardInfoToPB(request.UpdateShardInfo),
+		TableInfo:        cluster.ConvertTableInfoToPB(request.TableInfo),
+		EncodedSchema:    request.EncodedSchema,
+		Engine:           request.Engine,
+		CreateIfNotExist: request.CreateIfNotExist,
+		Options:          request.Options,
+		PartitionInfo:    request.PartitionInfo,
 	}
 }
 

--- a/server/coordinator/procedure/create_drop_partition_table_test.go
+++ b/server/coordinator/procedure/create_drop_partition_table_test.go
@@ -7,13 +7,16 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
+	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCreateAndDropPartitionTable(t *testing.T) {
+	re := require.New(t)
 	ctx := context.Background()
 	dispatch := MockDispatch{}
 	manager, c := prepare(t)
@@ -34,7 +37,8 @@ func TestCreateAndDropPartitionTable(t *testing.T) {
 	// Check get table.
 	for i := 0; i < testTableNum; i++ {
 		tableName := fmt.Sprintf("%s_%d", testTableName0, i)
-		checkTable(t, c, tableName, true)
+		table := checkTable(t, c, tableName, true)
+		re.Equal(table.PartitionInfo.Info != nil, true)
 		subTableNames := genSubTables(tableName, testSubTableNum)
 		for _, subTableName := range subTableNames {
 			checkTable(t, c, subTableName, true)
@@ -69,6 +73,7 @@ func testCreatePartitionTable(ctx context.Context, t *testing.T, dispatch eventd
 		},
 		PartitionTableInfo: &metaservicepb.PartitionTableInfo{
 			SubTableNames: subTableNames,
+			PartitionInfo: &clusterpb.PartitionInfo{},
 		},
 		SchemaName: testSchemaName,
 		Name:       tableName,
@@ -133,9 +138,10 @@ func genSubTables(tableName string, tableNum int) []string {
 	return subTableNames
 }
 
-func checkTable(t *testing.T, c *cluster.Cluster, tableName string, exist bool) {
+func checkTable(t *testing.T, c *cluster.Cluster, tableName string, exist bool) storage.Table {
 	re := require.New(t)
-	_, b, err := c.GetTable(testSchemaName, tableName)
+	table, b, err := c.GetTable(testSchemaName, tableName)
 	re.NoError(err)
 	re.Equal(b, exist)
+	return table
 }

--- a/server/coordinator/procedure/create_drop_partition_table_test.go
+++ b/server/coordinator/procedure/create_drop_partition_table_test.go
@@ -21,7 +21,7 @@ func TestCreateAndDropPartitionTable(t *testing.T) {
 
 	shardPicker := NewRandomBalancedShardPicker(manager)
 
-	testTableNum := 20
+	testTableNum := 8
 	testSubTableNum := 4
 
 	// Create table.

--- a/server/coordinator/procedure/create_partition_table.go
+++ b/server/coordinator/procedure/create_partition_table.go
@@ -7,12 +7,11 @@ import (
 	"encoding/json"
 	"sync"
 
-	"github.com/CeresDB/ceresmeta/server/storage"
-
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
+	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/looplab/fsm"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -219,14 +218,15 @@ func createPartitionTableCallback(event *fsm.Event) {
 	// Select first shard to create partition table.
 	partitionTableShardNode := req.partitionTableShards[0]
 
-	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), partitionTableShardNode.ShardInfo.ID, req.sourceReq.GetPartitionTableInfo().GetPartitionInfo())
+	partitionInfo := req.sourceReq.GetPartitionTableInfo().GetPartitionInfo()
+	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), partitionTableShardNode.ShardInfo.ID, partitionInfo)
 	if err != nil {
 		cancelEventWithLog(event, err, "create table metadata")
 		return
 	}
 	req.createTableResult = createTableResult
 
-	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, partitionTableShardNode.ShardInfo.ID, buildCreateTableRequest(createTableResult, req.sourceReq, req.sourceReq.GetPartitionTableInfo().GetPartitionInfo())); err != nil {
+	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, partitionTableShardNode.ShardInfo.ID, buildCreateTableRequest(createTableResult, req.sourceReq, partitionInfo)); err != nil {
 		cancelEventWithLog(event, err, "dispatch create table on shard")
 		return
 	}
@@ -241,13 +241,13 @@ func createDataTablesCallback(event *fsm.Event) {
 	}
 
 	for i, subTableShard := range req.subTablesShards {
-		createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetPartitionTableInfo().SubTableNames[i], subTableShard.ShardInfo.ID, req.sourceReq.GetPartitionTableInfo().GetPartitionInfo())
+		createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetPartitionTableInfo().SubTableNames[i], subTableShard.ShardInfo.ID, nil)
 		if err != nil {
 			cancelEventWithLog(event, err, "create table metadata")
 			return
 		}
 
-		if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, subTableShard.ShardInfo.ID, buildCreateTableRequest(createTableResult, req.sourceReq, req.sourceReq.GetPartitionTableInfo().GetPartitionInfo())); err != nil {
+		if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, subTableShard.ShardInfo.ID, buildCreateTableRequest(createTableResult, req.sourceReq, nil)); err != nil {
 			cancelEventWithLog(event, err, "dispatch create table on shard")
 			return
 		}
@@ -265,11 +265,12 @@ func openPartitionTableMetadataCallback(event *fsm.Event) {
 	req.partitionTableShards = append(req.partitionTableShards[:0], req.partitionTableShards[1:]...)
 	versions := make([]cluster.ShardVersionUpdate, 0, len(req.partitionTableShards))
 	for _, partitionTableShard := range req.partitionTableShards {
-		shardVersionUpdate, err := req.cluster.OpenTable(req.ctx, cluster.OpenTableRequest{
-			SchemaName: req.sourceReq.SchemaName,
-			TableName:  req.sourceReq.Name,
-			ShardID:    partitionTableShard.ShardInfo.ID,
-		})
+		shardVersionUpdate, err := req.cluster.OpenTable(req.ctx,
+			cluster.OpenTableRequest{
+				SchemaName: req.sourceReq.SchemaName,
+				TableName:  req.sourceReq.Name,
+				ShardID:    partitionTableShard.ShardInfo.ID,
+			})
 		if err != nil {
 			cancelEventWithLog(event, err, "open table")
 			return

--- a/server/coordinator/procedure/create_table.go
+++ b/server/coordinator/procedure/create_table.go
@@ -46,13 +46,13 @@ func createTablePrepareCallback(event *fsm.Event) {
 		return
 	}
 
-	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), req.shardID, false)
+	createTableResult, err := createTableMetadata(req.ctx, req.cluster, req.sourceReq.GetSchemaName(), req.sourceReq.GetName(), req.shardID, nil)
 	if err != nil {
 		cancelEventWithLog(event, err, "create table metadata")
 		return
 	}
 
-	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, createTableResult.ShardVersionUpdate.ShardID, buildCreateTableRequest(createTableResult, req.sourceReq, false)); err != nil {
+	if err = createTableOnShard(req.ctx, req.cluster, req.dispatch, createTableResult.ShardVersionUpdate.ShardID, buildCreateTableRequest(createTableResult, req.sourceReq, req.sourceReq.GetPartitionTableInfo().GetPartitionInfo())); err != nil {
 		cancelEventWithLog(event, err, "dispatch create table on shard")
 		return
 	}

--- a/server/coordinator/procedure/create_table_common_util.go
+++ b/server/coordinator/procedure/create_table_common_util.go
@@ -82,6 +82,5 @@ func buildCreateTableRequest(createTableResult cluster.CreateTableResult, req *m
 		Engine:           req.Engine,
 		CreateIfNotExist: req.CreateIfNotExist,
 		Options:          req.Options,
-		PartitionInfo:    partitionInfo,
 	}
 }

--- a/server/coordinator/procedure/create_table_common_util.go
+++ b/server/coordinator/procedure/create_table_common_util.go
@@ -26,7 +26,7 @@ func createTableMetadata(ctx context.Context, c *cluster.Cluster, schemaName str
 		ShardID:       shardID,
 		SchemaName:    schemaName,
 		TableName:     tableName,
-		PartitionInfo: partitionInfo,
+		PartitionInfo: storage.PartitionInfo{Info: partitionInfo},
 	})
 	if err != nil {
 		return cluster.CreateTableResult{}, errors.WithMessage(err, "create table")
@@ -76,7 +76,7 @@ func buildCreateTableRequest(createTableResult cluster.CreateTableResult, req *m
 			Name:          createTableResult.Table.Name,
 			SchemaID:      createTableResult.Table.SchemaID,
 			SchemaName:    req.GetSchemaName(),
-			PartitionInfo: partitionInfo,
+			PartitionInfo: storage.PartitionInfo{Info: partitionInfo},
 		},
 		EncodedSchema:    req.EncodedSchema,
 		Engine:           req.Engine,

--- a/server/coordinator/procedure/create_table_common_util.go
+++ b/server/coordinator/procedure/create_table_common_util.go
@@ -5,6 +5,7 @@ package procedure
 import (
 	"context"
 
+	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
@@ -12,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func createTableMetadata(ctx context.Context, c *cluster.Cluster, schemaName string, tableName string, shardID storage.ShardID, partitioned bool) (cluster.CreateTableResult, error) {
+func createTableMetadata(ctx context.Context, c *cluster.Cluster, schemaName string, tableName string, shardID storage.ShardID, partitionInfo *clusterpb.PartitionInfo) (cluster.CreateTableResult, error) {
 	_, exists, err := c.GetTable(schemaName, tableName)
 	if err != nil {
 		return cluster.CreateTableResult{}, errors.WithMessage(err, "cluster get table")
@@ -21,7 +22,12 @@ func createTableMetadata(ctx context.Context, c *cluster.Cluster, schemaName str
 		return cluster.CreateTableResult{}, errors.WithMessagef(ErrTableAlreadyExists, "create an existing table, schemaName:%s, tableName:%s", schemaName, tableName)
 	}
 
-	createTableResult, err := c.CreateTable(ctx, shardID, schemaName, tableName, partitioned)
+	createTableResult, err := c.CreateTable(ctx, cluster.CreateTableRequest{
+		ShardID:       shardID,
+		SchemaName:    schemaName,
+		TableName:     tableName,
+		PartitionInfo: partitionInfo,
+	})
 	if err != nil {
 		return cluster.CreateTableResult{}, errors.WithMessage(err, "create table")
 	}
@@ -54,11 +60,7 @@ func createTableOnShard(ctx context.Context, c *cluster.Cluster, dispatch eventd
 	return nil
 }
 
-func buildCreateTableRequest(createTableResult cluster.CreateTableResult, req *metaservicepb.CreateTableRequest, partitioned bool) eventdispatch.CreateTableOnShardRequest {
-	var encodedPartitionInfo []byte
-	if partitioned {
-		encodedPartitionInfo = req.EncodedPartitionInfo
-	}
+func buildCreateTableRequest(createTableResult cluster.CreateTableResult, req *metaservicepb.CreateTableRequest, partitionInfo *clusterpb.PartitionInfo) eventdispatch.CreateTableOnShardRequest {
 	return eventdispatch.CreateTableOnShardRequest{
 		UpdateShardInfo: eventdispatch.UpdateShardInfo{
 			CurrShardInfo: cluster.ShardInfo{
@@ -70,16 +72,16 @@ func buildCreateTableRequest(createTableResult cluster.CreateTableResult, req *m
 			PrevVersion: createTableResult.ShardVersionUpdate.PrevVersion,
 		},
 		TableInfo: cluster.TableInfo{
-			ID:          createTableResult.Table.ID,
-			Name:        createTableResult.Table.Name,
-			SchemaID:    createTableResult.Table.SchemaID,
-			SchemaName:  req.GetSchemaName(),
-			Partitioned: partitioned,
+			ID:            createTableResult.Table.ID,
+			Name:          createTableResult.Table.Name,
+			SchemaID:      createTableResult.Table.SchemaID,
+			SchemaName:    req.GetSchemaName(),
+			PartitionInfo: partitionInfo,
 		},
-		EncodedSchema:        req.EncodedSchema,
-		Engine:               req.Engine,
-		CreateIfNotExist:     req.CreateIfNotExist,
-		Options:              req.Options,
-		EncodedPartitionInfo: encodedPartitionInfo,
+		EncodedSchema:    req.EncodedSchema,
+		Engine:           req.Engine,
+		CreateIfNotExist: req.CreateIfNotExist,
+		Options:          req.Options,
+		PartitionInfo:    partitionInfo,
 	}
 }

--- a/server/coordinator/procedure/split_test.go
+++ b/server/coordinator/procedure/split_test.go
@@ -25,9 +25,17 @@ func TestSplit(t *testing.T) {
 	createTableNodeShard := getNodeShardsResult.NodeShards[0].ShardNode
 
 	// Create some tables in this shard.
-	createTableResult, err := c.CreateTable(ctx, createTableNodeShard.ID, testSchemaName, testTableName0, false)
+	createTableResult, err := c.CreateTable(ctx, cluster.CreateTableRequest{
+		ShardID:    createTableNodeShard.ID,
+		SchemaName: testSchemaName,
+		TableName:  testTableName0,
+	})
 	re.NoError(err)
-	_, err = c.CreateTable(ctx, createTableNodeShard.ID, testSchemaName, testTableName1, false)
+	_, err = c.CreateTable(ctx, cluster.CreateTableRequest{
+		ShardID:    createTableNodeShard.ID,
+		SchemaName: testSchemaName,
+		TableName:  testTableName1,
+	})
 	re.NoError(err)
 
 	// Split one table from this shard.

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -164,11 +164,11 @@ type Schema struct {
 }
 
 type Table struct {
-	ID          TableID
-	Name        string
-	SchemaID    SchemaID
-	CreatedAt   uint64
-	Partitioned bool
+	ID            TableID
+	Name          string
+	SchemaID      SchemaID
+	CreatedAt     uint64
+	PartitionInfo *clusterpb.PartitionInfo
 }
 
 type ShardView struct {
@@ -332,22 +332,22 @@ func convertSchemaPB(schema *clusterpb.Schema) Schema {
 
 func convertTableToPB(table Table) clusterpb.Table {
 	return clusterpb.Table{
-		Id:          uint64(table.ID),
-		Name:        table.Name,
-		SchemaId:    uint32(table.SchemaID),
-		Desc:        "",
-		CreatedAt:   table.CreatedAt,
-		Partitioned: table.Partitioned,
+		Id:            uint64(table.ID),
+		Name:          table.Name,
+		SchemaId:      uint32(table.SchemaID),
+		Desc:          "",
+		CreatedAt:     table.CreatedAt,
+		PartitionInfo: table.PartitionInfo,
 	}
 }
 
 func convertTablePB(table *clusterpb.Table) Table {
 	return Table{
-		ID:          TableID(table.Id),
-		Name:        table.Name,
-		SchemaID:    SchemaID(table.SchemaId),
-		CreatedAt:   table.CreatedAt,
-		Partitioned: table.Partitioned,
+		ID:            TableID(table.Id),
+		Name:          table.Name,
+		SchemaID:      SchemaID(table.SchemaId),
+		CreatedAt:     table.CreatedAt,
+		PartitionInfo: table.PartitionInfo,
 	}
 }
 

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -163,12 +163,20 @@ type Schema struct {
 	CreatedAt uint64
 }
 
+type PartitionInfo struct {
+	Info *clusterpb.PartitionInfo
+}
+
 type Table struct {
 	ID            TableID
 	Name          string
 	SchemaID      SchemaID
 	CreatedAt     uint64
-	PartitionInfo *clusterpb.PartitionInfo
+	PartitionInfo PartitionInfo
+}
+
+func (t Table) IsPartitioned() bool {
+	return t.PartitionInfo.Info != nil
 }
 
 type ShardView struct {
@@ -337,17 +345,19 @@ func convertTableToPB(table Table) clusterpb.Table {
 		SchemaId:      uint32(table.SchemaID),
 		Desc:          "",
 		CreatedAt:     table.CreatedAt,
-		PartitionInfo: table.PartitionInfo,
+		PartitionInfo: table.PartitionInfo.Info,
 	}
 }
 
 func convertTablePB(table *clusterpb.Table) Table {
 	return Table{
-		ID:            TableID(table.Id),
-		Name:          table.Name,
-		SchemaID:      SchemaID(table.SchemaId),
-		CreatedAt:     table.CreatedAt,
-		PartitionInfo: table.PartitionInfo,
+		ID:        TableID(table.Id),
+		Name:      table.Name,
+		SchemaID:  SchemaID(table.SchemaId),
+		CreatedAt: table.CreatedAt,
+		PartitionInfo: PartitionInfo{
+			Info: table.PartitionInfo,
+		},
 	}
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 In order to support the case where the partition table is opened by multiple machines in a non-cloud environment, store the partition info of `PartitionTable` in `ceresmeta`.
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
* Store partition info of `PartitionInfo` in metadata of the table.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Manual testing.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->