### PR TITLE
feat: add rebalanced shard scheduler

### DIFF
--- a/server/cluster/metadata/topology_manager.go
+++ b/server/cluster/metadata/topology_manager.go
@@ -82,6 +82,16 @@ type Topology struct {
 	ClusterView       storage.ClusterView
 }
 
+func (t *Topology) IsStable() bool {
+	if t.ClusterView.State != storage.ClusterStateStable {
+		return false
+	}
+	if len(t.ClusterView.ShardNodes) != len(t.ShardViewsMapping) {
+		return false
+	}
+	return true
+}
+
 type TopologyManagerImpl struct {
 	storage      storage.Storage
 	clusterID    storage.ClusterID

--- a/server/cluster/metadata/types.go
+++ b/server/cluster/metadata/types.go
@@ -135,8 +135,10 @@ func NewRegisteredNode(meta storage.Node, shardInfos []ShardInfo) RegisteredNode
 	}
 }
 
-func (n RegisteredNode) IsExpired(now int64) bool {
-	return now >= int64(expiredThreshold/time.Millisecond)+int64(n.Node.LastTouchTime)
+func (n RegisteredNode) IsExpired(now time.Time) bool {
+	expiredTime := time.UnixMilli(int64(n.Node.LastTouchTime)).Add(expiredThreshold)
+
+	return now.After(expiredTime)
 }
 
 func ConvertShardsInfoToPB(shard ShardInfo) *metaservicepb.ShardInfo {

--- a/server/cluster/metadata/types.go
+++ b/server/cluster/metadata/types.go
@@ -136,7 +136,7 @@ func NewRegisteredNode(meta storage.Node, shardInfos []ShardInfo) RegisteredNode
 }
 
 func (n RegisteredNode) IsExpired(now int64) bool {
-	return now >= int64(expiredThreshold)+int64(n.Node.LastTouchTime)
+	return now >= int64(expiredThreshold/time.Millisecond)+int64(n.Node.LastTouchTime)
 }
 
 func ConvertShardsInfoToPB(shard ShardInfo) *metaservicepb.ShardInfo {

--- a/server/coordinator/node_picker.go
+++ b/server/coordinator/node_picker.go
@@ -39,16 +39,16 @@ func (p *ConsistentHashNodePicker) PickNode(_ context.Context, shardID storage.S
 		}
 	}
 
-	if aliveNodeNumber == 0 {
+	if hashRing.IsEmpty() {
 		return metadata.RegisteredNode{}, errors.WithMessage(ErrNodeNumberNotEnough, "at least one online nodes is required")
 	}
 
 	pickedNodeName := hashRing.Get(strconv.Itoa(int(shardID)))
 	log.Debug("ConsistentHashNodePicker pick result", zap.Uint64("shardID", uint64(shardID)), zap.String("node", pickedNodeName), zap.Int("nodeNumber", aliveNodeNumber))
 
-	for _, registerNode := range registerNodes {
-		if registerNode.Node.Name == pickedNodeName {
-			return registerNode, nil
+	for i := 0; i < len(registerNodes); i++ {
+		if registerNodes[i].Node.Name == pickedNodeName {
+			return registerNodes[i], nil
 		}
 	}
 

--- a/server/coordinator/node_picker_test.go
+++ b/server/coordinator/node_picker_test.go
@@ -16,13 +16,14 @@ import (
 const (
 	nodeLength            = 3
 	selectOnlineNodeIndex = 1
+	defaultHashReplicas   = 50
 )
 
-func TestRandomNodePicker(t *testing.T) {
+func TestConsistentHashNodePicker(t *testing.T) {
 	re := require.New(t)
 	ctx := context.Background()
 
-	nodePicker := NewRandomNodePicker()
+	nodePicker := NewConsistentHashNodePicker(50)
 
 	var nodes []metadata.RegisteredNode
 	_, err := nodePicker.PickNode(ctx, 0, nodes)
@@ -54,12 +55,12 @@ func TestRandomNodePicker(t *testing.T) {
 			ShardInfos: nil,
 		})
 	}
-	nodes[selectOnlineNodeIndex].Node.LastTouchTime = uint64(time.Now().Unix())
+	nodes[selectOnlineNodeIndex].Node.LastTouchTime = uint64(time.Now().UnixMilli())
 	node, err := nodePicker.PickNode(ctx, 0, nodes)
 	re.NoError(err)
 	re.Equal(strconv.Itoa(selectOnlineNodeIndex), node.Node.Name)
 }
 
 func generateLastTouchTime(duration time.Duration) uint64 {
-	return uint64(time.Now().Unix() - int64(duration))
+	return uint64(time.Now().UnixMilli() - int64(duration))
 }

--- a/server/coordinator/node_picker_test.go
+++ b/server/coordinator/node_picker_test.go
@@ -25,7 +25,7 @@ func TestRandomNodePicker(t *testing.T) {
 	nodePicker := NewRandomNodePicker()
 
 	var nodes []metadata.RegisteredNode
-	_, err := nodePicker.PickNode(ctx, nodes)
+	_, err := nodePicker.PickNode(ctx, 0, nodes)
 	re.Error(err)
 
 	for i := 0; i < nodeLength; i++ {
@@ -34,7 +34,7 @@ func TestRandomNodePicker(t *testing.T) {
 			ShardInfos: nil,
 		})
 	}
-	_, err = nodePicker.PickNode(ctx, nodes)
+	_, err = nodePicker.PickNode(ctx, 0, nodes)
 	re.Error(err)
 
 	nodes = nodes[:0]
@@ -44,7 +44,7 @@ func TestRandomNodePicker(t *testing.T) {
 			ShardInfos: nil,
 		})
 	}
-	_, err = nodePicker.PickNode(ctx, nodes)
+	_, err = nodePicker.PickNode(ctx, 0, nodes)
 	re.NoError(err)
 
 	nodes = nodes[:0]
@@ -55,7 +55,7 @@ func TestRandomNodePicker(t *testing.T) {
 		})
 	}
 	nodes[selectOnlineNodeIndex].Node.LastTouchTime = uint64(time.Now().Unix())
