### PR TITLE
fix: fix get table of shards.

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -28,7 +28,7 @@ type Cluster struct {
 	schedulerManager scheduler.Manager
 }
 
-func NewCluster(metadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string, schedulerOperator bool) (*Cluster, error) {
+func NewCluster(metadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string, enableScheduled bool) (*Cluster, error) {
 	procedureStorage := procedure.NewEtcdStorageImpl(client, rootPath)
 	procedureManager, err := procedure.NewManagerImpl(metadata)
 	if err != nil {
@@ -37,7 +37,7 @@ func NewCluster(metadata *metadata.ClusterMetadata, client *clientv3.Client, roo
 	dispatch := eventdispatch.NewDispatchImpl()
 	procedureFactory := coordinator.NewFactory(id.NewAllocatorImpl(client, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage)
 
-	schedulerManager := scheduler.NewManager(procedureManager, procedureFactory, metadata, client, rootPath, schedulerOperator)
+	schedulerManager := scheduler.NewManager(procedureManager, procedureFactory, metadata, client, rootPath, enableScheduled)
 
 	return &Cluster{
 		metadata:         metadata,

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -28,7 +28,7 @@ type Cluster struct {
 	schedulerManager scheduler.Manager
 }
 
-func NewCluster(metadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string) (*Cluster, error) {
+func NewCluster(metadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string, schedulerOperator bool) (*Cluster, error) {
 	procedureStorage := procedure.NewEtcdStorageImpl(client, rootPath)
 	procedureManager, err := procedure.NewManagerImpl(metadata)
 	if err != nil {
@@ -37,7 +37,7 @@ func NewCluster(metadata *metadata.ClusterMetadata, client *clientv3.Client, roo
 	dispatch := eventdispatch.NewDispatchImpl()
 	procedureFactory := coordinator.NewFactory(id.NewAllocatorImpl(client, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage)
 
-	schedulerManager := scheduler.NewManager(procedureManager, procedureFactory, metadata, client, rootPath)
+	schedulerManager := scheduler.NewManager(procedureManager, procedureFactory, metadata, client, rootPath, schedulerOperator)
 
 	return &Cluster{
 		metadata:         metadata,

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -28,7 +28,7 @@ type Cluster struct {
 	schedulerManager scheduler.Manager
 }
 
-func NewCluster(metadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string, enableScheduled bool) (*Cluster, error) {
+func NewCluster(metadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string, enableSchedule bool) (*Cluster, error) {
 	procedureStorage := procedure.NewEtcdStorageImpl(client, rootPath)
 	procedureManager, err := procedure.NewManagerImpl(metadata)
 	if err != nil {
@@ -37,7 +37,7 @@ func NewCluster(metadata *metadata.ClusterMetadata, client *clientv3.Client, roo
 	dispatch := eventdispatch.NewDispatchImpl()
 	procedureFactory := coordinator.NewFactory(id.NewAllocatorImpl(client, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage)
 
-	schedulerManager := scheduler.NewManager(procedureManager, procedureFactory, metadata, client, rootPath, enableScheduled)
+	schedulerManager := scheduler.NewManager(procedureManager, procedureFactory, metadata, client, rootPath, enableSchedule)
 
 	return &Cluster{
 		metadata:         metadata,

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -55,10 +55,10 @@ type managerImpl struct {
 	alloc           id.Allocator
 	rootPath        string
 	idAllocatorStep uint
-	enableScheduled bool
+	enableSchedule  bool
 }
 
-func NewManagerImpl(storage storage.Storage, kv clientv3.KV, client *clientv3.Client, rootPath string, idAllocatorStep uint, enableScheduled bool) (Manager, error) {
+func NewManagerImpl(storage storage.Storage, kv clientv3.KV, client *clientv3.Client, rootPath string, idAllocatorStep uint, enableSchedule bool) (Manager, error) {
 	alloc := id.NewAllocatorImpl(kv, path.Join(rootPath, AllocClusterIDPrefix), idAllocatorStep)
 
 	manager := &managerImpl{
@@ -69,7 +69,7 @@ func NewManagerImpl(storage storage.Storage, kv clientv3.KV, client *clientv3.Cl
 		clusters:        make(map[string]*Cluster, 0),
 		rootPath:        rootPath,
 		idAllocatorStep: idAllocatorStep,
-		enableScheduled: enableScheduled,
+		enableSchedule:  enableSchedule,
 	}
 
 	return manager, nil
@@ -134,7 +134,7 @@ func (m *managerImpl) CreateCluster(ctx context.Context, clusterName string, opt
 		return nil, errors.WithMessage(err, "cluster load")
 	}
 
-	c, err := NewCluster(clusterMetadata, m.client, m.rootPath, m.enableScheduled)
+	c, err := NewCluster(clusterMetadata, m.client, m.rootPath, m.enableSchedule)
 	if err != nil {
 		return nil, errors.WithMessage(err, "new cluster")
 	}
@@ -287,7 +287,7 @@ func (m *managerImpl) Start(ctx context.Context) error {
 			return errors.WithMessage(err, "fail to load cluster")
 		}
 		log.Info("open cluster successfully", zap.String("cluster", clusterMetadata.Name()))
-		c, err := NewCluster(clusterMetadata, m.client, m.rootPath, m.enableScheduled)
+		c, err := NewCluster(clusterMetadata, m.client, m.rootPath, m.enableSchedule)
 		if err != nil {
 			return errors.WithMessage(err, "new cluster")
 		}

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -49,27 +49,27 @@ type managerImpl struct {
 	running  bool
 	clusters map[string]*Cluster
 
-	storage           storage.Storage
-	kv                clientv3.KV
-	client            *clientv3.Client
-	alloc             id.Allocator
-	rootPath          string
-	idAllocatorStep   uint
-	schedulerOperator bool
+	storage         storage.Storage
+	kv              clientv3.KV
+	client          *clientv3.Client
+	alloc           id.Allocator
+	rootPath        string
+	idAllocatorStep uint
+	enableScheduled bool
 }
 
-func NewManagerImpl(storage storage.Storage, kv clientv3.KV, client *clientv3.Client, rootPath string, idAllocatorStep uint, schedulerOperator bool) (Manager, error) {
+func NewManagerImpl(storage storage.Storage, kv clientv3.KV, client *clientv3.Client, rootPath string, idAllocatorStep uint, enableScheduled bool) (Manager, error) {
 	alloc := id.NewAllocatorImpl(kv, path.Join(rootPath, AllocClusterIDPrefix), idAllocatorStep)
 
 	manager := &managerImpl{
-		storage:           storage,
-		kv:                kv,
-		client:            client,
-		alloc:             alloc,
-		clusters:          make(map[string]*Cluster, 0),
-		rootPath:          rootPath,
-		idAllocatorStep:   idAllocatorStep,
-		schedulerOperator: schedulerOperator,
+		storage:         storage,
+		kv:              kv,
+		client:          client,
+		alloc:           alloc,
+		clusters:        make(map[string]*Cluster, 0),
+		rootPath:        rootPath,
+		idAllocatorStep: idAllocatorStep,
+		enableScheduled: enableScheduled,
 	}
 
 	return manager, nil
@@ -134,7 +134,7 @@ func (m *managerImpl) CreateCluster(ctx context.Context, clusterName string, opt
 		return nil, errors.WithMessage(err, "cluster load")
 	}
 
-	c, err := NewCluster(clusterMetadata, m.client, m.rootPath, m.schedulerOperator)
+	c, err := NewCluster(clusterMetadata, m.client, m.rootPath, m.enableScheduled)
 	if err != nil {
 		return nil, errors.WithMessage(err, "new cluster")
 	}
@@ -287,7 +287,7 @@ func (m *managerImpl) Start(ctx context.Context) error {
 			return errors.WithMessage(err, "fail to load cluster")
 		}
 		log.Info("open cluster successfully", zap.String("cluster", clusterMetadata.Name()))
-		c, err := NewCluster(clusterMetadata, m.client, m.rootPath, m.schedulerOperator)
+		c, err := NewCluster(clusterMetadata, m.client, m.rootPath, m.enableScheduled)
 		if err != nil {
 			return errors.WithMessage(err, "new cluster")
 		}

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -99,8 +99,8 @@ func (c *ClusterMetadata) GetShardTables(shardIDs []storage.ShardID) map[storage
 		}
 		result[shardID] = ShardTables{
 			Shard: ShardInfo{
-				ID:      shardTableID.ShardNode.ID,
-				Role:    shardTableID.ShardNode.ShardRole,
+				ID:      shardID,
+				Role:    storage.ShardRoleLeader,
 				Version: shardTableID.Version,
 			},
 			Tables: tableInfos,
@@ -385,7 +385,6 @@ func (c *ClusterMetadata) RegisterNode(ctx context.Context, registeredNode Regis
 			log.Error("update cluster view failed", zap.Error(err))
 		}
 	}
-
 	// Update shard node mapping.
 	shardNodes := make(map[string][]storage.ShardNode, 1)
 	shardNodes[registeredNode.Node.Name] = make([]storage.ShardNode, 0, len(registeredNode.ShardInfos))

--- a/server/cluster/metadata/table_manager_test.go
+++ b/server/cluster/metadata/table_manager_test.go
@@ -26,7 +26,7 @@ const (
 	defaultNodeCount                = 2
 	defaultReplicationFactor        = 1
 	defaultShardTotal               = 8
-	defaultEnableScheduled          = true
+	defaultEnableSchedule           = true
 	node1                           = "127.0.0.1:8081"
 	node2                           = "127.0.0.2:8081"
 	table1                          = "table1"
@@ -52,7 +52,7 @@ func newTestStorage(t *testing.T) (storage.Storage, clientv3.KV, *clientv3.Clien
 }
 
 func newClusterManagerWithStorage(storage storage.Storage, kv clientv3.KV, client *clientv3.Client) (cluster.Manager, error) {
-	return cluster.NewManagerImpl(storage, kv, client, testRootPath, defaultIDAllocatorStep, defaultEnableScheduled)
+	return cluster.NewManagerImpl(storage, kv, client, testRootPath, defaultIDAllocatorStep, defaultEnableSchedule)
 }
 
 func newTestClusterManager(t *testing.T) (cluster.Manager, etcdutil.CloseFn) {

--- a/server/cluster/metadata/table_manager_test.go
+++ b/server/cluster/metadata/table_manager_test.go
@@ -19,29 +19,28 @@ import (
 )
 
 const (
-	defaultTimeout                           = time.Second * 10
-	cluster1                                 = "ceresdbCluster1"
-	cluster2                                 = "ceresdbCluster2"
-	defaultSchema                            = "ceresdbSchema"
-	defaultNodeCount                         = 2
-	defaultReplicationFactor                 = 1
-	defaultShardTotal                        = 8
-	defaultPartitionTableRatioOfNodes        = 2
-	defaultLease                             = 100
-	node1                                    = "127.0.0.1:8081"
-	node2                                    = "127.0.0.2:8081"
-	table1                                   = "table1"
-	table2                                   = "table2"
-	table3                                   = "table3"
-	table4                                   = "table4"
-	defaultSchemaID                   uint32 = 0
-	tableID1                          uint64 = 0
-	tableID2                          uint64 = 1
-	tableID3                          uint64 = 2
-	tableID4                          uint64 = 3
-	testRootPath                             = "/rootPath"
-	defaultIDAllocatorStep                   = 20
-	defaultThreadNum                         = 20
+	defaultTimeout                  = time.Second * 10
+	cluster1                        = "ceresdbCluster1"
+	cluster2                        = "ceresdbCluster2"
+	defaultSchema                   = "ceresdbSchema"
+	defaultNodeCount                = 2
+	defaultReplicationFactor        = 1
+	defaultShardTotal               = 8
+	defaultEnableScheduled          = true
+	node1                           = "127.0.0.1:8081"
+	node2                           = "127.0.0.2:8081"
+	table1                          = "table1"
+	table2                          = "table2"
+	table3                          = "table3"
+	table4                          = "table4"
+	defaultSchemaID          uint32 = 0
+	tableID1                 uint64 = 0
+	tableID2                 uint64 = 1
+	tableID3                 uint64 = 2
+	tableID4                 uint64 = 3
+	testRootPath                    = "/rootPath"
+	defaultIDAllocatorStep          = 20
+	defaultThreadNum                = 20
 )
 
 func newTestStorage(t *testing.T) (storage.Storage, clientv3.KV, *clientv3.Client, etcdutil.CloseFn) {
@@ -53,7 +52,7 @@ func newTestStorage(t *testing.T) (storage.Storage, clientv3.KV, *clientv3.Clien
 }
 
 func newClusterManagerWithStorage(storage storage.Storage, kv clientv3.KV, client *clientv3.Client) (cluster.Manager, error) {
-	return cluster.NewManagerImpl(storage, kv, client, testRootPath, defaultIDAllocatorStep)
+	return cluster.NewManagerImpl(storage, kv, client, testRootPath, defaultIDAllocatorStep, defaultEnableScheduled)
 }
 
 func newTestClusterManager(t *testing.T) (cluster.Manager, etcdutil.CloseFn) {

--- a/server/cluster/metadata/topology_manager.go
+++ b/server/cluster/metadata/topology_manager.go
@@ -53,9 +53,8 @@ type TopologyManager interface {
 }
 
 type ShardTableIDs struct {
-	ShardNode storage.ShardNode
-	TableIDs  []storage.TableID
-	Version   uint64
+	TableIDs []storage.TableID
+	Version  uint64
 }
 
 type GetShardTablesByNodeResult struct {
@@ -166,15 +165,10 @@ func (m *TopologyManagerImpl) GetTableIDs(shardIDs []storage.ShardID) map[storag
 
 	shardTableIDs := make(map[storage.ShardID]ShardTableIDs, len(shardIDs))
 	for _, shardID := range shardIDs {
-		for _, shardNode := range m.shardNodesMapping[shardID] {
-			shardView := m.shardTablesMapping[shardID]
-
-			shardTableIDs[shardID] = ShardTableIDs{
-				ShardNode: shardNode,
-				TableIDs:  shardView.TableIDs,
-				Version:   shardView.Version,
-			}
-			break
+		shardView := m.shardTablesMapping[shardID]
+		shardTableIDs[shardID] = ShardTableIDs{
+			TableIDs: shardView.TableIDs,
+			Version:  shardView.Version,
 		}
 	}
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -47,8 +47,8 @@ const (
 	defaultClusterNodeCount         = 2
 	defaultClusterReplicationFactor = 1
 	defaultClusterShardTotal        = 8
-	// TODO: defaultSchedulerOperator should be set false, this is to be compatible with the implementation of CeresDB's local storage, which will be required later...
-	defaultSchedulerOperator = true
+	// TODO: defaultEnableScheduled should be set false, this is to be compatible with the implementation of CeresDB's local storage, which will be required later...
+	defaultEnableScheduled = false
 
 	defaultHTTPPort = 8080
 
@@ -109,8 +109,8 @@ type Config struct {
 	DefaultClusterReplicationFactor int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
 	DefaultClusterShardTotal        int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
 
-	// When the SchedulerOperator is turned on, the failover scheduling will be turned off, which is used for CeresDB cluster publishing and using local storage.
-	SchedulerOperator bool `toml:"scheduler-operator" env:"SCHEDULER_OPERATOR"`
+	// When the EnableScheduled is turned on, the failover scheduling will be turned on, which is used for CeresDB cluster publishing and using local storage.
+	EnableScheduled bool `toml:"enable-scheduled" env:"ENABLE_SCHEDULER"`
 
 	ClientUrls          string `toml:"client-urls" env:"CLIENT_URLS"`
 	PeerUrls            string `toml:"peer-urls" env:"PEER_URLS"`
@@ -273,7 +273,7 @@ func MakeConfigParser() (*Parser, error) {
 		DefaultClusterNodeCount:         defaultClusterNodeCount,
 		DefaultClusterReplicationFactor: defaultClusterReplicationFactor,
 		DefaultClusterShardTotal:        defaultClusterShardTotal,
-		SchedulerOperator:               defaultSchedulerOperator,
+		EnableScheduled:                 defaultEnableScheduled,
 
 		HTTPPort: defaultHTTPPort,
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -47,8 +47,8 @@ const (
 	defaultClusterNodeCount         = 2
 	defaultClusterReplicationFactor = 1
 	defaultClusterShardTotal        = 8
-	// TODO: DefaultClusterDeployMode should be set false, this is to be compatible with the implementation of CeresDB's local storage, which will be required later...
-	defaultClusterDeployMode = true
+	// TODO: defaultSchedulerOperator should be set false, this is to be compatible with the implementation of CeresDB's local storage, which will be required later...
+	defaultSchedulerOperator = true
 
 	defaultHTTPPort = 8080
 
@@ -108,8 +108,9 @@ type Config struct {
 	DefaultClusterNodeCount         int    `toml:"default-cluster-node-count" env:"DEFAULT_CLUSTER_NODE_COUNT"`
 	DefaultClusterReplicationFactor int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
 	DefaultClusterShardTotal        int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
-	// When the deployMode is turned on, the failover scheduling will be turned off, which is used for CeresDB cluster publishing and using local storage.
-	DefaultClusterDeployMode bool `toml:"default-cluster-deploy-mode" env:"DEFAULT_CLUSTER_DEPLOY_MODE"`
+
+	// When the SchedulerOperator is turned on, the failover scheduling will be turned off, which is used for CeresDB cluster publishing and using local storage.
+	SchedulerOperator bool `toml:"scheduler-operator" env:"SCHEDULER_OPERATOR"`
 
 	ClientUrls          string `toml:"client-urls" env:"CLIENT_URLS"`
 	PeerUrls            string `toml:"peer-urls" env:"PEER_URLS"`
@@ -272,7 +273,7 @@ func MakeConfigParser() (*Parser, error) {
 		DefaultClusterNodeCount:         defaultClusterNodeCount,
 		DefaultClusterReplicationFactor: defaultClusterReplicationFactor,
 		DefaultClusterShardTotal:        defaultClusterShardTotal,
-		DefaultClusterDeployMode:        defaultClusterDeployMode,
+		SchedulerOperator:               defaultSchedulerOperator,
 
 		HTTPPort: defaultHTTPPort,
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -47,8 +47,8 @@ const (
 	defaultClusterNodeCount         = 2
 	defaultClusterReplicationFactor = 1
 	defaultClusterShardTotal        = 8
-	// TODO: defaultEnableScheduled should be set false, this is to be compatible with the implementation of CeresDB's local storage, which will be required later...
-	defaultEnableScheduled = false
+	// TODO: enableSchedule should be set false, this is to be compatible with the implementation of CeresDB's local storage, which will be required later...
+	enableSchedule = false
 
 	defaultHTTPPort = 8080
 
@@ -109,8 +109,8 @@ type Config struct {
 	DefaultClusterReplicationFactor int    `toml:"default-cluster-replication-factor" env:"DEFAULT_CLUSTER_REPLICATION_FACTOR"`
 	DefaultClusterShardTotal        int    `toml:"default-cluster-shard-total" env:"DEFAULT_CLUSTER_SHARD_TOTAL"`
 
-	// When the EnableScheduled is turned on, the failover scheduling will be turned on, which is used for CeresDB cluster publishing and using local storage.
-	EnableScheduled bool `toml:"enable-scheduled" env:"ENABLE_SCHEDULER"`
+	// When the EnableSchedule is turned on, the failover scheduling will be turned on, which is used for CeresDB cluster publishing and using local storage.
+	EnableSchedule bool `toml:"enable-schedule" env:"ENABLE_SCHEDULE"`
 
 	ClientUrls          string `toml:"client-urls" env:"CLIENT_URLS"`
 	PeerUrls            string `toml:"peer-urls" env:"PEER_URLS"`
@@ -273,7 +273,7 @@ func MakeConfigParser() (*Parser, error) {
 		DefaultClusterNodeCount:         defaultClusterNodeCount,
 		DefaultClusterReplicationFactor: defaultClusterReplicationFactor,
 		DefaultClusterShardTotal:        defaultClusterShardTotal,
-		EnableScheduled:                 defaultEnableScheduled,
+		EnableSchedule:                  enableSchedule,
 
 		HTTPPort: defaultHTTPPort,
 	}

--- a/server/coordinator/procedure/test/common.go
+++ b/server/coordinator/procedure/test/common.go
@@ -27,6 +27,7 @@ const (
 	DefaultReplicationFactor               = 1
 	DefaultPartitionTableProportionOfNodes = 0.5
 	DefaultShardTotal                      = 4
+	DefaultSchedulerOperator               = true
 )
 
 type MockDispatch struct{}
@@ -97,7 +98,7 @@ func InitEmptyCluster(ctx context.Context, t *testing.T) *cluster.Cluster {
 	err = clusterMetadata.Load(ctx)
 	re.NoError(err)
 
-	c, err := cluster.NewCluster(clusterMetadata, client, TestRootPath)
+	c, err := cluster.NewCluster(clusterMetadata, client, TestRootPath, DefaultSchedulerOperator)
 	re.NoError(err)
 
 	_, _, err = c.GetMetadata().GetOrCreateSchema(ctx, TestSchemaName)

--- a/server/coordinator/scheduler/scheduler_manager.go
+++ b/server/coordinator/scheduler/scheduler_manager.go
@@ -35,7 +35,7 @@ type Manager interface {
 
 	Stop(ctx context.Context) error
 
-	UpdateDeployMode(ctx context.Context, deployMode bool)
+	UpdateSchedulerOperator(ctx context.Context, schedulerOperator bool)
 
 	// Scheduler will be called when received new heartbeat, every scheduler registered in schedulerManager will be called to generate procedures.
 	// Scheduler cloud be schedule with fix time interval or heartbeat.
@@ -55,10 +55,10 @@ type ManagerImpl struct {
 	registerSchedulers []Scheduler
 	shardWatch         *watch.ShardWatch
 	isRunning          bool
-	deployMode         bool
+	schedulerOperator  bool
 }
 
-func NewManager(procedureManager procedure.Manager, factory *coordinator.Factory, clusterMetadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string) Manager {
+func NewManager(procedureManager procedure.Manager, factory *coordinator.Factory, clusterMetadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string, schedulerOperator bool) Manager {
 	return &ManagerImpl{
 		procedureManager:   procedureManager,
 		registerSchedulers: []Scheduler{},
@@ -68,6 +68,7 @@ func NewManager(procedureManager procedure.Manager, factory *coordinator.Factory
 		clusterMetadata:    clusterMetadata,
 		client:             client,
 		rootPath:           rootPath,
+		schedulerOperator:  schedulerOperator,
 	}
 }
 
@@ -114,9 +115,9 @@ func (m *ManagerImpl) Start(ctx context.Context) error {
 				clusterSnapshot := m.clusterMetadata.GetClusterSnapshot()
 				log.Debug("scheduler manager invoke", zap.String("clusterSnapshot", fmt.Sprintf("%v", clusterSnapshot)))
 
-				// TODO: Perhaps these codes related to deployMode need to be refactored.
-				// If deployMode is turned on, the scheduler will only be scheduled in the non-stable state.
-				if m.deployMode && clusterSnapshot.Topology.ClusterView.State == storage.ClusterStateStable {
+				// TODO: Perhaps these codes related to schedulerOperator need to be refactored.
+				// If schedulerOperator is turned on, the scheduler will only be scheduled in the non-stable state.
+				if m.schedulerOperator && clusterSnapshot.Topology.ClusterView.State == storage.ClusterStateStable {
 					continue
 				}
 				if clusterSnapshot.Topology.IsPrepareFinished() {
@@ -199,10 +200,10 @@ func (m *ManagerImpl) Scheduler(ctx context.Context, clusterSnapshot metadata.Sn
 	return results
 }
 
-func (m *ManagerImpl) UpdateDeployMode(_ context.Context, deployMode bool) {
+func (m *ManagerImpl) UpdateSchedulerOperator(_ context.Context, schedulerOperator bool) {
 	m.lock.Lock()
-	m.deployMode = deployMode
+	m.schedulerOperator = schedulerOperator
 	m.lock.Unlock()
 
-	log.Info("scheduler manager update deploy mode", zap.Bool("deployMode", deployMode))
+	log.Info("scheduler manager update scheduler operator", zap.Bool("schedulerOperator", schedulerOperator))
 }

--- a/server/coordinator/scheduler/scheduler_manager.go
+++ b/server/coordinator/scheduler/scheduler_manager.go
@@ -35,7 +35,7 @@ type Manager interface {
 
 	Stop(ctx context.Context) error
 
-	UpdateEnableScheduled(ctx context.Context, enableScheduled bool)
+	UpdateEnableSchedule(ctx context.Context, enableSchedule bool)
 
 	// Scheduler will be called when received new heartbeat, every scheduler registered in schedulerManager will be called to generate procedures.
 	// Scheduler cloud be schedule with fix time interval or heartbeat.
@@ -55,10 +55,10 @@ type ManagerImpl struct {
 	registerSchedulers []Scheduler
 	shardWatch         *watch.ShardWatch
 	isRunning          bool
-	enableScheduled    bool
+	enableSchedule     bool
 }
 
-func NewManager(procedureManager procedure.Manager, factory *coordinator.Factory, clusterMetadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string, enableScheduled bool) Manager {
+func NewManager(procedureManager procedure.Manager, factory *coordinator.Factory, clusterMetadata *metadata.ClusterMetadata, client *clientv3.Client, rootPath string, enableSchedule bool) Manager {
 	return &ManagerImpl{
 		procedureManager:   procedureManager,
 		registerSchedulers: []Scheduler{},
@@ -68,7 +68,7 @@ func NewManager(procedureManager procedure.Manager, factory *coordinator.Factory
 		clusterMetadata:    clusterMetadata,
 		client:             client,
 		rootPath:           rootPath,
-		enableScheduled:    enableScheduled,
+		enableSchedule:     enableSchedule,
 	}
 }
 
@@ -117,7 +117,7 @@ func (m *ManagerImpl) Start(ctx context.Context) error {
 
 				// TODO: Perhaps these codes related to schedulerOperator need to be refactored.
 				// If schedulerOperator is turned on, the scheduler will only be scheduled in the non-stable state.
-				if !m.enableScheduled && clusterSnapshot.Topology.ClusterView.State == storage.ClusterStateStable {
+				if !m.enableSchedule && clusterSnapshot.Topology.ClusterView.State == storage.ClusterStateStable {
 					continue
 				}
 				if clusterSnapshot.Topology.IsPrepareFinished() {
@@ -200,10 +200,10 @@ func (m *ManagerImpl) Scheduler(ctx context.Context, clusterSnapshot metadata.Sn
 	return results
 }
 
-func (m *ManagerImpl) UpdateEnableScheduled(_ context.Context, enableScheduled bool) {
+func (m *ManagerImpl) UpdateEnableSchedule(_ context.Context, enableSchedule bool) {
 	m.lock.Lock()
-	m.enableScheduled = enableScheduled
+	m.enableSchedule = enableSchedule
 	m.lock.Unlock()
 
-	log.Info("scheduler manager update enableScheduled", zap.Bool("enableScheduled", enableScheduled))
+	log.Info("scheduler manager update enableSchedule", zap.Bool("enableSchedule", enableSchedule))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -159,7 +159,7 @@ func (srv *Server) startServer(_ context.Context) error {
 		MaxScanLimit: srv.cfg.MaxScanLimit, MinScanLimit: srv.cfg.MinScanLimit,
 	})
 
-	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.etcdCli, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep, srv.cfg.EnableScheduled)
+	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.etcdCli, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep, srv.cfg.EnableSchedule)
 	if err != nil {
 		return errors.WithMessage(err, "start server")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -159,7 +159,7 @@ func (srv *Server) startServer(_ context.Context) error {
 		MaxScanLimit: srv.cfg.MaxScanLimit, MinScanLimit: srv.cfg.MinScanLimit,
 	})
 
-	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.etcdCli, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep)
+	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.etcdCli, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep, srv.cfg.SchedulerOperator)
 	if err != nil {
 		return errors.WithMessage(err, "start server")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -159,7 +159,7 @@ func (srv *Server) startServer(_ context.Context) error {
 		MaxScanLimit: srv.cfg.MaxScanLimit, MinScanLimit: srv.cfg.MinScanLimit,
 	})
 
-	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.etcdCli, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep, srv.cfg.SchedulerOperator)
+	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.etcdCli, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep, srv.cfg.EnableScheduled)
 	if err != nil {
 		return errors.WithMessage(err, "start server")
 	}

--- a/server/service/grpc/service.go
+++ b/server/service/grpc/service.go
@@ -137,7 +137,9 @@ func (s *Service) GetTablesOfShards(ctx context.Context, req *metaservicepb.GetT
 		return &metaservicepb.GetTablesOfShardsResponse{Header: responseHeader(err, "grpc get tables of shards")}, nil
 	}
 
-	return convertToGetTablesOfShardsResponse(tables), nil
+	result := convertToGetTablesOfShardsResponse(tables)
+	log.Info("[GetTablesOfShards]", zap.String("result", fmt.Sprintf("%v", result)))
+	return result, nil
 }
 
 // CreateTable implements gRPC CeresmetaServer.

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -53,7 +53,7 @@ func (a *API) NewAPIRouter() *Router {
 	router.Post("/route", a.route)
 	router.Post("/dropTable", a.dropTable)
 	router.Post("/getNodeShards", a.getNodeShards)
-	router.Put("/schedulerOperator", a.schedulerOperator)
+	router.Put("/enableScheduled", a.enableScheduled)
 	router.Get("/healthCheck", a.healthCheck)
 
 	return router
@@ -367,28 +367,28 @@ func (a *API) split(writer http.ResponseWriter, req *http.Request) {
 	a.respond(writer, newShardID)
 }
 
-type UpdateSchedulerOperatorRequest struct {
-	ClusterName       string `json:"clusterName"`
-	SchedulerOperator bool   `json:"schedulerOperator"`
+type UpdateEnableScheduledRequest struct {
+	ClusterName     string `json:"clusterName"`
+	EnableScheduled bool   `json:"enableScheduled"`
 }
 
-func (a *API) schedulerOperator(writer http.ResponseWriter, req *http.Request) {
-	var updateSchedulerOperatorRequest UpdateSchedulerOperatorRequest
-	err := json.NewDecoder(req.Body).Decode(&updateSchedulerOperatorRequest)
+func (a *API) enableScheduled(writer http.ResponseWriter, req *http.Request) {
+	var updateEnableScheduledRequest UpdateEnableScheduledRequest
+	err := json.NewDecoder(req.Body).Decode(&updateEnableScheduledRequest)
 	if err != nil {
 		log.Error("decode request body failed", zap.Error(err))
 		a.respondError(writer, ErrParseRequest, "")
 		return
 	}
 
-	c, err := a.clusterManager.GetCluster(req.Context(), updateSchedulerOperatorRequest.ClusterName)
+	c, err := a.clusterManager.GetCluster(req.Context(), updateEnableScheduledRequest.ClusterName)
 	if err != nil {
-		log.Error("cluster not found", zap.String("clusterName", updateSchedulerOperatorRequest.ClusterName), zap.Error(err))
+		log.Error("cluster not found", zap.String("clusterName", updateEnableScheduledRequest.ClusterName), zap.Error(err))
 		a.respondError(writer, metadata.ErrClusterNotFound, "cluster not found")
 		return
 	}
 
-	c.GetSchedulerManager().UpdateSchedulerOperator(req.Context(), updateSchedulerOperatorRequest.SchedulerOperator)
+	c.GetSchedulerManager().UpdateEnableScheduled(req.Context(), updateEnableScheduledRequest.EnableScheduled)
 
 	a.respond(writer, nil)
 }

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -53,7 +53,7 @@ func (a *API) NewAPIRouter() *Router {
 	router.Post("/route", a.route)
 	router.Post("/dropTable", a.dropTable)
 	router.Post("/getNodeShards", a.getNodeShards)
-	router.Put("/deployMode", a.deployMode)
+	router.Put("/schedulerOperator", a.schedulerOperator)
 	router.Get("/healthCheck", a.healthCheck)
 
 	return router
@@ -367,28 +367,28 @@ func (a *API) split(writer http.ResponseWriter, req *http.Request) {
 	a.respond(writer, newShardID)
 }
 
-type UpdateDeployModeRequest struct {
-	ClusterName string `json:"clusterName"`
-	DeployMode  bool   `json:"deployMode"`
+type UpdateSchedulerOperatorRequest struct {
+	ClusterName       string `json:"clusterName"`
+	SchedulerOperator bool   `json:"schedulerOperator"`
 }
 
-func (a *API) deployMode(writer http.ResponseWriter, req *http.Request) {
-	var updateDeployModeRequest UpdateDeployModeRequest
-	err := json.NewDecoder(req.Body).Decode(&updateDeployModeRequest)
+func (a *API) schedulerOperator(writer http.ResponseWriter, req *http.Request) {
+	var updateSchedulerOperatorRequest UpdateSchedulerOperatorRequest
+	err := json.NewDecoder(req.Body).Decode(&updateSchedulerOperatorRequest)
 	if err != nil {
 		log.Error("decode request body failed", zap.Error(err))
 		a.respondError(writer, ErrParseRequest, "")
 		return
 	}
 
-	c, err := a.clusterManager.GetCluster(req.Context(), updateDeployModeRequest.ClusterName)
+	c, err := a.clusterManager.GetCluster(req.Context(), updateSchedulerOperatorRequest.ClusterName)
 	if err != nil {
-		log.Error("cluster not found", zap.String("clusterName", updateDeployModeRequest.ClusterName), zap.Error(err))
+		log.Error("cluster not found", zap.String("clusterName", updateSchedulerOperatorRequest.ClusterName), zap.Error(err))
 		a.respondError(writer, metadata.ErrClusterNotFound, "cluster not found")
 		return
 	}
 
-	c.GetSchedulerManager().UpdateDeployMode(req.Context(), updateDeployModeRequest.DeployMode)
+	c.GetSchedulerManager().UpdateSchedulerOperator(req.Context(), updateSchedulerOperatorRequest.SchedulerOperator)
 
 	a.respond(writer, nil)
 }

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -53,7 +53,7 @@ func (a *API) NewAPIRouter() *Router {
 	router.Post("/route", a.route)
 	router.Post("/dropTable", a.dropTable)
 	router.Post("/getNodeShards", a.getNodeShards)
-	router.Put("/enableScheduled", a.enableScheduled)
+	router.Put("/enableSchedule", a.enableSchedule)
 	router.Get("/healthCheck", a.healthCheck)
 
 	return router
@@ -367,28 +367,28 @@ func (a *API) split(writer http.ResponseWriter, req *http.Request) {
 	a.respond(writer, newShardID)
 }
 
-type UpdateEnableScheduledRequest struct {
-	ClusterName     string `json:"clusterName"`
-	EnableScheduled bool   `json:"enableScheduled"`
+type UpdateEnableScheduleRequest struct {
+	ClusterName    string `json:"clusterName"`
+	EnableSchedule bool   `json:"enableSchedule"`
 }
 
-func (a *API) enableScheduled(writer http.ResponseWriter, req *http.Request) {
-	var updateEnableScheduledRequest UpdateEnableScheduledRequest
-	err := json.NewDecoder(req.Body).Decode(&updateEnableScheduledRequest)
+func (a *API) enableSchedule(writer http.ResponseWriter, req *http.Request) {
+	var updateEnableScheduleRequest UpdateEnableScheduleRequest
+	err := json.NewDecoder(req.Body).Decode(&updateEnableScheduleRequest)
 	if err != nil {
 		log.Error("decode request body failed", zap.Error(err))
 		a.respondError(writer, ErrParseRequest, "")
 		return
 	}
 
-	c, err := a.clusterManager.GetCluster(req.Context(), updateEnableScheduledRequest.ClusterName)
+	c, err := a.clusterManager.GetCluster(req.Context(), updateEnableScheduleRequest.ClusterName)
 	if err != nil {
-		log.Error("cluster not found", zap.String("clusterName", updateEnableScheduledRequest.ClusterName), zap.Error(err))
+		log.Error("cluster not found", zap.String("clusterName", updateEnableScheduleRequest.ClusterName), zap.Error(err))
 		a.respondError(writer, metadata.ErrClusterNotFound, "cluster not found")
 		return
 	}
 
-	c.GetSchedulerManager().UpdateEnableScheduled(req.Context(), updateEnableScheduledRequest.EnableScheduled)
+	c.GetSchedulerManager().UpdateEnableSchedule(req.Context(), updateEnableScheduleRequest.EnableSchedule)
 
 	a.respond(writer, nil)
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Fix some bugs found in release testing.

# What changes are included in this PR?
1. Fix the bug of `getTableOfShard`, now CeresDB can open shard normally.
2. Rename `deployMode` to `schedulerOperator`.

# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests.