### PR TITLE
fix: fix create table idempotence

### DIFF
--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -131,6 +131,10 @@ func (c *ClusterMetadata) GetShardTables(shardIDs []storage.ShardID) map[storage
 	return result
 }
 
+func (c *ClusterMetadata) GetShardByTableID(tableID []storage.TableID) map[storage.TableID]storage.ShardID {
+	return c.topologyManager.GetShardIDs(tableID)
+}
+
 // DropTable will drop table metadata and all mapping of this table.
 // If the table to be dropped has been opened multiple times, all its mapping will be dropped.
 func (c *ClusterMetadata) DropTable(ctx context.Context, schemaName, tableName string) (DropTableResult, error) {

--- a/server/service/grpc/service.go
+++ b/server/service/grpc/service.go
@@ -99,7 +99,7 @@ func (s *Service) AllocSchemaID(ctx context.Context, req *metaservicepb.AllocSch
 		return ceresmetaClient.AllocSchemaID(ctx, req)
 	}
 
-	log.Info("[AllocSchemaID]", zap.String("schemaName", req.GetName()), zap.String("clusterName", req.GetHeader().GetClusterName()))
+	log.Debug("[AllocSchemaID]", zap.String("schemaName", req.GetName()), zap.String("clusterName", req.GetHeader().GetClusterName()))
 
 	schemaID, _, err := s.h.GetClusterManager().AllocSchemaID(ctx, req.GetHeader().GetClusterName(), req.GetName())
 	if err != nil {
@@ -125,7 +125,7 @@ func (s *Service) GetTablesOfShards(ctx context.Context, req *metaservicepb.GetT
 		return ceresmetaClient.GetTablesOfShards(ctx, req)
 	}
 
-	log.Info("[GetTablesOfShards]", zap.String("clusterName", req.GetHeader().GetClusterName()), zap.String("shardIDs", fmt.Sprint(req.ShardIds)))
+	log.Debug("[GetTablesOfShards]", zap.String("clusterName", req.GetHeader().GetClusterName()), zap.String("shardIDs", fmt.Sprint(req.ShardIds)))
 
 	shardIDs := make([]storage.ShardID, 0, len(req.GetShardIds()))
 	for _, shardID := range req.GetShardIds() {
@@ -153,7 +153,7 @@ func (s *Service) CreateTable(ctx context.Context, req *metaservicepb.CreateTabl
 		return ceresmetaClient.CreateTable(ctx, req)
 	}
 
-	log.Info("[CreateTable]", zap.String("schemaName", req.SchemaName), zap.String("clusterName", req.GetHeader().ClusterName), zap.String("tableName", req.GetName()))
+	log.Debug("[CreateTable]", zap.String("schemaName", req.SchemaName), zap.String("clusterName", req.GetHeader().ClusterName), zap.String("tableName", req.GetName()))
 
 	clusterManager := s.h.GetClusterManager()
 	c, err := clusterManager.GetCluster(ctx, req.GetHeader().GetClusterName())
@@ -224,7 +224,7 @@ func (s *Service) DropTable(ctx context.Context, req *metaservicepb.DropTableReq
 		return ceresmetaClient.DropTable(ctx, req)
 	}
 
-	log.Info("[DropTable]", zap.String("schemaName", req.SchemaName), zap.String("clusterName", req.GetHeader().ClusterName), zap.String("tableName", req.Name))
+	log.Debug("[DropTable]", zap.String("schemaName", req.SchemaName), zap.String("clusterName", req.GetHeader().ClusterName), zap.String("tableName", req.Name))
 
 	clusterManager := s.h.GetClusterManager()
 	c, err := clusterManager.GetCluster(ctx, req.GetHeader().GetClusterName())
@@ -279,7 +279,7 @@ func (s *Service) RouteTables(ctx context.Context, req *metaservicepb.RouteTable
 		return &metaservicepb.RouteTablesResponse{Header: responseHeader(err, "grpc routeTables")}, nil
 	}
 
-	log.Info("[RouteTable]", zap.String("schemaName", req.SchemaName), zap.String("clusterName", req.GetHeader().ClusterName), zap.String("tableNames", strings.Join(req.TableNames, ",")))
+	log.Debug("[RouteTable]", zap.String("schemaName", req.SchemaName), zap.String("clusterName", req.GetHeader().ClusterName), zap.String("tableNames", strings.Join(req.TableNames, ",")))
 
 	// Forward request to the leader.
 	if ceresmetaClient != nil {
@@ -306,7 +306,7 @@ func (s *Service) GetNodes(ctx context.Context, req *metaservicepb.GetNodesReque
 		return ceresmetaClient.GetNodes(ctx, req)
 	}
 
-	log.Info("[GetNodes]", zap.String("clusterName", req.GetHeader().ClusterName))
+	log.Debug("[GetNodes]", zap.String("clusterName", req.GetHeader().ClusterName))
 
 	nodesResult, err := s.h.GetClusterManager().GetNodeShards(ctx, req.GetHeader().GetClusterName())
 	if err != nil {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
In version 1.2.0, we have made a lot of modifications, resulting in the current table creation not having idempotent capabilities. If the table creation fails in CeresDB, it will lead to failure to build tables normally in the future. This problem is fixed in this pull request.

# What changes are included in this PR?
* Make table creation idempotent.
* Make `tableShardMapping` only mapping to single shard.

# Are there any user-facing changes?
Users can retry to create tables that failed to create before.

# How does this change test
Pass all unit tests and integration tests.