### PR TITLE
fix: fix update cluster view when shardinfos is empty

### DIFF
--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -387,7 +387,8 @@ func (c *ClusterMetadata) RegisterNode(ctx context.Context, registeredNode Regis
 	}
 
 	// Update shard node mapping.
-	shardNodes := make(map[string][]storage.ShardNode, len(registeredNode.ShardInfos))
+	shardNodes := make(map[string][]storage.ShardNode, 1)
+	shardNodes[registeredNode.Node.Name] = make([]storage.ShardNode, 0, len(registeredNode.ShardInfos))
 	for _, shardInfo := range registeredNode.ShardInfos {
 		shardNodes[registeredNode.Node.Name] = append(shardNodes[registeredNode.Node.Name], storage.ShardNode{
 			ID:        shardInfo.ID,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
When testing locally, it is found that shardNodes cannot be updated normally when the shardInfo in registerNode is empty.

# What changes are included in this PR?
1. Fix the bug that clusterView cannot be updated normally when the node is registered.

# Are there any user-facing changes?
None.

# How does this change test
All unit tests pass, and local validation is correct.