### PR TITLE
refactor: implement failover based distributed etcd lock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
-	github.com/CeresDB/ceresdbproto/golang v0.0.0-20230116070525-9430fe7d3219
+	github.com/CeresDB/ceresdbproto/golang v0.0.0-20230330101212-9add015b62cf
 	github.com/axw/gocov v1.1.0
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,16 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/CeresDB/ceresdbproto v1.0.1-0.20230330080500-1c3bf4e803ef h1:uWHypLA/6JxWGMYY/ohQgQq9j9CgMOJaQTnh3YErQCQ=
+github.com/CeresDB/ceresdbproto v1.0.1-0.20230330080500-1c3bf4e803ef/go.mod h1:6qWvbMz3dvjcyKVZkg1L/yKb6OrD8r+/rk5Q1GWhyWQ=
+github.com/CeresDB/ceresdbproto v1.0.1-0.20230330101212-9add015b62cf h1:RZqP97cwSEW1bg0K/cB9jfwXjY7ykiEd25hl6YgzlQY=
+github.com/CeresDB/ceresdbproto v1.0.1-0.20230330101212-9add015b62cf/go.mod h1:6qWvbMz3dvjcyKVZkg1L/yKb6OrD8r+/rk5Q1GWhyWQ=
 github.com/CeresDB/ceresdbproto/golang v0.0.0-20230116070525-9430fe7d3219 h1:xI3o/UcsSX0S15+NXhhOnoY0tNvlxgBo3g1inXxhmrU=
 github.com/CeresDB/ceresdbproto/golang v0.0.0-20230116070525-9430fe7d3219/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20230330080500-1c3bf4e803ef h1:LkT/saqReicelzVPfUcF23kEkJ14cWMi4LBaQ0X/ag8=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20230330080500-1c3bf4e803ef/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20230330101212-9add015b62cf h1:WOLpPZuC5azSCxEyiZ236PMxUXgluGM7u8PwIK6yLXA=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20230330101212-9add015b62cf/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/server/coordinator/watch/watch.go
+++ b/server/coordinator/watch/watch.go
@@ -1,0 +1,131 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package coordinator
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	"github.com/CeresDB/ceresmeta/server/storage"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+)
+
+type ShardEventType uint64
+
+const (
+	shardPath                  = "shards"
+	EventDelete ShardEventType = 0
+	EventPut                   = 1
+)
+
+// ShardWatch used to watch the distributed lock of shard, and provide the corresponding callback function.
+type ShardWatch struct {
+	rootPath       string
+	etcdClient     *clientv3.Client
+	eventCallbacks []func(shardID storage.ShardID, nodeName string, eventType ShardEventType) error
+
+	lock      sync.RWMutex
+	isRunning bool
+	quit      chan bool
+}
+
+func NewWatch(rootPath string, client *clientv3.Client) *ShardWatch {
+	return &ShardWatch{
+		rootPath:       rootPath,
+		etcdClient:     client,
+		eventCallbacks: []func(shardID storage.ShardID, nodeName string, eventType ShardEventType) error{},
+		quit:           make(chan bool),
+	}
+}
+
+func (w *ShardWatch) Start(ctx context.Context) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	if w.isRunning {
+		return nil
+	}
+
+	shardsKeyPath := strings.Join([]string{w.rootPath, shardPath}, "/")
+
+	if err := w.startWatch(ctx, shardsKeyPath); err != nil {
+		return errors.WithMessage(err, "etcd register watch failed")
+	}
+
+	w.isRunning = true
+	return nil
+}
+
+func (w *ShardWatch) Stop(ctx context.Context) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	w.isRunning = false
+	w.quit <- true
+	return nil
+}
+
+func (w *ShardWatch) RegisteringEventCallback(eventCallback func(shardID storage.ShardID, nodeName string, eventType ShardEventType) error) {
+	w.eventCallbacks = append(w.eventCallbacks, eventCallback)
+}
+
+func (w *ShardWatch) startWatch(ctx context.Context, path string) error {
+	log.Info("register shard watch", zap.String("watchPath", path))
+	go func() {
+		for {
+			select {
+			case <-w.quit:
+				return
+			default:
+				respChan := w.etcdClient.Watch(ctx, path, clientv3.WithPrefix(), clientv3.WithPrevKV())
+				for resp := range respChan {
+					for _, event := range resp.Events {
+						if err := w.processEvent(event); err != nil {
+							log.Error("process event", zap.Error(err))
+						}
+					}
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+func (w *ShardWatch) processEvent(event *clientv3.Event) error {
+	switch event.Type {
+	case mvccpb.DELETE:
+		pathList := strings.Split(string(event.Kv.Key), "/")
+		shardID, err := strconv.ParseUint(pathList[len(pathList)-1], 10, 64)
+		if err != nil {
+			return err
+		}
+		oldLeader := string(event.PrevKv.Value)
+		log.Info("receive delete event", zap.String("preKV", fmt.Sprintf("%v", event.PrevKv)), zap.String("event", fmt.Sprintf("%v", event)), zap.Uint64("shardID", shardID), zap.String("oldLeader", oldLeader))
+		for _, callback := range w.eventCallbacks {
+			if err := callback(storage.ShardID(shardID), oldLeader, EventDelete); err != nil {
+				return err
+			}
+		}
+	case mvccpb.PUT:
+		pathList := strings.Split(string(event.Kv.Key), "/")
+		shardID, err := strconv.ParseUint(pathList[len(pathList)-1], 10, 64)
+		if err != nil {
+			return err
+		}
+		newLeader := string(event.Kv.Value)
+		log.Info("receive put event", zap.String("event", fmt.Sprintf("%v", event)), zap.Uint64("shardID", shardID), zap.String("oldLeader", newLeader))
+		for _, callback := range w.eventCallbacks {
+			if err := callback(storage.ShardID(shardID), newLeader, EventPut); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/server/coordinator/watch/watch.go
+++ b/server/coordinator/watch/watch.go
@@ -5,18 +5,18 @@ package coordinator
 import (
 	"context"
 	"fmt"
-	"github.com/CeresDB/ceresdbproto/golang/pkg/metaeventpb"
-	"google.golang.org/protobuf/proto"
 	"strconv"
 	"strings"
 	"sync"
 
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaeventpb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -75,7 +75,7 @@ func (w *ShardWatch) Start(ctx context.Context) error {
 	return nil
 }
 
-func (w *ShardWatch) Stop(ctx context.Context) error {
+func (w *ShardWatch) Stop(_ context.Context) error {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
@@ -165,9 +165,9 @@ func encodeShardKey(rootPath string, shardPath string, shardID uint64) string {
 	return strings.Join([]string{shardKeyPrefix, strconv.FormatUint(shardID, 10)}, keySep)
 }
 
-func convertShardLockValueToPB(value []byte) (metaeventpb.ShardLockValue, error) {
-	shardLockValue := metaeventpb.ShardLockValue{}
-	if err := proto.Unmarshal(value, &shardLockValue); err != nil {
+func convertShardLockValueToPB(value []byte) (*metaeventpb.ShardLockValue, error) {
+	shardLockValue := &metaeventpb.ShardLockValue{}
+	if err := proto.Unmarshal(value, shardLockValue); err != nil {
 		return shardLockValue, errors.WithMessage(err, "unmarshal shardLockValue failed")
 	}
 	return shardLockValue, nil

--- a/server/coordinator/watch/watch.go
+++ b/server/coordinator/watch/watch.go
@@ -5,6 +5,8 @@ package coordinator
 import (
 	"context"
 	"fmt"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaeventpb"
+	"google.golang.org/protobuf/proto"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,31 +19,42 @@ import (
 	"go.uber.org/zap"
 )
 
-type ShardEventType uint64
-
 const (
-	shardPath                  = "shards"
-	EventDelete ShardEventType = 0
-	EventPut                   = 1
+	shardPath = "shards"
+	keySep    = "/"
 )
+
+type ShardRegisterEvent struct {
+	ShardID       storage.ShardID
+	NewLeaderNode string
+}
+
+type ShardExpireEvent struct {
+	ShardID       storage.ShardID
+	OldLeaderNode string
+}
+
+type ShardEventCallback interface {
+	OnShardRegistered(event ShardRegisterEvent) error
+	OnShardExpired(event ShardExpireEvent) error
+}
 
 // ShardWatch used to watch the distributed lock of shard, and provide the corresponding callback function.
 type ShardWatch struct {
 	rootPath       string
 	etcdClient     *clientv3.Client
-	eventCallbacks []func(shardID storage.ShardID, nodeName string, eventType ShardEventType) error
+	eventCallbacks []ShardEventCallback
 
 	lock      sync.RWMutex
 	isRunning bool
-	quit      chan bool
+	cancel    context.CancelFunc
 }
 
 func NewWatch(rootPath string, client *clientv3.Client) *ShardWatch {
 	return &ShardWatch{
 		rootPath:       rootPath,
 		etcdClient:     client,
-		eventCallbacks: []func(shardID storage.ShardID, nodeName string, eventType ShardEventType) error{},
-		quit:           make(chan bool),
+		eventCallbacks: []ShardEventCallback{},
 	}
 }
 
@@ -53,9 +66,8 @@ func (w *ShardWatch) Start(ctx context.Context) error {
 		return nil
 	}
 
-	shardsKeyPath := strings.Join([]string{w.rootPath, shardPath}, "/")
-
-	if err := w.startWatch(ctx, shardsKeyPath); err != nil {
+	shardKeyPrefix := encodeShardKeyPrefix(w.rootPath, shardPath)
+	if err := w.startWatch(ctx, shardKeyPrefix); err != nil {
 		return errors.WithMessage(err, "etcd register watch failed")
 	}
 
@@ -68,29 +80,24 @@ func (w *ShardWatch) Stop(ctx context.Context) error {
 	defer w.lock.Unlock()
 
 	w.isRunning = false
-	w.quit <- true
+	w.cancel()
 	return nil
 }
 
-func (w *ShardWatch) RegisteringEventCallback(eventCallback func(shardID storage.ShardID, nodeName string, eventType ShardEventType) error) {
+func (w *ShardWatch) RegisteringEventCallback(eventCallback ShardEventCallback) {
 	w.eventCallbacks = append(w.eventCallbacks, eventCallback)
 }
 
 func (w *ShardWatch) startWatch(ctx context.Context, path string) error {
 	log.Info("register shard watch", zap.String("watchPath", path))
 	go func() {
-		for {
-			select {
-			case <-w.quit:
-				return
-			default:
-				respChan := w.etcdClient.Watch(ctx, path, clientv3.WithPrefix(), clientv3.WithPrevKV())
-				for resp := range respChan {
-					for _, event := range resp.Events {
-						if err := w.processEvent(event); err != nil {
-							log.Error("process event", zap.Error(err))
-						}
-					}
+		ctxWithCancel, cancel := context.WithCancel(ctx)
+		w.cancel = cancel
+		respChan := w.etcdClient.Watch(ctxWithCancel, path, clientv3.WithPrefix(), clientv3.WithPrevKV())
+		for resp := range respChan {
+			for _, event := range resp.Events {
+				if err := w.processEvent(event); err != nil {
+					log.Error("process event", zap.Error(err))
 				}
 			}
 		}
@@ -101,31 +108,67 @@ func (w *ShardWatch) startWatch(ctx context.Context, path string) error {
 func (w *ShardWatch) processEvent(event *clientv3.Event) error {
 	switch event.Type {
 	case mvccpb.DELETE:
-		pathList := strings.Split(string(event.Kv.Key), "/")
-		shardID, err := strconv.ParseUint(pathList[len(pathList)-1], 10, 64)
+		shardID, err := decodeShardKey(string(event.Kv.Key))
 		if err != nil {
 			return err
 		}
-		oldLeader := string(event.PrevKv.Value)
-		log.Info("receive delete event", zap.String("preKV", fmt.Sprintf("%v", event.PrevKv)), zap.String("event", fmt.Sprintf("%v", event)), zap.Uint64("shardID", shardID), zap.String("oldLeader", oldLeader))
+		shardLockValue, err := convertShardLockValueToPB(event.PrevKv.Value)
+		if err != nil {
+			return err
+		}
+		log.Info("receive delete event", zap.String("preKV", fmt.Sprintf("%v", event.PrevKv)), zap.String("event", fmt.Sprintf("%v", event)), zap.Uint64("shardID", shardID), zap.String("oldLeader", shardLockValue.NodeName))
 		for _, callback := range w.eventCallbacks {
-			if err := callback(storage.ShardID(shardID), oldLeader, EventDelete); err != nil {
+			if err := callback.OnShardExpired(ShardExpireEvent{
+				ShardID:       storage.ShardID(shardID),
+				OldLeaderNode: shardLockValue.NodeName,
+			}); err != nil {
 				return err
 			}
 		}
 	case mvccpb.PUT:
-		pathList := strings.Split(string(event.Kv.Key), "/")
-		shardID, err := strconv.ParseUint(pathList[len(pathList)-1], 10, 64)
+		shardID, err := decodeShardKey(string(event.Kv.Key))
 		if err != nil {
 			return err
 		}
-		newLeader := string(event.Kv.Value)
-		log.Info("receive put event", zap.String("event", fmt.Sprintf("%v", event)), zap.Uint64("shardID", shardID), zap.String("oldLeader", newLeader))
+		shardLockValue, err := convertShardLockValueToPB(event.Kv.Value)
+		if err != nil {
+			return err
+		}
+		log.Info("receive put event", zap.String("event", fmt.Sprintf("%v", event)), zap.Uint64("shardID", shardID), zap.String("oldLeader", shardLockValue.NodeName))
 		for _, callback := range w.eventCallbacks {
-			if err := callback(storage.ShardID(shardID), newLeader, EventPut); err != nil {
+			if err := callback.OnShardRegistered(ShardRegisterEvent{
+				ShardID:       storage.ShardID(shardID),
+				NewLeaderNode: shardLockValue.NodeName,
+			}); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+func decodeShardKey(keyPath string) (uint64, error) {
+	pathList := strings.Split(keyPath, keySep)
+	shardID, err := strconv.ParseUint(pathList[len(pathList)-1], 10, 64)
+	if err != nil {
+		return 0, errors.WithMessage(err, "decode etcd event key failed")
+	}
+	return shardID, nil
+}
+
+func encodeShardKeyPrefix(rootPath, shardPath string) string {
+	return strings.Join([]string{rootPath, shardPath}, keySep)
+}
+
+func encodeShardKey(rootPath string, shardPath string, shardID uint64) string {
+	shardKeyPrefix := encodeShardKeyPrefix(rootPath, shardPath)
+	return strings.Join([]string{shardKeyPrefix, strconv.FormatUint(shardID, 10)}, keySep)
+}
+
+func convertShardLockValueToPB(value []byte) (metaeventpb.ShardLockValue, error) {
+	shardLockValue := metaeventpb.ShardLockValue{}
+	if err := proto.Unmarshal(value, &shardLockValue); err != nil {
+		return shardLockValue, errors.WithMessage(err, "unmarshal shardLockValue failed")
+	}
+	return shardLockValue, nil
 }

--- a/server/coordinator/watch/watch_test.go
+++ b/server/coordinator/watch/watch_test.go
@@ -1,0 +1,61 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package coordinator
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CeresDB/ceresmeta/server/etcdutil"
+	"github.com/CeresDB/ceresmeta/server/storage"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+const (
+	TestRootPath  = "/rootPath"
+	TestShardPath = "shards"
+	TestShardID   = 1
+	TestNodeName  = "testNode"
+)
+
+func TestWatch(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+
+	_, client, _ := etcdutil.PrepareEtcdServerAndClient(t)
+	watch := NewWatch(TestRootPath, client)
+	err := watch.Start(ctx)
+	re.NoError(err)
+
+	callbackResult := 0
+	testCallback := func(shardID storage.ShardID, nodeName string, eventType ShardEventType) error {
+		switch eventType {
+		case EventDelete:
+			callbackResult = 1
+			re.Equal(storage.ShardID(TestShardID), shardID)
+			re.Equal(TestNodeName, nodeName)
+		case EventPut:
+			callbackResult = 2
+			re.Equal(storage.ShardID(TestShardID), shardID)
+			re.Equal(TestNodeName, nodeName)
+		}
+		return nil
+	}
+	watch.RegisteringEventCallback(testCallback)
+
+	// Valid that callback function is executed and the params are as expected.
+	keyPath := strings.Join([]string{TestRootPath, TestShardPath, strconv.Itoa(TestShardID)}, "/")
+	_, err = client.Put(ctx, keyPath, TestNodeName)
+	re.NoError(err)
+	time.Sleep(time.Millisecond * 10)
+	re.Equal(callbackResult, 2)
+
+	_, err = client.Delete(ctx, keyPath, clientv3.WithPrevKV())
+	re.NoError(err)
+	time.Sleep(time.Millisecond * 10)
+	re.Equal(callbackResult, 1)
+}

--- a/server/coordinator/watch/watch_test.go
+++ b/server/coordinator/watch/watch_test.go
@@ -4,15 +4,15 @@ package coordinator
 
 import (
 	"context"
-	"github.com/CeresDB/ceresdbproto/golang/pkg/metaeventpb"
-	"google.golang.org/protobuf/proto"
 	"testing"
 	"time"
 
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaeventpb"
 	"github.com/CeresDB/ceresmeta/server/etcdutil"
 	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/protobuf/proto"
 )
 
 const (


### PR DESCRIPTION
# Which issue does this PR close?

(https://github.com/CeresDB/ceresmeta/issues/145)

# Rationale for this change
 In order to ensure that user data in distributed mode will not be lost, we need a mechanism to ensure that CeresDB will not have multiple leader shard under any circumstances. `etcd` lock has been added in https://github.com/CeresDB/ceresdb/pull/706 , we refactor scheduler to implement failover based `etcd` distributed lock.


# What changes are included in this PR?
* Add shard watcher to get notify when shard lock is expired.


# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests and integration tests.