### PR TITLE
refactor: implement failover based distributed etcd lock

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -478,6 +478,10 @@ func (c *Cluster) GetClusterState() storage.ClusterState {
 	return c.topologyManager.GetClusterState()
 }
 
+func (c *Cluster) GetClusterView() storage.ClusterView {
+	return c.topologyManager.GetClusterView()
+}
+
 func (c *Cluster) UpdateClusterView(ctx context.Context, state storage.ClusterState, shardNodes []storage.ShardNode) error {
 	if err := c.topologyManager.UpdateClusterView(ctx, state, shardNodes); err != nil {
 		return errors.WithMessage(err, "update cluster view")
@@ -491,6 +495,10 @@ func (c *Cluster) CreateShardViews(ctx context.Context, views []CreateShardView)
 	}
 
 	return nil
+}
+
+func (c *Cluster) GetShardViews() []storage.ShardView {
+	return c.topologyManager.GetShardViews()
 }
 
 // Initialize the cluster view and shard view of the cluster.

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -41,6 +41,7 @@ type Manager interface {
 
 	RegisterNode(ctx context.Context, clusterName string, registeredNode RegisteredNode) error
 	GetRegisteredNode(ctx context.Context, clusterName string, node string) (RegisteredNode, error)
+	ListRegisterNodes(ctx context.Context, clusterName string) ([]RegisteredNode, error)
 }
 
 type managerImpl struct {
@@ -221,6 +222,16 @@ func (m *managerImpl) GetRegisteredNode(_ context.Context, clusterName string, n
 	}
 
 	return registeredNode, nil
+}
+
+func (m *managerImpl) ListRegisterNodes(_ context.Context, clusterName string) ([]RegisteredNode, error) {
+	cluster, err := m.getCluster(clusterName)
+	if err != nil {
+		log.Error("get cluster", zap.Error(err), zap.String("clusterName", clusterName))
+		return nil, errors.WithMessage(err, "get cluster")
+	}
+
+	return cluster.GetRegisteredNodes(), nil
 }
 
 func (m *managerImpl) getCluster(clusterName string) (*Cluster, error) {

--- a/server/cluster/topology_manager.go
+++ b/server/cluster/topology_manager.go
@@ -134,16 +134,14 @@ func (m *TopologyManagerImpl) GetTableIDs(shardIDs []storage.ShardID, nodeName s
 	shardTableIDs := make(map[storage.ShardID]ShardTableIDs, len(shardIDs))
 	for _, shardID := range shardIDs {
 		for _, shardNode := range m.shardNodesMapping[shardID] {
-			if shardNode.NodeName == nodeName {
-				shardView := m.shardTablesMapping[shardID]
+			shardView := m.shardTablesMapping[shardID]
 
-				shardTableIDs[shardID] = ShardTableIDs{
-					ShardNode: shardNode,
-					TableIDs:  shardView.TableIDs,
-					Version:   shardView.Version,
-				}
-				break
+			shardTableIDs[shardID] = ShardTableIDs{
+				ShardNode: shardNode,
+				TableIDs:  shardView.TableIDs,
+				Version:   shardView.Version,
 			}
+			break
 		}
 	}
 

--- a/server/coordinator/node_picker.go
+++ b/server/coordinator/node_picker.go
@@ -1,0 +1,31 @@
+package coordinator
+
+import (
+	"context"
+	"crypto/rand"
+	"github.com/CeresDB/ceresmeta/server/cluster"
+	"github.com/pkg/errors"
+	"math/big"
+)
+
+type NodePicker interface {
+	PickNode(ctx context.Context, clusterName string) (cluster.RegisteredNode, error)
+}
+
+type RandomNodePicker struct {
+	clusterManager cluster.Manager
+}
+
+func (p *RandomNodePicker) PickNode(ctx context.Context, clusterName string) (cluster.RegisteredNode, error) {
+	nodes, err := p.clusterManager.ListRegisterNodes(ctx, clusterName)
+	if err != nil {
+		return cluster.RegisteredNode{}, err
+	}
+
+	selectNodeIndex, err := rand.Int(rand.Reader, big.NewInt(int64(len(nodes))))
+	if err != nil {
+		return cluster.RegisteredNode{}, errors.WithMessage(err, "generate random node index")
+	}
+
+	return nodes[selectNodeIndex.Int64()], nil
+}

--- a/server/coordinator/procedure/dml/createpartitiontable/create_partition_table.go
+++ b/server/coordinator/procedure/dml/createpartitiontable/create_partition_table.go
@@ -113,6 +113,21 @@ func (p *Procedure) Typ() procedure.Typ {
 	return procedure.CreatePartitionTable
 }
 
+func (p *Procedure) GetShardID() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetShardVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetClusterVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (p *Procedure) Start(ctx context.Context) error {
 	p.updateStateWithLock(procedure.StateRunning)
 

--- a/server/coordinator/procedure/dml/createtable/create_table.go
+++ b/server/coordinator/procedure/dml/createtable/create_table.go
@@ -155,6 +155,21 @@ func (p *Procedure) Typ() procedure.Typ {
 	return procedure.CreateTable
 }
 
+func (p *Procedure) GetShardID() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetShardVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetClusterVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (p *Procedure) Start(ctx context.Context) error {
 	p.updateState(procedure.StateRunning)
 

--- a/server/coordinator/procedure/dml/droppartitiontable/drop_partition_table.go
+++ b/server/coordinator/procedure/dml/droppartitiontable/drop_partition_table.go
@@ -96,6 +96,21 @@ func NewProcedure(req ProcedureRequest) *Procedure {
 	}
 }
 
+func (p *Procedure) GetShardID() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetShardVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetClusterVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (p *Procedure) ID() uint64 {
 	return p.id
 }

--- a/server/coordinator/procedure/dml/droptable/drop_table.go
+++ b/server/coordinator/procedure/dml/droptable/drop_table.go
@@ -185,6 +185,21 @@ type Procedure struct {
 	state procedure.State
 }
 
+func (p *Procedure) GetShardID() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetShardVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetClusterVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (p *Procedure) ID() uint64 {
 	return p.id
 }

--- a/server/coordinator/procedure/error.go
+++ b/server/coordinator/procedure/error.go
@@ -18,4 +18,5 @@ var (
 	ErrEmptyPartitionNames   = coderr.NewCodeError(coderr.Internal, "partition names is empty")
 	ErrDropTableResult       = coderr.NewCodeError(coderr.Internal, "length of shard not correct")
 	ErrPickShard             = coderr.NewCodeError(coderr.Internal, "pick shard failed")
+	ErrSubmitProcedure       = coderr.NewCodeError(coderr.Internal, "submit new procedure")
 )

--- a/server/coordinator/procedure/manager.go
+++ b/server/coordinator/procedure/manager.go
@@ -17,5 +17,6 @@ type Manager interface {
 	Submit(ctx context.Context, procedure Procedure) error
 	// Cancel procedure that has been submitted.
 	Cancel(ctx context.Context, procedureID uint64) error
+	// ListRunningProcedure return immutable procedures info.
 	ListRunningProcedure(ctx context.Context) ([]*Info, error)
 }

--- a/server/coordinator/procedure/manager_impl.go
+++ b/server/coordinator/procedure/manager_impl.go
@@ -5,6 +5,7 @@ package procedure
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
@@ -13,8 +14,9 @@ import (
 )
 
 const (
-	queueSize         = 10
-	metaListBatchSize = 100
+	queueSize                   = 10
+	metaListBatchSize           = 100
+	defaultProcedureExpiredTime = time.Second * 5
 )
 
 type ManagerImpl struct {
@@ -27,6 +29,13 @@ type ManagerImpl struct {
 	dispatch eventdispatch.Dispatch
 
 	procedureQueue chan Procedure
+
+	// There is only one procedure running for every shard.
+	// It will be removed when the procedure is finished or failed.
+	runningProcedures map[uint64]Procedure
+
+	// All procedure will be put into waiting queue first,
+	waitingProcedures map[uint64]WaitingProcedureQueue
 }
 
 func (m *ManagerImpl) Start(ctx context.Context) error {
@@ -37,7 +46,8 @@ func (m *ManagerImpl) Start(ctx context.Context) error {
 		return nil
 	}
 	m.procedureQueue = make(chan Procedure, queueSize)
-	go m.startProcedureWorker(ctx, m.procedureQueue)
+	go m.startProcedurePromote(ctx)
+	go m.startProcedureWorker(ctx)
 	err := m.retryAll(ctx)
 	if err != nil {
 		return errors.WithMessage(err, "retry all running procedure failed")
@@ -63,9 +73,8 @@ func (m *ManagerImpl) Stop(ctx context.Context) error {
 func (m *ManagerImpl) Submit(_ context.Context, procedure Procedure) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	m.procedures = append(m.procedures, procedure)
-	m.procedureQueue <- procedure
-	return nil
+
+	return m.waitingProcedures[procedure.ID()].Add(procedure)
 }
 
 func (m *ManagerImpl) Cancel(ctx context.Context, procedureID uint64) error {
@@ -123,14 +132,27 @@ func (m *ManagerImpl) retryAll(ctx context.Context) error {
 	return nil
 }
 
-func (m *ManagerImpl) startProcedureWorker(ctx context.Context, procedures <-chan Procedure) {
-	for procedure := range procedures {
-		err := procedure.Start(ctx)
-		if err != nil {
-			log.Error("procedure start failed", zap.Error(err))
+func (m *ManagerImpl) startProcedurePromote(ctx context.Context) {
+	for {
+		for shardID, old := range m.runningProcedures {
+			if old.State() == StateFailed || old.State() == StateFinished || old.State() == StateCancelled {
+				delete(m.runningProcedures, shardID)
+				new := m.promoteProcedure(ctx, shardID)
+				m.runningProcedures[shardID] = new
+			}
 		}
+	}
+}
 
-		m.removeProcedure(procedure.ID())
+func (m *ManagerImpl) startProcedureWorker(ctx context.Context) {
+	for _, procedure := range m.runningProcedures {
+		p := procedure
+		go func() {
+			err := p.Start(ctx)
+			if err != nil {
+				log.Error("procedure start failed", zap.Error(err))
+			}
+		}()
 	}
 }
 
@@ -159,6 +181,37 @@ func (m *ManagerImpl) retry(ctx context.Context, procedure Procedure) error {
 		return errors.WithMessagef(err, "start procedure failed, procedureID:%d", procedure.ID())
 	}
 	return nil
+}
+
+// Whether a waiting procedure could be running procedure.
+func (m *ManagerImpl) checkValid(procedure Procedure) bool {
+	return true
+}
+
+// Promote a waiting procedure to be a running procedure.
+func (m *ManagerImpl) promoteProcedure(ctx context.Context, shardID uint64) Procedure {
+	if m.runningProcedures[shardID] != nil {
+		log.Warn("current running procedure do not finish, could not promote waiting procedure", zap.Uint64("shardID", shardID))
+		return nil
+	}
+
+	// Get a waiting procedure, it has been sorted in queue.
+	queue := m.waitingProcedures[shardID]
+
+	for {
+		p := queue.Deque()
+		if p == nil {
+			return nil
+		}
+
+		if !m.checkValid(p) {
+			// This procedure is invalid, just cancel it.
+			p.Cancel(ctx)
+			continue
+		}
+
+		return p
+	}
 }
 
 // Load meta and restore procedure.

--- a/server/coordinator/procedure/operation/scatter/scatter.go
+++ b/server/coordinator/procedure/operation/scatter/scatter.go
@@ -203,6 +203,21 @@ type Procedure struct {
 	state procedure.State
 }
 
+func (p *Procedure) GetShardID() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetShardVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetClusterVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (p *Procedure) ID() uint64 {
 	return p.id
 }

--- a/server/coordinator/procedure/operation/split/split.go
+++ b/server/coordinator/procedure/operation/split/split.go
@@ -113,6 +113,21 @@ func (p *Procedure) Typ() procedure.Typ {
 	return procedure.Split
 }
 
+func (p *Procedure) GetShardID() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetShardVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetClusterVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (p *Procedure) Start(ctx context.Context) error {
 	p.updateStateWithLock(procedure.StateRunning)
 

--- a/server/coordinator/procedure/operation/split/split.go
+++ b/server/coordinator/procedure/operation/split/split.go
@@ -289,22 +289,22 @@ func createShardViewCallback(event *fsm.Event) {
 	//}
 }
 
-func updateShardTablesCallback(_ *fsm.Event) {
-	//request, err := procedure.GetRequestFromEvent[callbackRequest](event)
-	//if err != nil {
-	//	procedure.CancelEventWithLog(event, err, "get request from event")
-	//	return
-	//}
-	//
-	//if err := request.cluster.MigrateTable(request.ctx, cluster.MigrateTableRequest{
-	//	SchemaName: request.schemaName,
-	//	TableNames: request.tableNames,
-	//	OldShardID: request.shardID,
-	//	NewShardID: request.newShardID,
-	//}); err != nil {
-	//	procedure.CancelEventWithLog(event, err, "update shard tables")
-	//	return
-	//}
+func updateShardTablesCallback(event *fsm.Event) {
+	request, err := procedure.GetRequestFromEvent[callbackRequest](event)
+	if err != nil {
+		procedure.CancelEventWithLog(event, err, "get request from event")
+		return
+	}
+
+	if err := request.cluster.MigrateTable(request.ctx, cluster.MigrateTableRequest{
+		SchemaName: request.schemaName,
+		TableNames: request.tableNames,
+		OldShardID: request.shardID,
+		NewShardID: request.newShardID,
+	}); err != nil {
+		procedure.CancelEventWithLog(event, err, "update shard tables")
+		return
+	}
 }
 
 func openShardCallback(event *fsm.Event) {

--- a/server/coordinator/procedure/operation/split/split.go
+++ b/server/coordinator/procedure/operation/split/split.go
@@ -271,39 +271,40 @@ func openNewShardMetadataCallback(event *fsm.Event) {
 	}
 }
 
+// Does shardView need to be retained?
 func createShardViewCallback(event *fsm.Event) {
-	request, err := procedure.GetRequestFromEvent[callbackRequest](event)
-	if err != nil {
-		procedure.CancelEventWithLog(event, err, "get request from event")
-		return
-	}
-	ctx := request.ctx
-
-	if err := request.cluster.CreateShardViews(ctx, []cluster.CreateShardView{{
-		ShardID: request.newShardID,
-		Tables:  []storage.TableID{},
-	}}); err != nil {
-		procedure.CancelEventWithLog(event, err, "create shard views")
-		return
-	}
+	//request, err := procedure.GetRequestFromEvent[callbackRequest](event)
+	//if err != nil {
+	//	procedure.CancelEventWithLog(event, err, "get request from event")
+	//	return
+	//}
+	//ctx := request.ctx
+	//
+	//if err := request.cluster.CreateShardViews(ctx, []cluster.CreateShardView{{
+	//	ShardID: request.newShardID,
+	//	Tables:  []storage.TableID{},
+	//}}); err != nil {
+	//	procedure.CancelEventWithLog(event, err, "create shard views")
+	//	return
+	//}
 }
 
-func updateShardTablesCallback(event *fsm.Event) {
-	request, err := procedure.GetRequestFromEvent[callbackRequest](event)
-	if err != nil {
-		procedure.CancelEventWithLog(event, err, "get request from event")
-		return
-	}
-
-	if err := request.cluster.MigrateTable(request.ctx, cluster.MigrateTableRequest{
-		SchemaName: request.schemaName,
-		TableNames: request.tableNames,
-		OldShardID: request.shardID,
-		NewShardID: request.newShardID,
-	}); err != nil {
-		procedure.CancelEventWithLog(event, err, "update shard tables")
-		return
-	}
+func updateShardTablesCallback(_ *fsm.Event) {
+	//request, err := procedure.GetRequestFromEvent[callbackRequest](event)
+	//if err != nil {
+	//	procedure.CancelEventWithLog(event, err, "get request from event")
+	//	return
+	//}
+	//
+	//if err := request.cluster.MigrateTable(request.ctx, cluster.MigrateTableRequest{
+	//	SchemaName: request.schemaName,
+	//	TableNames: request.tableNames,
+	//	OldShardID: request.shardID,
+	//	NewShardID: request.newShardID,
+	//}); err != nil {
+	//	procedure.CancelEventWithLog(event, err, "update shard tables")
+	//	return
+	//}
 }
 
 func openShardCallback(event *fsm.Event) {

--- a/server/coordinator/procedure/operation/transferleader/transfer_leader.go
+++ b/server/coordinator/procedure/operation/transferleader/transfer_leader.go
@@ -129,6 +129,21 @@ func (p *Procedure) Typ() procedure.Typ {
 	return procedure.TransferLeader
 }
 
+func (p *Procedure) GetShardID() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetShardVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *Procedure) GetClusterVersion() uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (p *Procedure) Start(ctx context.Context) error {
 	p.updateStateWithLock(procedure.StateRunning)
 

--- a/server/coordinator/procedure/procedure.go
+++ b/server/coordinator/procedure/procedure.go
@@ -48,6 +48,12 @@ type Procedure interface {
 
 	// State of the procedure. Retrieve the state of this procedure.
 	State() State
+
+	// GetShardID return the shardID associated with this procedure.
+	// It may be multiple shardIDs.
+	GetShardID() []uint64
+
+	GetShardVersion() uint64
 }
 
 // Info is used to provide immutable description procedure information.

--- a/server/coordinator/procedure/procedure.go
+++ b/server/coordinator/procedure/procedure.go
@@ -19,6 +19,7 @@ const (
 type Typ uint
 
 const (
+	// Cluster Operation
 	Create Typ = iota
 	Delete
 	TransferLeader
@@ -26,6 +27,8 @@ const (
 	Split
 	Merge
 	Scatter
+
+	// DDL
 	CreateTable
 	DropTable
 	CreatePartitionTable
@@ -50,10 +53,14 @@ type Procedure interface {
 	State() State
 
 	// GetShardID return the shardID associated with this procedure.
-	// It may be multiple shardIDs.
-	GetShardID() []uint64
+	// TODO: Some procedure may be associated with multi shards, it should be supported.
+	GetShardID() uint64
 
 	GetShardVersion() uint64
+
+	// GetClusterVersion return the cluster version when the procedure is created.
+	// When performing cluster operation, it is necessary to ensure cluster version consistency.
+	GetClusterVersion() uint64
 }
 
 // Info is used to provide immutable description procedure information.
@@ -61,4 +68,14 @@ type Info struct {
 	ID    uint64
 	Typ   Typ
 	State State
+}
+
+// IsDDL used to check procedure operation type.
+// Procedure only has two operation type: 1. DDL  2. Cluster Operation
+// We need ensure shardVersion consist when it is DDL and cluster version is consist when it is cluster operation.
+func IsDDL(p Procedure) bool {
+	if p.Typ() == CreateTable || p.Typ() == DropTable || p.Typ() == CreatePartitionTable || p.Typ() == DropPartitionTable {
+		return true
+	}
+	return false
 }

--- a/server/coordinator/procedure/waiting_procedure_queue.go
+++ b/server/coordinator/procedure/waiting_procedure_queue.go
@@ -5,7 +5,7 @@ import "time"
 type WaitingProcedureQueue interface {
 	Add(procedure Procedure) error
 
-	Deque() (error, Procedure)
+	Deque() Procedure
 }
 
 // WaitingProcedureQueueImpl is used to manager procedures on specify shard.

--- a/server/coordinator/procedure/waiting_procedure_queue.go
+++ b/server/coordinator/procedure/waiting_procedure_queue.go
@@ -1,0 +1,22 @@
+package procedure
+
+import "time"
+
+type WaitingProcedureQueue interface {
+	Add(procedure Procedure) error
+
+	Deque() (error, Procedure)
+}
+
+// WaitingProcedureQueueImpl is used to manager procedures on specify shard.
+type WaitingProcedureQueueImpl struct {
+	shardID    uint64
+	procedures []Procedure
+
+	maxLength   uint64
+	expiredTime time.Duration
+}
+
+func (q WaitingProcedureQueueImpl) expired() {
+
+}

--- a/server/coordinator/scheduler.go
+++ b/server/coordinator/scheduler.go
@@ -4,6 +4,8 @@ package coordinator
 
 import (
 	"context"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
 	"sync"
 	"time"
 
@@ -13,13 +15,13 @@ import (
 	"github.com/CeresDB/ceresmeta/server/coordinator/eventdispatch"
 	"github.com/CeresDB/ceresmeta/server/coordinator/procedure"
 	"github.com/CeresDB/ceresmeta/server/storage"
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
-	heartbeatCheckInterval = 10 * time.Second
+	heartbeatCheckInterval     = 10 * time.Second
+	failoverRetryMaxSize       = 3
+	failoverRetryInterval      = 10 * time.Second
+	heartbeatChannelBufferSize = 1000
 )
 
 type Scheduler struct {
@@ -33,15 +35,24 @@ type Scheduler struct {
 	dispatch         eventdispatch.Dispatch
 
 	checkNodeTicker *time.Ticker
+
+	ShardWatch ShardWatch
+
+	heartbeatChan chan *metaservicepb.NodeInfo
 }
 
-func NewScheduler(clusterManager cluster.Manager, procedureManager procedure.Manager, procedureFactory *Factory, dispatch eventdispatch.Dispatch) *Scheduler {
+func NewScheduler(clusterManager cluster.Manager, procedureManager procedure.Manager, procedureFactory *Factory, dispatch eventdispatch.Dispatch, rootPath string, etcdClient *clientv3.Client) *Scheduler {
 	return &Scheduler{
 		running:          false,
 		clusterManager:   clusterManager,
 		procedureManager: procedureManager,
 		procedureFactory: procedureFactory,
 		dispatch:         dispatch,
+		ShardWatch: ShardWatch{
+			rootPath:   rootPath,
+			etcdClient: etcdClient,
+		},
+		heartbeatChan: make(chan *metaservicepb.NodeInfo, heartbeatChannelBufferSize),
 	}
 }
 
@@ -57,7 +68,33 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	s.running = true
 	ticker := time.NewTicker(heartbeatCheckInterval)
 	s.checkNodeTicker = ticker
-	go s.checkNode(ctx, ticker)
+	if err := s.ShardWatch.registerWatch(ctx); err != nil {
+		return err
+	}
+	s.ShardWatch.registerCallback(func(shardID storage.ShardID, nodeName string, eventType ShardEventType) error {
+		switch eventType {
+		case eventDelete:
+			for retrySize := 0; retrySize < failoverRetryMaxSize; retrySize++ {
+				err := s.failover(shardID, nodeName)
+				if err != nil {
+					// if failover failed, maybe is the node info is expired, try to retry after a while.
+					log.Error("failover failed", zap.Error(err), zap.Int("retry size", retrySize))
+					time.Sleep(failoverRetryInterval)
+				}
+			}
+		case eventPut:
+			// Do nothing
+		}
+		return nil
+	})
+
+	go func() {
+		err := s.ProcessHeartbeat(ctx)
+		if err != nil {
+			log.Error("process heartbeat", zap.Error(err))
+		}
+	}()
+
 	return nil
 }
 
@@ -66,112 +103,60 @@ func (s *Scheduler) Stop(_ context.Context) error {
 	return nil
 }
 
-func (s *Scheduler) ProcessHeartbeat(_ context.Context, _ *metaservicepb.NodeInfo) {
-	// Check node version and update to latest.
+// ReceiveHeartbeat only receive heartbeat and put it into channel.
+// If process heartbeat failed, what should we do?
+func (s *Scheduler) ReceiveHeartbeat(_ context.Context, nodeInfo *metaservicepb.NodeInfo) {
+	s.heartbeatChan <- nodeInfo
 }
 
-func (s *Scheduler) checkNode(ctx context.Context, ticker *time.Ticker) {
-	for t := range ticker.C {
-		clusters, err := s.clusterManager.ListClusters(ctx)
+func (s *Scheduler) ProcessHeartbeat(ctx context.Context) error {
+	for nodeInfo := range s.heartbeatChan {
+		c, err := s.clusterManager.GetCluster(ctx, "defaultCluster")
 		if err != nil {
-			log.Error("list clusters failed", zap.Error(err))
-			continue
-		}
-		for _, c := range clusters {
-			nodes := c.GetRegisteredNodes()
-			nodeShards, err := c.GetNodeShards(ctx)
-			if err != nil {
-				log.Error("get node shards failed", zap.Error(err))
-				continue
-			}
-			nodeShardsMapping := map[string][]cluster.ShardInfo{}
-			for _, nodeShard := range nodeShards.NodeShards {
-				_, exists := nodeShardsMapping[nodeShard.ShardNode.NodeName]
-				if !exists {
-					nodeShardsMapping[nodeShard.ShardNode.NodeName] = []cluster.ShardInfo{}
-				}
-				nodeShardsMapping[nodeShard.ShardNode.NodeName] = append(nodeShardsMapping[nodeShard.ShardNode.NodeName], cluster.ShardInfo{
-					ID:      nodeShard.ShardNode.ID,
-					Role:    nodeShard.ShardNode.ShardRole,
-					Version: nodeShard.ShardInfo.Version,
-				})
-			}
-			s.processNodes(ctx, nodes, t, nodeShardsMapping)
-		}
-	}
-}
-
-func (s *Scheduler) processNodes(ctx context.Context, nodes []cluster.RegisteredNode, t time.Time, nodeShardsMapping map[string][]cluster.ShardInfo) {
-	group := new(errgroup.Group)
-	for _, node := range nodes {
-		// Refer to: https://go.dev/doc/faq#closures_and_goroutines
-		node := node
-		// Determines whether node is expired.
-		if !node.IsExpired(uint64(t.Unix()), cluster.HeartbeatKeepAliveIntervalSec) {
-			// Shard versions of CeresDB and CeresMeta may be inconsistent. And close extra shards and open missing shards if so.
-			group.Go(func() error {
-				realShards := node.ShardInfos
-				expectShards := nodeShardsMapping[node.Node.Name]
-				err := s.applyMetadataShardInfo(ctx, node.Node.Name, realShards, expectShards)
-				if err != nil {
-					log.Error("apply metadata failed", zap.Error(err))
-				}
-				return nil
-			})
-		}
-	}
-	if err := group.Wait(); err != nil {
-		log.Error("error group wait", zap.Error(err))
-	}
-}
-
-// applyMetadataShardInfo verify shardInfo in heartbeats and metadata, they are forcibly synchronized to the latest version if they are inconsistent.
-// TODO: Encapsulate the following logic as a standalone ApplyProcedure.
-func (s *Scheduler) applyMetadataShardInfo(ctx context.Context, node string, realShards []cluster.ShardInfo, expectShards []cluster.ShardInfo) error {
-	realShardInfoMapping := make(map[storage.ShardID]cluster.ShardInfo, len(realShards))
-	expectShardInfoMapping := make(map[storage.ShardID]cluster.ShardInfo, len(expectShards))
-	for _, realShard := range realShards {
-		realShardInfoMapping[realShard.ID] = realShard
-	}
-	for _, expectShard := range expectShards {
-		expectShardInfoMapping[expectShard.ID] = expectShard
-	}
-
-	// This includes the following cases:
-	for _, expectShard := range expectShards {
-		realShard, exists := realShardInfoMapping[expectShard.ID]
-
-		// 1. Shard exists in metadata and not exists in node, reopen lack shards on node.
-		if !exists {
-			log.Info("Shard exists in metadata and not exists in node, reopen lack shards on node.", zap.String("node", node), zap.Uint32("shardID", uint32(expectShard.ID)))
-			if err := s.dispatch.OpenShard(ctx, node, eventdispatch.OpenShardRequest{Shard: expectShard}); err != nil {
-				return errors.WithMessagef(err, "reopen shard failed, shardInfo:%d", expectShard.ID)
-			}
-			continue
+			log.Error("get cluster", zap.Error(err))
+			return err
 		}
 
-		// 2. Shard exists in both metadata and node, versions are consistent, do nothing.
-		if realShard.Version == expectShard.Version {
-			continue
+		if c.GetClusterState() != storage.ClusterStateStable {
+			return nil
 		}
 
-		// 3. Shard exists in both metadata and node, versions are inconsistent, close and reopen invalid shard on node.
-		// TODO: In the current implementation mode, the scheduler will close and reopen Shard during the table creation process, which will cause Shard to be unavailable for a short time, temporarily close the detection of version inconsistency, and then open it after repair.
-		// Related issue: https://github.com/CeresDB/ceresmeta/issues/140
-		log.Info("Shard exists in both metadata and node, versions are inconsistent, close and reopen invalid shard on node.", zap.String("node", node), zap.Uint32("shardID", uint32(expectShard.ID)))
-	}
-
-	// 4. Shard exists in node and not exists in metadata, close extra shard on node.
-	for _, realShard := range realShards {
-		_, ok := expectShardInfoMapping[realShard.ID]
-		if ok {
-			continue
-		}
-		log.Info("Shard exists in node and not exists in metadata, close extra shard on node.", zap.String("node", node), zap.Uint32("shardID", uint32(realShard.ID)))
-		if err := s.dispatch.CloseShard(ctx, node, eventdispatch.CloseShardRequest{ShardID: uint32(realShard.ID)}); err != nil {
-			return errors.WithMessagef(err, "close shard failed, shardInfo:%d", realShard.ID)
+		if err := c.UpdateTopologyByNodeInfo(ctx, nodeInfo); err != nil {
+			log.Error("update topology by node info", zap.Error(err))
+			return err
 		}
 	}
-
 	return nil
+}
+
+func (s *Scheduler) failover(shardID storage.ShardID, nodeName string) error {
+	// Pick Node and transfer leader.
+	ctx := context.Background()
+	nodes, err := s.clusterManager.ListRegisterNodes(ctx, "defaultCluster")
+	if err != nil {
+		return err
+	}
+	// Select another node to open shard.
+	// TODO: replace the hard code with node picker, and try to retry transfer leader with another node when it failed.
+	var newLeaderNode string
+	for _, node := range nodes {
+		if node.Node.Name != nodeName {
+			newLeaderNode = node.Node.Name
+		}
+	}
+	if len(newLeaderNode) == 0 {
+		return procedure.ErrNodeNumberNotEnough
+	}
+
+	p, err := s.procedureFactory.CreateTransferLeaderProcedure(ctx, TransferLeaderRequest{
+		ClusterName:       "defaultCluster",
+		ShardID:           shardID,
+		OldLeaderNodeName: nodeName,
+		NewLeaderNodeName: newLeaderNode,
+		ClusterVersion:    0,
+	})
+	if err != nil {
+		return err
+	}
+	return s.procedureManager.Submit(ctx, p)
 }

--- a/server/coordinator/scheduler/assign_shard_scheduler.go
+++ b/server/coordinator/scheduler/assign_shard_scheduler.go
@@ -1,5 +1,55 @@
 package scheduler
 
+import (
+	"context"
+	"github.com/CeresDB/ceresmeta/server/coordinator"
+	"github.com/CeresDB/ceresmeta/server/coordinator/procedure"
+	"github.com/CeresDB/ceresmeta/server/storage"
+)
+
 // AssignShardScheduler used to assigning shards without nodes.
 type AssignShardScheduler struct {
+	clusterName string
+	factory     coordinator.Factory
+	nodePicker  coordinator.NodePicker
+}
+
+func (a AssignShardScheduler) Schedule(ctx context.Context, clusterView storage.ClusterView, shardViews []storage.ShardView) (error, procedure.Procedure, string) {
+	if clusterView.State != storage.ClusterStateStable {
+		return nil, nil, ""
+	}
+
+	// Check if there is a shard without node mapping.
+	for _, shardView := range shardViews {
+		exists, _ := contains(shardView.ShardID, clusterView.ShardNodes)
+		if exists {
+			continue
+		}
+		newLeaderNode, err := a.nodePicker.PickNode(ctx, a.clusterName)
+		if err != nil {
+			return err, nil, ""
+		}
+		// Shard exists and ShardNode not exists.
+		p, err := a.factory.CreateTransferLeaderProcedure(ctx, coordinator.TransferLeaderRequest{
+			ClusterName:       a.clusterName,
+			ShardID:           shardView.ShardID,
+			OldLeaderNodeName: "",
+			NewLeaderNodeName: newLeaderNode.Node.Name,
+			ClusterVersion:    clusterView.Version,
+		})
+		if err != nil {
+			return err, p, ""
+		}
+		return nil, p, ""
+	}
+	return nil, nil, ""
+}
+
+func contains(shardID storage.ShardID, shardNodes []storage.ShardNode) (bool, storage.ShardNode) {
+	for _, shardNode := range shardNodes {
+		if shardID == shardNode.ID {
+			return true, shardNode
+		}
+	}
+	return false, storage.ShardNode{}
 }

--- a/server/coordinator/scheduler/assign_shard_scheduler.go
+++ b/server/coordinator/scheduler/assign_shard_scheduler.go
@@ -1,0 +1,5 @@
+package scheduler
+
+// AssignShardScheduler used to assigning shards without nodes.
+type AssignShardScheduler struct {
+}

--- a/server/coordinator/scheduler/failover_shard_scheduler.go
+++ b/server/coordinator/scheduler/failover_shard_scheduler.go
@@ -1,0 +1,1 @@
+package scheduler

--- a/server/coordinator/scheduler/scheduler.go
+++ b/server/coordinator/scheduler/scheduler.go
@@ -1,0 +1,11 @@
+package scheduler
+
+import (
+	"context"
+	"github.com/CeresDB/ceresmeta/server/coordinator/procedure"
+	"github.com/CeresDB/ceresmeta/server/storage"
+)
+
+type Scheduler interface {
+	Schedule(ctx context.Context, clusterView storage.ClusterView, shardViews []storage.ShardView) (error, procedure.Procedure, string)
+}

--- a/server/coordinator/scheduler/scheduler_manager.go
+++ b/server/coordinator/scheduler/scheduler_manager.go
@@ -1,0 +1,73 @@
+package scheduler
+
+import (
+	"context"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/CeresDB/ceresmeta/server/coordinator/procedure"
+	"github.com/CeresDB/ceresmeta/server/storage"
+	"go.uber.org/zap"
+	"sync"
+)
+
+// Manager used to manage schedulers.
+// Each registered scheduler will generate a procedure if the cluster s
+type Manager interface {
+	RegisterScheduler(scheduler Scheduler)
+
+	ListScheduler() []Scheduler
+
+	// Scheduler will be called when received new heartbeat, every scheduler register in schedulerManager will be
+	// Scheduler cloud be schedule with fix time interval or heartbeat.
+	Scheduler(clusterView storage.ClusterView) []procedure.Procedure
+}
+
+type ManagerImpl struct {
+	lock               sync.RWMutex
+	registerSchedulers []Scheduler
+
+	procedureManager procedure.Manager
+
+	heartbeatChan chan *metaservicepb.NodeInfo
+}
+
+func (m *ManagerImpl) Start(ctx context.Context) error {
+	go func() {
+		// Get latest clusterView from heartbeat.
+
+		// Get lateset shardViews from metadata
+		m.Scheduler(ctx, nil, nil)
+	}()
+
+	return nil
+}
+
+func (m *ManagerImpl) RegisterScheduler(scheduler Scheduler) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	log.Info("register new scheduler", zap.Int("schedulerLen", len(m.registerSchedulers)))
+	m.registerSchedulers = append(m.registerSchedulers, scheduler)
+}
+
+func (m *ManagerImpl) ListScheduler() []Scheduler {
+	m.lock.RLock()
+	m.lock.RUnlock()
+
+	return m.registerSchedulers
+}
+
+func (m *ManagerImpl) Scheduler(ctx context.Context, clusterView storage.ClusterView, shardViews []storage.ShardView) []procedure.Procedure {
+	for _, scheduler := range m.registerSchedulers {
+		log.Info("scheduler start")
+		err, p, desc := scheduler.Schedule(ctx, clusterView, shardViews)
+		if err != nil {
+			log.Info("scheduler new procedure", zap.String("desc", desc))
+			err := m.procedureManager.Submit(ctx, p)
+			if err != nil {
+				log.Error("scheduler submit new procedure", zap.Uint64("ProcedureID", p.ID()), zap.Error(err))
+			}
+		}
+	}
+	return nil
+}

--- a/server/coordinator/watch.go
+++ b/server/coordinator/watch.go
@@ -1,0 +1,73 @@
+package coordinator
+
+import (
+	"context"
+	"fmt"
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/CeresDB/ceresmeta/server/storage"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+	"strconv"
+	"strings"
+)
+
+type ShardEventType uint64
+
+const (
+	shardPath                  = "shards"
+	eventDelete ShardEventType = 0
+	eventPut                   = 1
+)
+
+type ShardWatch struct {
+	rootPath      string
+	etcdClient    *clientv3.Client
+	eventCallback func(shardID storage.ShardID, nodeName string, eventType ShardEventType) error
+}
+
+func (w *ShardWatch) registerCallback(eventCallback func(shardID storage.ShardID, nodeName string, eventType ShardEventType) error) {
+	w.eventCallback = eventCallback
+}
+
+func (w *ShardWatch) registerWatch(ctx context.Context) error {
+	shardsKeyPath := strings.Join([]string{w.rootPath, shardPath}, "/")
+	log.Info("register shard watch", zap.String("watchPath", shardsKeyPath))
+	go func() {
+		respChan := w.etcdClient.Watch(ctx, shardsKeyPath, clientv3.WithPrefix(), clientv3.WithPrevKV())
+		for resp := range respChan {
+			for _, event := range resp.Events {
+				if err := w.processEvent(event); err != nil {
+					log.Error("process event", zap.Error(err))
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+func (w *ShardWatch) processEvent(event *clientv3.Event) error {
+	switch event.Type {
+	// DELETE means shard lease is expired,
+	case mvccpb.DELETE:
+		pathList := strings.Split(string(event.Kv.Key), "/")
+		shardID, err := strconv.ParseUint(pathList[len(pathList)-1], 10, 64)
+		if err != nil {
+			return err
+		}
+		oldLeader := string(event.PrevKv.Value)
+		log.Info("receive delete event", zap.String("preKV", fmt.Sprintf("%v", event.PrevKv)), zap.String("event", fmt.Sprintf("%v", event)), zap.Uint64("shardID", shardID), zap.String("oldLeader", oldLeader))
+		return w.eventCallback(storage.ShardID(shardID), oldLeader, eventDelete)
+	// PUT means new leader is elected.
+	case mvccpb.PUT:
+		pathList := strings.Split(string(event.Kv.Key), "/")
+		shardID, err := strconv.ParseUint(pathList[len(pathList)-1], 10, 64)
+		if err != nil {
+			return err
+		}
+		newLeader := string(event.Kv.Value)
+		log.Info("receive put event", zap.String("event", fmt.Sprintf("%v", event)), zap.Uint64("shardID", shardID), zap.String("oldLeader", newLeader))
+		return w.eventCallback(storage.ShardID(shardID), newLeader, eventPut)
+	}
+	return nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"github.com/CeresDB/ceresmeta/server/coordinator/scheduler"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -50,6 +51,8 @@ type Server struct {
 	procedureManager procedure.Manager
 	// scheduler schedule procedure for all cluster.
 	scheduler *coordinator.Scheduler
+	// schedulerManager manager schedulers for all cluster.
+	schedulerManager scheduler.Manager
 
 	// member describes membership in ceresmeta cluster.
 	member  *member.Member
@@ -184,6 +187,7 @@ func (srv *Server) startServer(_ context.Context) error {
 	procedureFactory := coordinator.NewFactory(id.NewAllocatorImpl(srv.etcdCli, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage, manager, srv.cfg.DefaultPartitionTableProportionOfNodes)
 	srv.procedureFactory = procedureFactory
 	srv.scheduler = coordinator.NewScheduler(manager, procedureManager, procedureFactory, dispatch, srv.cfg.StorageRootPath, srv.etcdCli)
+	srv.schedulerManager = scheduler.NewManager(procedureManager, srv.clusterManager)
 
 	api := http.NewAPI(procedureManager, procedureFactory, manager, http.NewForwardClient(srv.member, srv.cfg.HTTPPort))
 	httpService := http.NewHTTPService(srv.cfg.HTTPPort, time.Second*10, time.Second*10, api.NewAPIRouter())
@@ -260,22 +264,26 @@ func (srv *Server) createDefaultCluster(ctx context.Context) error {
 		} else {
 			log.Info("create default cluster succeed", zap.String("cluster", defaultCluster.Name()))
 		}
-		// Create and submit scatter procedure for default cluster.
-		shardIDs := make([]storage.ShardID, 0, defaultCluster.GetTotalShardNum())
-		for i := uint32(0); i < defaultCluster.GetTotalShardNum(); i++ {
-			shardID, err := defaultCluster.AllocShardID(ctx)
-			if err != nil {
-				return errors.WithMessage(err, "alloc shard id failed")
+		// Create ShardView
+		if defaultCluster.GetClusterState() == storage.ClusterStateEmpty {
+			var createShardViews []cluster.CreateShardView
+			for i := uint32(0); i < defaultCluster.GetTotalShardNum(); i++ {
+				shardID, err := defaultCluster.AllocShardID(ctx)
+				if err != nil {
+					return errors.WithMessage(err, "alloc shard id failed")
+				}
+				createShardViews = append(createShardViews, cluster.CreateShardView{
+					ShardID: storage.ShardID(shardID),
+					Tables:  []storage.TableID{},
+				})
 			}
-			shardIDs = append(shardIDs, storage.ShardID(shardID))
-		}
-		scatterRequest := coordinator.ScatterRequest{Cluster: defaultCluster, ShardIDs: shardIDs}
-		scatterProcedure, err := srv.procedureFactory.CreateScatterProcedure(ctx, scatterRequest)
-		if err != nil {
-			return errors.WithMessage(err, "create scatter procedure failed")
-		}
-		if err := srv.procedureManager.Submit(ctx, scatterProcedure); err != nil {
-			return errors.WithMessage(err, "submit scatter procedure failed")
+			if err := defaultCluster.CreateShardViews(ctx, createShardViews); err != nil {
+				log.Error("create default shard views failed", zap.Error(err))
+			}
+			if err := defaultCluster.UpdateClusterView(ctx, storage.ClusterStateStable, []storage.ShardNode{}); err != nil {
+				log.Error("update cluster view failed", zap.Error(err))
+			}
+			log.Info("create shard view finish")
 		}
 	}
 	return nil
@@ -330,6 +338,9 @@ func (c *leadershipEventCallbacks) AfterElected(ctx context.Context) {
 	if err := c.srv.scheduler.Start(ctx); err != nil {
 		panic(fmt.Sprintf("procedure scheduler fail to start, err:%v", err))
 	}
+	if err := c.srv.schedulerManager.Start(ctx); err != nil {
+		panic(fmt.Sprintf("scheduler manager fail to start, err:%v", err))
+	}
 }
 
 func (c *leadershipEventCallbacks) BeforeTransfer(ctx context.Context) {
@@ -342,5 +353,8 @@ func (c *leadershipEventCallbacks) BeforeTransfer(ctx context.Context) {
 	}
 	if err := c.srv.scheduler.Stop(ctx); err != nil {
 		panic(fmt.Sprintf("procedure scheduler fail to stop, err:%v", err))
+	}
+	if err := c.srv.schedulerManager.Stop(ctx); err != nil {
+		panic(fmt.Sprintf("scheduler manager fail to stop, err:%v", err))
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -183,7 +183,7 @@ func (srv *Server) startServer(_ context.Context) error {
 	dispatch := eventdispatch.NewDispatchImpl()
 	procedureFactory := coordinator.NewFactory(id.NewAllocatorImpl(srv.etcdCli, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage, manager, srv.cfg.DefaultPartitionTableProportionOfNodes)
 	srv.procedureFactory = procedureFactory
-	srv.scheduler = coordinator.NewScheduler(manager, procedureManager, procedureFactory, dispatch)
+	srv.scheduler = coordinator.NewScheduler(manager, procedureManager, procedureFactory, dispatch, srv.cfg.StorageRootPath, srv.etcdCli)
 
 	api := http.NewAPI(procedureManager, procedureFactory, manager, http.NewForwardClient(srv.member, srv.cfg.HTTPPort))
 	httpService := http.NewHTTPService(srv.cfg.HTTPPort, time.Second*10, time.Second*10, api.NewAPIRouter())
@@ -307,6 +307,10 @@ func (srv *Server) GetProcedureFactory() *coordinator.Factory {
 
 func (srv *Server) GetProcedureManager() procedure.Manager {
 	return srv.procedureManager
+}
+
+func (srv *Server) GetScheduler() *coordinator.Scheduler {
+	return srv.scheduler
 }
 
 type leadershipEventCallbacks struct {

--- a/server/service/grpc/service.go
+++ b/server/service/grpc/service.go
@@ -45,6 +45,7 @@ type Handler interface {
 	GetLeader(ctx context.Context) (*member.GetLeaderResp, error)
 	GetProcedureFactory() *coordinator.Factory
 	GetProcedureManager() procedure.Manager
+	GetScheduler() *coordinator.Scheduler
 
 	// TODO: define the methods for handling other grpc requests.
 }

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -107,7 +107,6 @@ type CreateShardViewsRequest struct {
 
 type ListShardViewsRequest struct {
 	ClusterID ClusterID
-	ShardIDs  []ShardID
 }
 
 type ListShardViewsResult struct {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 In order to ensure that user data in distributed mode will not be lost, we need a mechanism to ensure that CeresDB will not have multiple leader shard under any circumstances. `etcd` lock has been added in https://github.com/CeresDB/ceresdb/pull/706 , we refactor scheduler to implement failover based `etcd` distributed lock.


# What changes are included in this PR?
* Add shard watcher to get notify when shard lock is expired.
* Refactor scheduler module, add shard lock delete callback to implement auto failover. 


# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests and integration tests.