-	node, err := nodePicker.PickNode(ctx, nodes)
+	node, err := nodePicker.PickNode(ctx, 0, nodes)
 	re.NoError(err)
 	re.Equal(strconv.Itoa(selectOnlineNodeIndex), node.Node.Name)
 }

--- a/server/coordinator/scheduler/assign_shard_scheduler.go
+++ b/server/coordinator/scheduler/assign_shard_scheduler.go
@@ -38,7 +38,7 @@ func (a AssignShardScheduler) Schedule(ctx context.Context, clusterSnapshot meta
 		if exists {
 			continue
 		}
-		newLeaderNode, err := a.nodePicker.PickNode(ctx, clusterSnapshot.RegisteredNodes)
+		newLeaderNode, err := a.nodePicker.PickNode(ctx, shardView.ShardID, clusterSnapshot.RegisteredNodes)
 		if err != nil {
 			return ScheduleResult{}, err
 		}

--- a/server/coordinator/scheduler/rebalanced_shard_scheduler.go
+++ b/server/coordinator/scheduler/rebalanced_shard_scheduler.go
@@ -1,0 +1,54 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package scheduler
+
+import (
+	"context"
+
+	"github.com/CeresDB/ceresmeta/server/cluster/metadata"
+	"github.com/CeresDB/ceresmeta/server/coordinator"
+)
+
+type RebalancedShardScheduler struct {
+	factory    *coordinator.Factory
+	nodePicker coordinator.NodePicker
+}
+
+func NewRebalancedShardScheduler(factory *coordinator.Factory, nodePicker coordinator.NodePicker) Scheduler {
+	return &RebalancedShardScheduler{
+		factory:    factory,
+		nodePicker: nodePicker,
+	}
+}
+
+func (r RebalancedShardScheduler) Schedule(ctx context.Context, clusterSnapshot metadata.Snapshot) (ScheduleResult, error) {
+	// RebalancedShardScheduler can only be scheduled when the cluster is stable.
+	if !clusterSnapshot.Topology.IsStable() {
+		return ScheduleResult{}, nil
+	}
+
+	// TODO: Improve scheduling efficiency and verify whether the topology changes.
+	for _, shardNode := range clusterSnapshot.Topology.ClusterView.ShardNodes {
+		node, err := r.nodePicker.PickNode(ctx, shardNode.ID, clusterSnapshot.RegisteredNodes)
+		if err != nil {
+			return ScheduleResult{}, err
+		}
+		if node.Node.Name != shardNode.NodeName {
+			p, err := r.factory.CreateTransferLeaderProcedure(ctx, coordinator.TransferLeaderRequest{
+				Snapshot:          clusterSnapshot,
+				ShardID:           shardNode.ID,
+				OldLeaderNodeName: shardNode.NodeName,
+				NewLeaderNodeName: node.Node.Name,
+			})
+			if err != nil {
+				return ScheduleResult{}, err
+			}
+			return ScheduleResult{
+				Procedure: p,
+				Reason:    "",
+			}, nil
+		}
+	}
+
+	return ScheduleResult{}, nil
+}

--- a/server/coordinator/scheduler/scheduler_manager.go
+++ b/server/coordinator/scheduler/scheduler_manager.go
@@ -60,7 +60,7 @@ func NewManager(procedureManager procedure.Manager, factory *coordinator.Factory
 		registerSchedulers: []Scheduler{},
 		isRunning:          false,
 		factory:            factory,
-		nodePicker:         coordinator.NewRandomNodePicker(),
+		nodePicker:         coordinator.NewConsistentHashNodePicker(5),
 		clusterMetadata:    clusterMetadata,
 		client:             client,
 		rootPath:           rootPath,
@@ -151,6 +151,9 @@ func (callback *schedulerWatchCallback) OnShardExpired(ctx context.Context, even
 func (m *ManagerImpl) initRegister() {
 	assignShardScheduler := NewAssignShardScheduler(m.factory, m.nodePicker)
 	m.registerScheduler(assignShardScheduler)
+
+	rebalancedShardScheduler := NewRebalancedShardScheduler(m.factory, m.nodePicker)
+	m.registerScheduler(rebalancedShardScheduler)
 }
 
 func (m *ManagerImpl) registerScheduler(scheduler Scheduler) {

--- a/server/coordinator/scheduler/scheduler_manager.go
+++ b/server/coordinator/scheduler/scheduler_manager.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	schedulerInterval = time.Second * 5
+	schedulerInterval   = time.Second * 5
+	defaultHashReplicas = 50
 )
 
 // Manager used to manage schedulers, it will register all schedulers when it starts.
@@ -60,7 +61,7 @@ func NewManager(procedureManager procedure.Manager, factory *coordinator.Factory
 		registerSchedulers: []Scheduler{},
 		isRunning:          false,
 		factory:            factory,
-		nodePicker:         coordinator.NewConsistentHashNodePicker(5),
+		nodePicker:         coordinator.NewConsistentHashNodePicker(defaultHashReplicas),
 		clusterMetadata:    clusterMetadata,
 		client:             client,
 		rootPath:           rootPath,

--- a/server/hash/consistent_hash_ring.go
+++ b/server/hash/consistent_hash_ring.go
@@ -1,5 +1,17 @@
 // Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
 // This file refer from [groupcache](https://github.com/golang/groupcache/blob/4a4ac3fbac33b83bb138f808c8945a2812023fc4/consistenthash/consistenthash.go)
+/*
+Copyright 2013 Google Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package hash
 

--- a/server/hash/consistent_hash_ring.go
+++ b/server/hash/consistent_hash_ring.go
@@ -1,0 +1,67 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+// This file refer from [groupcache](https://github.com/golang/groupcache/blob/4a4ac3fbac33b83bb138f808c8945a2812023fc4/consistenthash/consistenthash.go)
+
+package hash
+
+import (
+	"hash/crc32"
+	"sort"
+	"strconv"
+)
+
+type Hash func(data []byte) uint32
+
+type ConsistentHashRing struct {
+	hash     Hash
+	replicas int
+	ring     []int
+	nodes    map[int]string
+}
+
+func New(replicas int, fn Hash) *ConsistentHashRing {
+	m := &ConsistentHashRing{
+		replicas: replicas,
+		hash:     fn,
+		nodes:    make(map[int]string),
+	}
+	if m.hash == nil {
+		m.hash = crc32.ChecksumIEEE
+	}
+	return m
+}
+
+// IsEmpty returns true if there are no items available.
+func (h *ConsistentHashRing) IsEmpty() bool {
+	return len(h.ring) == 0
+}
+
+// Add adds some keys to the hash.
+func (h *ConsistentHashRing) Add(nodes ...string) {
+	for _, node := range nodes {
+		for i := 0; i < h.replicas; i++ {
+			hash := int(h.hash([]byte(strconv.Itoa(i) + node)))
+			h.ring = append(h.ring, hash)
+			h.nodes[hash] = node
+		}
+	}
+	sort.Ints(h.ring)
+}
+
+// Get gets the closest item in the hash to the provided key.
+func (h *ConsistentHashRing) Get(key string) string {
+	if h.IsEmpty() {
+		return ""
+	}
+
+	hash := int(h.hash([]byte(key)))
+
+	// Binary search for appropriate replica.
+	idx := sort.Search(len(h.ring), func(i int) bool { return h.ring[i] >= hash })
+
+	// Means we have cycled back to the first replica.
+	if idx == len(h.ring) {
+		idx = 0
+	}
+
+	return h.nodes[h.ring[idx]]
+}

--- a/server/hash/consistent_hash_ring.go
+++ b/server/hash/consistent_hash_ring.go
@@ -1,5 +1,5 @@
 // Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
-// This file refer from [groupcache](https://github.com/golang/groupcache/blob/4a4ac3fbac33b83bb138f808c8945a2812023fc4/consistenthash/consistenthash.go)
+// The consistent hash ring refers to [groupcache](https://github.com/golang/groupcache/blob/4a4ac3fbac33b83bb138f808c8945a2812023fc4/consistenthash/consistenthash.go)
 /*
 Copyright 2013 Google Inc.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/server/hash/consistent_hash_ring_test.go
+++ b/server/hash/consistent_hash_ring_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+// This file refer from [groupcache](https://github.com/golang/groupcache/blob/4a4ac3fbac33b83bb138f808c8945a2812023fc4/consistenthash/consistenthash_test.go)
+
+package hash
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+func TestHashing(t *testing.T) {
+	// Override the hash function to return easier to reason about values. Assumes
+	// the keys can be converted to an integer.
+	hash := New(3, func(key []byte) uint32 {
+		i, err := strconv.Atoi(string(key))
+		if err != nil {
+			panic(err)
+		}
+		return uint32(i)
+	})
+
+	// Given the above hash function, this will give replicas with "hashes":
+	// 2, 4, 6, 12, 14, 16, 22, 24, 26
+	hash.Add("6", "4", "2")
+
+	testCases := map[string]string{
+		"2":  "2",
+		"11": "2",
+		"23": "4",
+		"27": "2",
+	}
+
+	for k, v := range testCases {
+		if hash.Get(k) != v {
+			t.Errorf("Asking for %s, should have yielded %s", k, v)
+		}
+	}
+
+	// Adds 8, 18, 28
+	hash.Add("8")
+
+	// 27 should now map to 8.
+	testCases["27"] = "8"
+
+	for k, v := range testCases {
+		if hash.Get(k) != v {
+			t.Errorf("Asking for %s, should have yielded %s", k, v)
+		}
+	}
+}
+
+func TestConsistency(t *testing.T) {
+	hash1 := New(1, nil)
+	hash2 := New(1, nil)
+
+	hash1.Add("Bill", "Bob", "Bonny")
+	hash2.Add("Bob", "Bonny", "Bill")
+
+	if hash1.Get("Ben") != hash2.Get("Ben") {
+		t.Errorf("Fetching 'Ben' from both hashes should be the same")
+	}
+
+	hash2.Add("Becky", "Ben", "Bobby")
+
+	if hash1.Get("Ben") != hash2.Get("Ben") ||
+		hash1.Get("Bob") != hash2.Get("Bob") ||
+		hash1.Get("Bonny") != hash2.Get("Bonny") {
+		t.Errorf("Direct matches should always return the same entry")
+	}
+}
+
+func BenchmarkGet8(b *testing.B)   { benchmarkGet(b, 8) }
+func BenchmarkGet32(b *testing.B)  { benchmarkGet(b, 32) }
+func BenchmarkGet128(b *testing.B) { benchmarkGet(b, 128) }
+func BenchmarkGet512(b *testing.B) { benchmarkGet(b, 512) }
+
+func benchmarkGet(b *testing.B, shards int) {
+	hash := New(50, nil)
+
+	var buckets []string
+	for i := 0; i < shards; i++ {
+		buckets = append(buckets, fmt.Sprintf("shard-%d", i))
+	}
+
+	hash.Add(buckets...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hash.Get(buckets[i&(shards-1)])
+	}
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
In the current failover implementation, if a node goes down, all its shards will be moved to other shards, and the shards will not be transferred back after the node is restarted, which will cause a lot of pressure on operation and maintenance. We need supports automatic load balancing.

# What changes are included in this PR?
1. Introduced the consistent hash implementation in the golang standard library, ref: https://github.com/golang/groupcache/blob/4a4ac3fbac33b83bb138f808c8945a2812023fc4/consistenthash/consistenthash.go
2. Implemented shard load balancing based on consistent hashing.

# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests and local tests.