### PR TITLE
feat: renew the leader lease in a modern way

### DIFF
--- a/server/member/lease.go
+++ b/server/member/lease.go
@@ -167,7 +167,11 @@ func (l *lease) renewLeaseBg(ctx context.Context, renewed chan<- bool) {
 	defer l.logger.Info("stop renewing lease background", zap.Int64("lease-id", int64(l.ID)))
 
 	keepaliveStream, err := l.rawLease.KeepAlive(ctx, l.ID)
-	l.logger.Error("fail to keep lease alive", zap.Int64("lease-id", int64(l.ID)), zap.Error(err))
+	if err != nil {
+		l.logger.Error("fail to start keep lease alive stream", zap.Int64("lease-id", int64(l.ID)), zap.Error(err))
+		return
+	}
+
 	for {
 		start := time.Now()
 		select {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 The current way to renew leader lease is by a tick keep alive rpc, however, the etcd client supports a stream way to do such thing, which is more elegant and efficient.
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Renew the leader lease in a modern way;

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test locally. Before this pr, if the etcd log level is debug, then such logs will be printed again and again:
```
{"level":"debug","ts":"2023-04-25T16:22:53.891+0800","caller":"v3rpc/lease.go:118","msg":"failed to receive lease keepalive request from gRPC stream","error":"rpc error: code = Canceled desc = context canceled"}
```
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->