### PR TITLE
refactor: avoid frequent update of clusterVersion

### DIFF
--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -411,26 +411,26 @@ func (c *ClusterMetadata) RegisterNode(ctx context.Context, registeredNode Regis
 
 func needUpdate(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
 	if len(oldCache.ShardInfos) >= 50 {
-		return !sortCompare(oldCache, registeredNode)
+		return !sortCompare(oldCache.ShardInfos, registeredNode.ShardInfos)
 	}
-	return !simpleCompare(oldCache, registeredNode)
+	return !simpleCompare(oldCache.ShardInfos, registeredNode.ShardInfos)
 }
 
 // sortCompare compare if they are the same by sorted slice, return true when they are the same.
-func sortCompare(oldCache, registeredNode RegisteredNode) bool {
-	if len(oldCache.ShardInfos) != len(registeredNode.ShardInfos) {
+func sortCompare(oldShardInfos, newShardInfos []ShardInfo) bool {
+	if len(oldShardInfos) != len(newShardInfos) {
 		return true
 	}
-	oldShardIDs := make([]storage.ShardID, 0, len(oldCache.ShardInfos))
-	for i := 0; i < len(oldCache.ShardInfos); i++ {
-		oldShardIDs = append(oldShardIDs, oldCache.ShardInfos[i].ID)
+	oldShardIDs := make([]storage.ShardID, 0, len(oldShardInfos))
+	for i := 0; i < len(oldShardInfos); i++ {
+		oldShardIDs = append(oldShardIDs, oldShardInfos[i].ID)
 	}
 	sort.Slice(oldShardIDs, func(i, j int) bool {
 		return oldShardIDs[i] < oldShardIDs[j]
 	})
-	curShardIDs := make([]storage.ShardID, 0, len(registeredNode.ShardInfos))
-	for i := 0; i < len(registeredNode.ShardInfos); i++ {
-		curShardIDs = append(curShardIDs, registeredNode.ShardInfos[i].ID)
+	curShardIDs := make([]storage.ShardID, 0, len(newShardInfos))
+	for i := 0; i < len(newShardInfos); i++ {
+		curShardIDs = append(curShardIDs, newShardInfos[i].ID)
 	}
 	sort.Slice(curShardIDs, func(i, j int) bool {
 		return curShardIDs[i] < curShardIDs[j]
@@ -444,14 +444,14 @@ func sortCompare(oldCache, registeredNode RegisteredNode) bool {
 }
 
 // simpleCompare compare if they are the same by simple loop, return true when they are the same.
-func simpleCompare(oldCache, registeredNode RegisteredNode) bool {
-	if len(oldCache.ShardInfos) != len(registeredNode.ShardInfos) {
+func simpleCompare(oldShardInfos, newShardInfos []ShardInfo) bool {
+	if len(oldShardInfos) != len(newShardInfos) {
 		return true
 	}
 L1:
-	for i := 0; i < len(oldCache.ShardInfos); i++ {
-		for j := 0; j < len(registeredNode.ShardInfos); j++ {
-			if oldCache.ShardInfos[i].ID == registeredNode.ShardInfos[j].ID {
+	for i := 0; i < len(newShardInfos); i++ {
+		for j := 0; j < len(newShardInfos); j++ {
+			if oldShardInfos[i].ID == newShardInfos[j].ID {
 				continue L1
 			}
 		}

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -411,7 +411,7 @@ func (c *ClusterMetadata) RegisterNode(ctx context.Context, registeredNode Regis
 }
 
 func needUpdate(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
-	if len(oldCache.ShardInfos) >= 20 {
+	if len(oldCache.ShardInfos) >= 50 {
 		return !sortCompare(oldCache, registeredNode)
 	}
 	return !simpleCompare(oldCache, registeredNode)

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -415,11 +415,12 @@ func needUpdate(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
 		return true
 	}
 	if len(oldCache.ShardInfos) >= 20 {
-		return sortCompare(oldCache, registeredNode)
+		return !sortCompare(oldCache, registeredNode)
 	}
-	return simpleCompare(oldCache, registeredNode)
+	return !simpleCompare(oldCache, registeredNode)
 }
 
+// sortCompare compare if they are the same by sorted slice, return true when they are the same.
 func sortCompare(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
 	oldShardIDs := make([]storage.ShardID, 0, len(oldCache.ShardInfos))
 	for i := 0; i < len(oldCache.ShardInfos); i++ {
@@ -437,26 +438,25 @@ func sortCompare(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
 	})
 	for i := 0; i < len(curShardIDs); i++ {
 		if curShardIDs[i] != oldShardIDs[i] {
-			return true
+			return false
 		}
 	}
-	return false
+	return true
 }
 
+// simpleCompare compare if they are the same by simple loop, return true when they are the same.
 func simpleCompare(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
+L1:
 	for i := 0; i < len(oldCache.ShardInfos); i++ {
-		found := false
 		for j := 0; j < len(registeredNode.ShardInfos); j++ {
 			if oldCache.ShardInfos[i].ID == registeredNode.ShardInfos[j].ID {
-				found = true
+				continue L1
 			}
 		}
-		if !found {
-			return true
-		}
+		return false
 	}
 
-	return false
+	return true
 }
 
 func (c *ClusterMetadata) GetRegisteredNodes() []RegisteredNode {

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -377,9 +377,6 @@ func (c *ClusterMetadata) RegisterNode(ctx context.Context, registeredNode Regis
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	oldCache, exists := c.registeredNodesCache[registeredNode.Node.Name]
-	c.registeredNodesCache[registeredNode.Node.Name] = registeredNode
-
 	// When the number of nodes in the cluster reaches the threshold, modify the cluster status to prepare.
 	// TODO: Consider the design of the entire cluster state, which may require refactoring.
 	if uint32(len(c.registeredNodesCache)) >= c.metaData.MinNodeCount && c.topologyManager.GetClusterState() == storage.ClusterStateEmpty {
@@ -390,6 +387,8 @@ func (c *ClusterMetadata) RegisterNode(ctx context.Context, registeredNode Regis
 
 	// Update shard node mapping.
 	// Check whether to update persistence data.
+	oldCache, exists := c.registeredNodesCache[registeredNode.Node.Name]
+	c.registeredNodesCache[registeredNode.Node.Name] = registeredNode
 	if exists && !needUpdate(oldCache, registeredNode) {
 		return nil
 	}
@@ -418,7 +417,7 @@ func needUpdate(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
 }
 
 // sortCompare compare if they are the same by sorted slice, return true when they are the same.
-func sortCompare(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
+func sortCompare(oldCache, registeredNode RegisteredNode) bool {
 	if len(oldCache.ShardInfos) != len(registeredNode.ShardInfos) {
 		return true
 	}
@@ -445,7 +444,7 @@ func sortCompare(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
 }
 
 // simpleCompare compare if they are the same by simple loop, return true when they are the same.
-func simpleCompare(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
+func simpleCompare(oldCache, registeredNode RegisteredNode) bool {
 	if len(oldCache.ShardInfos) != len(registeredNode.ShardInfos) {
 		return true
 	}

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -411,9 +411,6 @@ func (c *ClusterMetadata) RegisterNode(ctx context.Context, registeredNode Regis
 }
 
 func needUpdate(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
-	if len(oldCache.ShardInfos) != len(registeredNode.ShardInfos) {
-		return true
-	}
 	if len(oldCache.ShardInfos) >= 20 {
 		return !sortCompare(oldCache, registeredNode)
 	}
@@ -422,6 +419,9 @@ func needUpdate(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
 
 // sortCompare compare if they are the same by sorted slice, return true when they are the same.
 func sortCompare(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
+	if len(oldCache.ShardInfos) != len(registeredNode.ShardInfos) {
+		return true
+	}
 	oldShardIDs := make([]storage.ShardID, 0, len(oldCache.ShardInfos))
 	for i := 0; i < len(oldCache.ShardInfos); i++ {
 		oldShardIDs = append(oldShardIDs, oldCache.ShardInfos[i].ID)
@@ -446,6 +446,9 @@ func sortCompare(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
 
 // simpleCompare compare if they are the same by simple loop, return true when they are the same.
 func simpleCompare(oldCache RegisteredNode, registeredNode RegisteredNode) bool {
+	if len(oldCache.ShardInfos) != len(registeredNode.ShardInfos) {
+		return true
+	}
 L1:
 	for i := 0; i < len(oldCache.ShardInfos); i++ {
 		for j := 0; j < len(registeredNode.ShardInfos); j++ {

--- a/server/cluster/metadata/compare_benchmark_test.go
+++ b/server/cluster/metadata/compare_benchmark_test.go
@@ -1,0 +1,69 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/CeresDB/ceresmeta/server/storage"
+)
+
+func buildRegisterNode(shardNumber int) RegisteredNode {
+	shardInfos := make([]ShardInfo, 0, shardNumber)
+	for i := shardNumber; i > 0; i-- {
+		shardInfos = append(shardInfos, ShardInfo{
+			ID:      storage.ShardID(i),
+			Role:    0,
+			Version: 0,
+		})
+	}
+	return RegisteredNode{ShardInfos: shardInfos}
+}
+
+func BenchmarkSortWith10Shards(b *testing.B) {
+	registerNode := buildRegisterNode(10)
+	oldCache := registerNode
+	for i := 0; i < b.N; i++ {
+		sortCompare(oldCache, registerNode)
+	}
+}
+
+func BenchmarkCompareWith10Shards(b *testing.B) {
+	registerNode := buildRegisterNode(10)
+	oldCache := registerNode
+	for i := 0; i < b.N; i++ {
+		simpleCompare(oldCache, registerNode)
+	}
+}
+
+func BenchmarkSortWith20Shards(b *testing.B) {
+	registerNode := buildRegisterNode(20)
+	oldCache := registerNode
+	for i := 0; i < b.N; i++ {
+		sortCompare(oldCache, registerNode)
+	}
+}
+
+func BenchmarkCompareWith20Shards(b *testing.B) {
+	registerNode := buildRegisterNode(20)
+	oldCache := registerNode
+	for i := 0; i < b.N; i++ {
+		simpleCompare(oldCache, registerNode)
+	}
+}
+
+func BenchmarkSortWith100Shards(b *testing.B) {
+	registerNode := buildRegisterNode(100)
+	oldCache := registerNode
+	for i := 0; i < b.N; i++ {
+		sortCompare(oldCache, registerNode)
+	}
+}
+
+func BenchmarkCompareWith100Shards(b *testing.B) {
+	registerNode := buildRegisterNode(100)
+	oldCache := registerNode
+	for i := 0; i < b.N; i++ {
+		simpleCompare(oldCache, registerNode)
+	}
+}

--- a/server/cluster/metadata/compare_benchmark_test.go
+++ b/server/cluster/metadata/compare_benchmark_test.go
@@ -37,7 +37,7 @@ func BenchmarkCompareWith10Shards(b *testing.B) {
 }
 
 func BenchmarkSortWith20Shards(b *testing.B) {
-	registerNode := buildRegisterNode(20)
+	registerNode := buildRegisterNode(50)
 	oldCache := registerNode
 	for i := 0; i < b.N; i++ {
 		sortCompare(oldCache, registerNode)
@@ -45,7 +45,7 @@ func BenchmarkSortWith20Shards(b *testing.B) {
 }
 
 func BenchmarkCompareWith20Shards(b *testing.B) {
-	registerNode := buildRegisterNode(20)
+	registerNode := buildRegisterNode(50)
 	oldCache := registerNode
 	for i := 0; i < b.N; i++ {
 		simpleCompare(oldCache, registerNode)

--- a/server/cluster/metadata/compare_benchmark_test.go
+++ b/server/cluster/metadata/compare_benchmark_test.go
@@ -24,7 +24,7 @@ func BenchmarkSortWith10Shards(b *testing.B) {
 	registerNode := buildRegisterNode(10)
 	oldCache := registerNode
 	for i := 0; i < b.N; i++ {
-		sortCompare(oldCache, registerNode)
+		sortCompare(oldCache.ShardInfos, registerNode.ShardInfos)
 	}
 }
 
@@ -32,23 +32,23 @@ func BenchmarkCompareWith10Shards(b *testing.B) {
 	registerNode := buildRegisterNode(10)
 	oldCache := registerNode
 	for i := 0; i < b.N; i++ {
-		simpleCompare(oldCache, registerNode)
+		simpleCompare(oldCache.ShardInfos, registerNode.ShardInfos)
 	}
 }
 
-func BenchmarkSortWith20Shards(b *testing.B) {
+func BenchmarkSortWith50Shards(b *testing.B) {
 	registerNode := buildRegisterNode(50)
 	oldCache := registerNode
 	for i := 0; i < b.N; i++ {
-		sortCompare(oldCache, registerNode)
+		sortCompare(oldCache.ShardInfos, registerNode.ShardInfos)
 	}
 }
 
-func BenchmarkCompareWith20Shards(b *testing.B) {
+func BenchmarkCompareWith50Shards(b *testing.B) {
 	registerNode := buildRegisterNode(50)
 	oldCache := registerNode
 	for i := 0; i < b.N; i++ {
-		simpleCompare(oldCache, registerNode)
+		simpleCompare(oldCache.ShardInfos, registerNode.ShardInfos)
 	}
 }
 
@@ -56,7 +56,7 @@ func BenchmarkSortWith100Shards(b *testing.B) {
 	registerNode := buildRegisterNode(100)
 	oldCache := registerNode
 	for i := 0; i < b.N; i++ {
-		sortCompare(oldCache, registerNode)
+		sortCompare(oldCache.ShardInfos, registerNode.ShardInfos)
 	}
 }
 
@@ -64,6 +64,6 @@ func BenchmarkCompareWith100Shards(b *testing.B) {
 	registerNode := buildRegisterNode(100)
 	oldCache := registerNode
 	for i := 0; i < b.N; i++ {
-		simpleCompare(oldCache, registerNode)
+		simpleCompare(oldCache.ShardInfos, registerNode.ShardInfos)
 	}
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Check whether updates are required during node registration to avoid frequent updates of ClusterVersion and put pressure on ETCD.

# What changes are included in this PR?
* Add verification of node shard information in `RegisterNode` to avoid invalid updates.

# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests.