### PR TITLE
refactor: implement entry lock

### DIFF
--- a/server/coordinator/lock/entry_lock.go
+++ b/server/coordinator/lock/entry_lock.go
@@ -1,0 +1,54 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package lock
+
+import (
+	"fmt"
+	"sync"
+)
+
+type EntryLock struct {
+	lock       sync.Mutex
+	entryLocks map[uint64]struct{}
+}
+
+func NewEntryLock(initCapacity int) EntryLock {
+	return EntryLock{
+		entryLocks: make(map[uint64]struct{}, initCapacity),
+	}
+}
+
+func (l *EntryLock) TryLock(locks []uint64) bool {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	for _, lock := range locks {
+		_, exists := l.entryLocks[lock]
+		if exists {
+			return false
+		}
+	}
+
+	for _, lock := range locks {
+		l.entryLocks[lock] = struct{}{}
+	}
+
+	return true
+}
+
+func (l *EntryLock) UnLock(locks []uint64) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	for _, lock := range locks {
+		_, exists := l.entryLocks[lock]
+		if !exists {
+			panic(fmt.Sprintf("try to unlock nonexistent lock, exists locks:%v, unlock locks:%v", l.entryLocks, locks))
+		}
+	}
+
+	for _, lock := range locks {
+		delete(l.entryLocks, lock)
+	}
+
+}

--- a/server/coordinator/lock/entry_lock_test.go
+++ b/server/coordinator/lock/entry_lock_test.go
@@ -1,0 +1,42 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package lock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntryLock(t *testing.T) {
+	re := require.New(t)
+
+	lock := NewEntryLock(3)
+
+	lock1 := []uint64{1}
+	result := lock.TryLock(lock1)
+	re.Equal(true, result)
+	result = lock.TryLock(lock1)
+	re.Equal(false, result)
+	lock.UnLock(lock1)
+	result = lock.TryLock(lock1)
+	re.Equal(true, result)
+	lock.UnLock(lock1)
+
+	lock2 := []uint64{2, 3, 4}
+	lock3 := []uint64{3, 4, 5}
+	result = lock.TryLock(lock2)
+	re.Equal(true, result)
+	result = lock.TryLock(lock2)
+	re.Equal(false, result)
+	result = lock.TryLock(lock3)
+	re.Equal(false, result)
+	lock.UnLock(lock2)
+	result = lock.TryLock(lock2)
+	re.Equal(true, result)
+	lock.UnLock(lock2)
+
+	re.Panics(func() {
+		lock.UnLock(lock2)
+	}, "this function did not panic")
+}


### PR DESCRIPTION
# Which issue does this PR close?
(https://github.com/CeresDB/ceresmeta/issues/145)

# Rationale for this change
 In order to achieve concurrency of procedures at the shard level, we need to implement locks on the shard entity for procedures.



# What changes are included in this PR?
* Implement entry lock in `entry_lock.go`, which support try lock in multi shards.
* Add unit test for entry lock.

# Are there any user-facing changes?
None.

# How does this change test
Pass the newly created unit test.