### PR TITLE
feat: add deploy mode

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -59,6 +59,10 @@ func (c *Cluster) GetProcedureFactory() *coordinator.Factory {
 	return c.procedureFactory
 }
 
+func (c *Cluster) GetSchedulerManager() scheduler.Manager {
+	return c.schedulerManager
+}
+
 func (c *Cluster) Start(ctx context.Context) error {
 	if err := c.procedureManager.Start(ctx); err != nil {
 		return errors.WithMessage(err, "start procedure manager")

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -378,10 +378,10 @@ func (c *ClusterMetadata) RegisterNode(ctx context.Context, registeredNode Regis
 
 	c.registeredNodesCache[registeredNode.Node.Name] = registeredNode
 
-	// When the number of nodes in the cluster reaches the threshold, modify the cluster status to stable.
+	// When the number of nodes in the cluster reaches the threshold, modify the cluster status to prepare.
 	// TODO: Consider the design of the entire cluster state, which may require refactoring.
 	if uint32(len(c.registeredNodesCache)) >= c.metaData.MinNodeCount && c.topologyManager.GetClusterState() == storage.ClusterStateEmpty {
-		if err := c.UpdateClusterView(ctx, storage.ClusterStateStable, []storage.ShardNode{}); err != nil {
+		if err := c.UpdateClusterView(ctx, storage.ClusterStatePrepare, []storage.ShardNode{}); err != nil {
 			log.Error("update cluster view failed", zap.Error(err))
 		}
 	}

--- a/server/cluster/metadata/topology_manager.go
+++ b/server/cluster/metadata/topology_manager.go
@@ -92,6 +92,16 @@ func (t *Topology) IsStable() bool {
 	return true
 }
 
+func (t *Topology) IsPrepareFinished() bool {
+	if t.ClusterView.State != storage.ClusterStatePrepare {
+		return false
+	}
+	if len(t.ShardViewsMapping) != len(t.ClusterView.ShardNodes) {
+		return false
+	}
+	return true
+}
+
 type TopologyManagerImpl struct {
 	storage      storage.Storage
 	clusterID    storage.ClusterID

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -47,7 +47,8 @@ const (
 	defaultClusterNodeCount         = 2
 	defaultClusterReplicationFactor = 1
 	defaultClusterShardTotal        = 8
-	defaultClusterDeployMode        = false
+	// TODO: DefaultClusterDeployMode should be set false, this is to be compatible with the implementation of CeresDB's local storage, which will be required later...
+	defaultClusterDeployMode = true
 
 	defaultHTTPPort = 8080
 
@@ -108,7 +109,7 @@ type Config struct {
 	DefaultClusterReplicationFactor int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
 	DefaultClusterShardTotal        int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
 	// When the deployMode is turned on, the failover scheduling will be turned off, which is used for CeresDB cluster publishing and using local storage.
-	DefaultClusterDeployMode bool `toml:"default-cluster-deploy_mode" env:"DEFAULT_CLUSTER_DEPLOY_MODE"`
+	DefaultClusterDeployMode bool `toml:"default-cluster-deploy-mode" env:"DEFAULT_CLUSTER_DEPLOY_MODE"`
 
 	ClientUrls          string `toml:"client-urls" env:"CLIENT_URLS"`
 	PeerUrls            string `toml:"peer-urls" env:"PEER_URLS"`

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -43,11 +43,11 @@ const (
 	defaultMinScanLimit    int  = 20
 	defaultIDAllocatorStep uint = 20
 
-	defaultClusterName                     = "defaultCluster"
-	defaultClusterNodeCount                = 2
-	defaultClusterReplicationFactor        = 1
-	defaultClusterShardTotal               = 8
-	defaultPartitionTableProportionOfNodes = 0
+	defaultClusterName              = "defaultCluster"
+	defaultClusterNodeCount         = 2
+	defaultClusterReplicationFactor = 1
+	defaultClusterShardTotal        = 8
+	defaultClusterDeployMode        = false
 
 	defaultHTTPPort = 8080
 
@@ -107,6 +107,8 @@ type Config struct {
 	DefaultClusterNodeCount         int    `toml:"default-cluster-node-count" env:"DEFAULT_CLUSTER_NODE_COUNT"`
 	DefaultClusterReplicationFactor int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
 	DefaultClusterShardTotal        int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
+	// When the deployMode is turned on, the failover scheduling will be turned off, which is used for CeresDB cluster publishing and using local storage.
+	DefaultClusterDeployMode bool `toml:"default-cluster-deploy_mode" env:"DEFAULT_CLUSTER_DEPLOY_MODE"`
 
 	ClientUrls          string `toml:"client-urls" env:"CLIENT_URLS"`
 	PeerUrls            string `toml:"peer-urls" env:"PEER_URLS"`
@@ -269,6 +271,7 @@ func MakeConfigParser() (*Parser, error) {
 		DefaultClusterNodeCount:         defaultClusterNodeCount,
 		DefaultClusterReplicationFactor: defaultClusterReplicationFactor,
 		DefaultClusterShardTotal:        defaultClusterShardTotal,
+		DefaultClusterDeployMode:        defaultClusterDeployMode,
 
 		HTTPPort: defaultHTTPPort,
 	}

--- a/server/coordinator/scheduler/assign_shard_scheduler.go
+++ b/server/coordinator/scheduler/assign_shard_scheduler.go
@@ -28,7 +28,7 @@ func NewAssignShardScheduler(factory *coordinator.Factory, nodePicker coordinato
 }
 
 func (a AssignShardScheduler) Schedule(ctx context.Context, clusterSnapshot metadata.Snapshot) (ScheduleResult, error) {
-	if clusterSnapshot.Topology.ClusterView.State != storage.ClusterStateStable {
+	if clusterSnapshot.Topology.ClusterView.State == storage.ClusterStateEmpty {
 		return ScheduleResult{}, nil
 	}
 

--- a/server/coordinator/scheduler/scheduler_manager.go
+++ b/server/coordinator/scheduler/scheduler_manager.go
@@ -35,6 +35,8 @@ type Manager interface {
 
 	Stop(ctx context.Context) error
 
+	UpdateDeployMode(ctx context.Context, deployMode bool)
+
 	// Scheduler will be called when received new heartbeat, every scheduler registered in schedulerManager will be called to generate procedures.
 	// Scheduler cloud be schedule with fix time interval or heartbeat.
 	Scheduler(ctx context.Context, clusterSnapshot metadata.Snapshot) []ScheduleResult
@@ -53,6 +55,7 @@ type ManagerImpl struct {
 	registerSchedulers []Scheduler
 	shardWatch         *watch.ShardWatch
 	isRunning          bool
+	deployMode         bool
 }
 
 func NewManager(procedureManager procedure.Manager, factory *coordinator.Factory, clusterMetadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string) Manager {
@@ -110,6 +113,19 @@ func (m *ManagerImpl) Start(ctx context.Context) error {
 				// Get latest cluster snapshot.
 				clusterSnapshot := m.clusterMetadata.GetClusterSnapshot()
 				log.Debug("scheduler manager invoke", zap.String("clusterSnapshot", fmt.Sprintf("%v", clusterSnapshot)))
+
+				// TODO: Perhaps these codes related to deployMode need to be refactored.
+				// If deployMode is turned on, the scheduler will only be scheduled in the non-stable state.
+				if m.deployMode && clusterSnapshot.Topology.ClusterView.State == storage.ClusterStateStable {
+					continue
+				}
+				if clusterSnapshot.Topology.ClusterView.State == storage.ClusterStatePrepare && len(clusterSnapshot.Topology.ShardViewsMapping) == len(clusterSnapshot.Topology.ClusterView.ShardNodes) {
+					if err := m.clusterMetadata.UpdateClusterView(ctx, storage.ClusterStateStable, clusterSnapshot.Topology.ClusterView.ShardNodes); err != nil {
+						log.Error("update cluster view failed", zap.Error(err))
+					}
+					continue
+				}
+
 				results := m.Scheduler(ctx, clusterSnapshot)
 				for _, result := range results {
 					if result.Procedure != nil {
@@ -181,4 +197,12 @@ func (m *ManagerImpl) Scheduler(ctx context.Context, clusterSnapshot metadata.Sn
 		results = append(results, result)
 	}
 	return results
+}
+
+func (m *ManagerImpl) UpdateDeployMode(_ context.Context, deployMode bool) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.deployMode = deployMode
+	log.Info("scheduler manager update deploy mode", zap.Bool("deployMode", deployMode))
 }

--- a/server/coordinator/scheduler/scheduler_manager.go
+++ b/server/coordinator/scheduler/scheduler_manager.go
@@ -119,7 +119,7 @@ func (m *ManagerImpl) Start(ctx context.Context) error {
 				if m.deployMode && clusterSnapshot.Topology.ClusterView.State == storage.ClusterStateStable {
 					continue
 				}
-				if clusterSnapshot.Topology.ClusterView.State == storage.ClusterStatePrepare && len(clusterSnapshot.Topology.ShardViewsMapping) == len(clusterSnapshot.Topology.ClusterView.ShardNodes) {
+				if clusterSnapshot.Topology.IsPrepareFinished() {
 					if err := m.clusterMetadata.UpdateClusterView(ctx, storage.ClusterStateStable, clusterSnapshot.Topology.ClusterView.ShardNodes); err != nil {
 						log.Error("update cluster view failed", zap.Error(err))
 					}
@@ -201,8 +201,8 @@ func (m *ManagerImpl) Scheduler(ctx context.Context, clusterSnapshot metadata.Sn
 
 func (m *ManagerImpl) UpdateDeployMode(_ context.Context, deployMode bool) {
 	m.lock.Lock()
-	defer m.lock.Unlock()
-
 	m.deployMode = deployMode
+	m.lock.Unlock()
+
 	log.Info("scheduler manager update deploy mode", zap.Bool("deployMode", deployMode))
 }

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -53,7 +53,7 @@ func (a *API) NewAPIRouter() *Router {
 	router.Post("/route", a.route)
 	router.Post("/dropTable", a.dropTable)
 	router.Post("/getNodeShards", a.getNodeShards)
-	router.Post("/deployMode", a.deployMode)
+	router.Put("/deployMode", a.deployMode)
 	router.Get("/healthCheck", a.healthCheck)
 
 	return router

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -53,6 +53,7 @@ func (a *API) NewAPIRouter() *Router {
 	router.Post("/route", a.route)
 	router.Post("/dropTable", a.dropTable)
 	router.Post("/getNodeShards", a.getNodeShards)
+	router.Post("/deployMode", a.deployMode)
 	router.Get("/healthCheck", a.healthCheck)
 
 	return router
@@ -364,6 +365,32 @@ func (a *API) split(writer http.ResponseWriter, req *http.Request) {
 	}
 
 	a.respond(writer, newShardID)
+}
+
+type UpdateDeployModeRequest struct {
+	ClusterName string `json:"clusterName"`
+	DeployMode  bool   `json:"deployMode"`
+}
+
+func (a *API) deployMode(writer http.ResponseWriter, req *http.Request) {
+	var updateDeployModeRequest UpdateDeployModeRequest
+	err := json.NewDecoder(req.Body).Decode(&updateDeployModeRequest)
+	if err != nil {
+		log.Error("decode request body failed", zap.Error(err))
+		a.respondError(writer, ErrParseRequest, "")
+		return
+	}
+
+	c, err := a.clusterManager.GetCluster(req.Context(), updateDeployModeRequest.ClusterName)
+	if err != nil {
+		log.Error("cluster not found", zap.String("clusterName", updateDeployModeRequest.ClusterName), zap.Error(err))
+		a.respondError(writer, metadata.ErrClusterNotFound, "cluster not found")
+		return
+	}
+
+	c.GetSchedulerManager().UpdateDeployMode(req.Context(), updateDeployModeRequest.DeployMode)
+
+	a.respond(writer, nil)
 }
 
 func (a *API) healthCheck(writer http.ResponseWriter, _ *http.Request) {

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -21,6 +21,7 @@ type (
 const (
 	ClusterStateEmpty ClusterState = iota + 1
 	ClusterStateStable
+	ClusterStatePrepare
 )
 
 const (
@@ -270,6 +271,8 @@ func convertClusterStateToPB(state ClusterState) clusterpb.ClusterView_ClusterSt
 		return clusterpb.ClusterView_EMPTY
 	case ClusterStateStable:
 		return clusterpb.ClusterView_STABLE
+	case ClusterStatePrepare:
+		return clusterpb.ClusterView_PREPARE_REBALANCE
 	}
 	return clusterpb.ClusterView_EMPTY
 }
@@ -280,6 +283,8 @@ func convertClusterStatePB(state clusterpb.ClusterView_ClusterState) ClusterStat
 		return ClusterStateEmpty
 	case clusterpb.ClusterView_STABLE:
 		return ClusterStateStable
+	case clusterpb.ClusterView_PREPARE_REBALANCE:
+		return ClusterStatePrepare
 	}
 	return ClusterStateEmpty
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
We support automatic failover and load balancing in the latest version, but they are not applicable in some scenarios, so add a switch to control their opening.


# What changes are included in this PR?
* Add `DeployMode` config, When the deployMode is turned on, the failover scheduling will be turned off, which is used for CeresDB cluster publishing and using local storage.

# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests and verify that the switch takes effect in the local environment.