### PR TITLE
fix: add node state check in transfer leader procedure & Support multi-node concurrent shard opening.

### DIFF
--- a/server/cluster/types.go
+++ b/server/cluster/types.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	MinShardID = 0
+	MinShardID                           = 0
+	HeartbeatKeepAliveIntervalSec uint64 = 15
 )
 
 type TableInfo struct {

--- a/server/coordinator/scheduler.go
+++ b/server/coordinator/scheduler.go
@@ -157,6 +157,7 @@ func (s *Scheduler) applyMetadataShardInfo(ctx context.Context, node string, rea
 
 		// 3. Shard exists in both metadata and node, versions are inconsistent, close and reopen invalid shard on node.
 		// TODO: In the current implementation mode, the scheduler will close and reopen Shard during the table creation process, which will cause Shard to be unavailable for a short time, temporarily close the detection of version inconsistency, and then open it after repair.
+		// Related issue: https://github.com/CeresDB/ceresmeta/issues/140
 		log.Info("Shard exists in both metadata and node, versions are inconsistent, close and reopen invalid shard on node.", zap.String("node", node), zap.Uint32("shardID", uint32(expectShard.ID)))
 	}
 

--- a/server/coordinator/scheduler.go
+++ b/server/coordinator/scheduler.go
@@ -156,13 +156,8 @@ func (s *Scheduler) applyMetadataShardInfo(ctx context.Context, node string, rea
 		}
 
 		// 3. Shard exists in both metadata and node, versions are inconsistent, close and reopen invalid shard on node.
+		// TODO: In the current implementation mode, the scheduler will close and reopen Shard during the table creation process, which will cause Shard to be unavailable for a short time, temporarily close the detection of version inconsistency, and then open it after repair.
 		log.Info("Shard exists in both metadata and node, versions are inconsistent, close and reopen invalid shard on node.", zap.String("node", node), zap.Uint32("shardID", uint32(expectShard.ID)))
-		if err := s.dispatch.CloseShard(ctx, node, eventdispatch.CloseShardRequest{ShardID: uint32(expectShard.ID)}); err != nil {
-			return errors.WithMessagef(err, "close shard failed, shardInfo:%d", expectShard.ID)
-		}
-		if err := s.dispatch.OpenShard(ctx, node, eventdispatch.OpenShardRequest{Shard: expectShard}); err != nil {
-			return errors.WithMessagef(err, "reopen shard failed, shardInfo:%d", expectShard.ID)
-		}
 	}
 
 	// 4. Shard exists in node and not exists in metadata, close extra shard on node.

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -270,7 +270,7 @@ func (a *API) getNodeShards(writer http.ResponseWriter, req *http.Request) {
 	result, err := a.clusterManager.GetNodeShards(context.Background(), nodeShardsRequest.ClusterName)
 	if err != nil {
 		log.Error("get node shards failed", zap.Error(err))
-		a.respondError(writer, ErrGetShardNodes, "get node shards failed")
+		a.respondError(writer, ErrGetNodeShards, "get node shards failed")
 		return
 	}
 

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -52,6 +52,7 @@ func (a *API) NewAPIRouter() *Router {
 	router.Post("/split", a.split)
 	router.Post("/route", a.route)
 	router.Post("/dropTable", a.dropTable)
+	router.Post("/getNodeShards", a.getNodeShards)
 
 	return router
 }
@@ -236,6 +237,40 @@ func (a *API) route(writer http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		log.Error("route tables failed", zap.Error(err))
 		a.respondError(writer, ErrRouteTable, "route tables failed")
+		return
+	}
+
+	a.respond(writer, result)
+}
+
+type NodeShardsRequest struct {
+	ClusterName string `json:"clusterName"`
+}
+
+func (a *API) getNodeShards(writer http.ResponseWriter, req *http.Request) {
+	resp, isLeader, err := a.forwardClient.forwardToLeader(req)
+	if err != nil {
+		log.Error("forward to leader failed", zap.Error(err))
+		a.respondError(writer, ErrForwardToLeader, "forward to leader failed")
+		return
+	}
+
+	if !isLeader {
+		a.respondForward(writer, resp)
+		return
+	}
+	var nodeShardsRequest NodeShardsRequest
+	err = json.NewDecoder(req.Body).Decode(&nodeShardsRequest)
+	if err != nil {
+		log.Error("decode request body failed", zap.Error(err))
+		a.respondError(writer, ErrParseRequest, "decode request body failed")
+		return
+	}
+
+	result, err := a.clusterManager.GetNodeShards(context.Background(), nodeShardsRequest.ClusterName)
+	if err != nil {
+		log.Error("get node shards failed", zap.Error(err))
+		a.respondError(writer, ErrGetShardNodes, "get node shards failed")
 		return
 	}
 

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -8,7 +8,7 @@ var (
 	ErrParseRequest    = coderr.NewCodeError(coderr.BadRequest, "parse request params")
 	ErrDropTable       = coderr.NewCodeError(coderr.Internal, "drop table")
 	ErrRouteTable      = coderr.NewCodeError(coderr.Internal, "route table")
-	ErrGetShardNodes   = coderr.NewCodeError(coderr.Internal, "get shard nodes")
+	ErrGetNodeShards   = coderr.NewCodeError(coderr.Internal, "get node shards")
 	ErrCreateProcedure = coderr.NewCodeError(coderr.Internal, "create procedure")
 	ErrSubmitProcedure = coderr.NewCodeError(coderr.Internal, "submit procedure")
 	ErrGetCluster      = coderr.NewCodeError(coderr.Internal, "get cluster")

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -8,6 +8,7 @@ var (
 	ErrParseRequest    = coderr.NewCodeError(coderr.BadRequest, "parse request params")
 	ErrDropTable       = coderr.NewCodeError(coderr.Internal, "drop table")
 	ErrRouteTable      = coderr.NewCodeError(coderr.Internal, "route table")
+	ErrGetShardNodes   = coderr.NewCodeError(coderr.Internal, "get shard nodes")
 	ErrCreateProcedure = coderr.NewCodeError(coderr.Internal, "create procedure")
 	ErrSubmitProcedure = coderr.NewCodeError(coderr.Internal, "submit procedure")
 	ErrGetCluster      = coderr.NewCodeError(coderr.Internal, "get cluster")


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Fix the scheduling and failover bugs found in recent use.

# What changes are included in this PR?
* Add node state check in `TransferLeaderProcedure`.
* Support multi-node concurrent shard opening to speed up replay.
* Add `getShardNodes` interface.

# Are there any user-facing changes?
None.

# How does this change test
Pass existing unit tests.