### PR TITLE
fix: make create table idempotent

### DIFF
--- a/server/cluster/table_manager_test.go
+++ b/server/cluster/table_manager_test.go
@@ -191,7 +191,7 @@ func testCreateTable(ctx context.Context, re *require.Assertions, manager Manage
 ) {
 	c, err := manager.GetCluster(ctx, clusterName)
 	re.NoError(err)
-	table, err := c.CreateTable(ctx, CreateTableRequest{
+	table, _, err := c.CreateTable(ctx, CreateTableRequest{
 		ShardID:       shardID,
 		SchemaName:    schema,
 		TableName:     tableName,

--- a/server/coordinator/procedure/create_table_common_util.go
+++ b/server/coordinator/procedure/create_table_common_util.go
@@ -22,7 +22,8 @@ func CreateTableMetadata(ctx context.Context, c *cluster.Cluster, schemaName str
 		return cluster.CreateTableResult{}, errors.WithMessagef(ErrTableAlreadyExists, "create an existing table, schemaName:%s, tableName:%s", schemaName, tableName)
 	}
 
-	createTableResult, err := c.CreateTable(ctx, cluster.CreateTableRequest{
+	// TODO: Now we can't tell whether the table has been created or there is an error, openTableOnShard should return a specific error to indicate whether the table already exists.
+	createTableResult, _, err := c.CreateTable(ctx, cluster.CreateTableRequest{
 		ShardID:       shardID,
 		SchemaName:    schemaName,
 		TableName:     tableName,

--- a/server/coordinator/procedure/operation/split/split_test.go
+++ b/server/coordinator/procedure/operation/split/split_test.go
@@ -27,13 +27,13 @@ func TestSplit(t *testing.T) {
 	createTableNodeShard := getNodeShardsResult.NodeShards[0].ShardNode
 
 	// Create some tables in this shard.
-	createTableResult, err := c.CreateTable(ctx, cluster.CreateTableRequest{
+	createTableResult, _, err := c.CreateTable(ctx, cluster.CreateTableRequest{
 		ShardID:    createTableNodeShard.ID,
 		SchemaName: test.TestSchemaName,
 		TableName:  test.TestTableName0,
 	})
 	re.NoError(err)
-	_, err = c.CreateTable(ctx, cluster.CreateTableRequest{
+	_, _, err = c.CreateTable(ctx, cluster.CreateTableRequest{
 		ShardID:    createTableNodeShard.ID,
 		SchemaName: test.TestSchemaName,
 		TableName:  test.TestTableName1,


### PR DESCRIPTION
# Which issue does this PR close?
None.

# Rationale for this change
Fix the problem that when CeresDB fails to create a table and the metadata already exists, the table cannot be created repeatedly.

# What changes are included in this PR?
* Make `createTableMetadata` idempotent.

# Are there any user-facing changes?
User cloud retry creating table repeatedly when CeresDB fails to create a table.

# How does this change test
Pass existing unit tests.