### PR TITLE
fix: add leader cache

### DIFF
--- a/server/member/member.go
+++ b/server/member/member.go
@@ -80,13 +80,19 @@ func (m *Member) getLeader(ctx context.Context) (*getLeaderResp, error) {
 	return &getLeaderResp{Leader: leader, Revision: leaderKv.ModRevision, IsLocal: leader.GetId() == m.ID}, nil
 }
 
-// GetLeader gets the leader of the cluster with memory cache.
+// GetLeaderAddr gets the leader address of the cluster with memory cache.
 // return error if no leader found.
-func (m *Member) GetLeader(_ context.Context) (*metastoragepb.Member, bool, error) {
+func (m *Member) GetLeaderAddr(_ context.Context) (GetLeaderAddrResp, error) {
 	if m.leader == nil {
-		return nil, false, errors.WithMessage(ErrGetLeader, "no leader found")
+		return GetLeaderAddrResp{
+			LeaderEndpoint: "",
+			IsLocal:        false,
+		}, errors.WithMessage(ErrGetLeader, "no leader found")
 	}
-	return m.leader, m.leader.GetId() == m.ID, nil
+	return GetLeaderAddrResp{
+		LeaderEndpoint: m.leader.Endpoint,
+		IsLocal:        m.leader.GetId() == m.ID,
+	}, nil
 }
 
 func (m *Member) ResetLeader(ctx context.Context) error {
@@ -249,4 +255,9 @@ type getLeaderResp struct {
 	Leader   *metastoragepb.Member
 	Revision int64
 	IsLocal  bool
+}
+
+type GetLeaderAddrResp struct {
+	LeaderEndpoint string
+	IsLocal        bool
 }

--- a/server/member/member.go
+++ b/server/member/member.go
@@ -11,6 +11,7 @@ import (
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metastoragepb"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/etcdutil"
+	"github.com/pkg/errors"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -54,9 +55,9 @@ func NewMember(rootPath string, id uint64, name, endpoint string, etcdCli *clien
 	}
 }
 
-// GetLeader gets the leader of the cluster.
-// GetLeaderResp.Leader == nil if no leader found.
-func (m *Member) GetLeader(ctx context.Context) (*GetLeaderResp, error) {
+// getLeader gets the leader of the cluster.
+// getLeaderResp.Leader == nil if no leader found.
+func (m *Member) getLeader(ctx context.Context) (*getLeaderResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, m.rpcTimeout)
 	defer cancel()
 	resp, err := m.etcdCli.Get(ctx, m.leaderKey)
@@ -67,7 +68,7 @@ func (m *Member) GetLeader(ctx context.Context) (*GetLeaderResp, error) {
 		return nil, ErrMultipleLeader
 	}
 	if len(resp.Kvs) == 0 {
-		return &GetLeaderResp{}, nil
+		return &getLeaderResp{}, nil
 	}
 	leaderKv := resp.Kvs[0]
 	leader := &metastoragepb.Member{}
@@ -76,7 +77,16 @@ func (m *Member) GetLeader(ctx context.Context) (*GetLeaderResp, error) {
 		return nil, ErrInvalidLeaderValue.WithCause(err)
 	}
 
-	return &GetLeaderResp{Leader: leader, Revision: leaderKv.ModRevision, IsLocal: leader.GetId() == m.ID}, nil
+	return &getLeaderResp{Leader: leader, Revision: leaderKv.ModRevision, IsLocal: leader.GetId() == m.ID}, nil
+}
+
+// GetLeader gets the leader of the cluster with memory cache.
+// return error if no leader found.
+func (m *Member) GetLeader(_ context.Context) (*metastoragepb.Member, bool, error) {
+	if m.leader == nil {
+		return nil, false, errors.WithMessage(ErrGetLeader, "no leader found")
+	}
+	return m.leader, m.leader.GetId() == m.ID, nil
 }
 
 func (m *Member) ResetLeader(ctx context.Context) error {
@@ -174,6 +184,12 @@ func (m *Member) CampaignAndKeepLeader(ctx context.Context, leaseTTLSec int64, c
 	}
 
 	m.logger.Info("[SetLeader]", zap.String("leader-key", m.leaderKey), zap.String("leader", m.Name))
+	// Update leader memory cache.
+	m.leader = &metastoragepb.Member{
+		Name:     m.Name,
+		Id:       m.ID,
+		Endpoint: m.Endpoint,
+	}
 
 	if callbacks != nil {
 		// The leader has been elected and trigger the callbacks.
@@ -229,7 +245,7 @@ func (m *Member) Marshal() (string, error) {
 	return string(bs), nil
 }
 
-type GetLeaderResp struct {
+type getLeaderResp struct {
 	Leader   *metastoragepb.Member
 	Revision int64
 	IsLocal  bool

--- a/server/member/watch_leader.go
+++ b/server/member/watch_leader.go
@@ -78,7 +78,7 @@ func (l *LeaderWatcher) Watch(ctx context.Context, callbacks LeadershipEventCall
 		}
 
 		// Check whether leader exists.
-		leaderResp, err := l.self.GetLeader(ctx)
+		leaderResp, err := l.self.getLeader(ctx)
 		if err != nil {
 			logger.Error("fail to get leader", zap.Error(err))
 			wait = waitReasonFailEtcd
@@ -103,6 +103,10 @@ func (l *LeaderWatcher) Watch(ctx context.Context, callbacks LeadershipEventCall
 			// For other nodes that is not etcd leader, just wait for the new leader elected.
 			wait = waitReasonElectLeader
 		} else {
+			// Cache leader in memory.
+			l.self.leader = leaderResp.Leader
+			log.Info("update leader cache", zap.String("endpoint", leaderResp.Leader.Endpoint))
+
 			// Leader does exist.
 			// A new leader should be elected (the leader should be reset by the current leader itself) if the leader is
 			// not the etcd leader.

--- a/server/member/watch_leader_test.go
+++ b/server/member/watch_leader_test.go
@@ -55,7 +55,7 @@ func TestWatchLeaderSingle(t *testing.T) {
 	// check the member has been the leader
 	ctx, cancel := context.WithTimeout(context.Background(), rpcTimeout)
 	defer cancel()
-	resp, err := mem.GetLeader(ctx)
+	resp, err := mem.getLeader(ctx)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, resp.Leader.Id, mem.ID)
@@ -67,7 +67,7 @@ func TestWatchLeaderSingle(t *testing.T) {
 	// check again whether the leader should be reset
 	ctx, cancel = context.WithTimeout(context.Background(), rpcTimeout)
 	defer cancel()
-	resp, err = mem.GetLeader(ctx)
+	resp, err = mem.getLeader(ctx)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Nil(t, resp.Leader)

--- a/server/server.go
+++ b/server/server.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
-	"github.com/CeresDB/ceresdbproto/golang/pkg/metastoragepb"
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
@@ -217,13 +216,13 @@ func (srv *Server) watchEtcdLeaderPriority(_ context.Context) {
 }
 
 func (srv *Server) createDefaultCluster(ctx context.Context) error {
-	_, isLocal, err := srv.member.GetLeader(ctx)
+	resp, err := srv.member.GetLeaderAddr(ctx)
 	if err != nil {
 		log.Warn("get leader failed", zap.Error(err))
 	}
 
 	// Create default cluster by the leader.
-	if isLocal {
+	if resp.IsLocal {
 		topologyType, err := metadata.ParseTopologyType(srv.cfg.TopologyType)
 		if err != nil {
 			return err
@@ -267,9 +266,9 @@ func (srv *Server) GetClusterManager() cluster.Manager {
 	return srv.clusterManager
 }
 
-func (srv *Server) GetLeader(ctx context.Context) (*metastoragepb.Member, bool, error) {
+func (srv *Server) GetLeader(ctx context.Context) (member.GetLeaderAddrResp, error) {
 	// Get leader with cache.
-	return srv.member.GetLeader(ctx)
+	return srv.member.GetLeaderAddr(ctx)
 }
 
 type leadershipEventCallbacks struct {

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metastoragepb"
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
@@ -216,13 +217,13 @@ func (srv *Server) watchEtcdLeaderPriority(_ context.Context) {
 }
 
 func (srv *Server) createDefaultCluster(ctx context.Context) error {
-	leaderResp, err := srv.member.GetLeader(ctx)
+	_, isLocal, err := srv.member.GetLeader(ctx)
 	if err != nil {
 		log.Warn("get leader failed", zap.Error(err))
 	}
 
 	// Create default cluster by the leader.
-	if leaderResp.IsLocal {
+	if isLocal {
 		topologyType, err := metadata.ParseTopologyType(srv.cfg.TopologyType)
 		if err != nil {
 			return err
@@ -266,7 +267,8 @@ func (srv *Server) GetClusterManager() cluster.Manager {
 	return srv.clusterManager
 }
 
-func (srv *Server) GetLeader(ctx context.Context) (*member.GetLeaderResp, error) {
+func (srv *Server) GetLeader(ctx context.Context) (*metastoragepb.Member, bool, error) {
+	// Get leader with cache.
 	return srv.member.GetLeader(ctx)
 }
 

--- a/server/service/grpc/forward.go
+++ b/server/service/grpc/forward.go
@@ -53,12 +53,12 @@ func (s *Service) getForwardedGrpcClient(ctx context.Context, forwardedAddr stri
 }
 
 func (s *Service) getForwardedAddr(ctx context.Context) (string, bool, error) {
-	member, isLocal, err := s.h.GetLeader(ctx)
+	resp, err := s.h.GetLeader(ctx)
 	if err != nil {
 		return "", false, errors.WithMessage(err, "get forwarded addr")
 	}
-	if isLocal {
+	if resp.IsLocal {
 		return "", true, nil
 	}
-	return member.GetEndpoint(), false, nil
+	return resp.LeaderEndpoint, false, nil
 }

--- a/server/service/grpc/forward.go
+++ b/server/service/grpc/forward.go
@@ -53,12 +53,12 @@ func (s *Service) getForwardedGrpcClient(ctx context.Context, forwardedAddr stri
 }
 
 func (s *Service) getForwardedAddr(ctx context.Context) (string, bool, error) {
-	member, err := s.h.GetLeader(ctx)
+	member, isLocal, err := s.h.GetLeader(ctx)
 	if err != nil {
 		return "", false, errors.WithMessage(err, "get forwarded addr")
 	}
-	if member.IsLocal {
+	if isLocal {
 		return "", true, nil
 	}
-	return member.Leader.GetEndpoint(), false, nil
+	return member.GetEndpoint(), false, nil
 }

--- a/server/service/grpc/service.go
+++ b/server/service/grpc/service.go
@@ -12,12 +12,12 @@ import (
 	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresdbproto/golang/pkg/commonpb"
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
-	"github.com/CeresDB/ceresdbproto/golang/pkg/metastoragepb"
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/cluster/metadata"
 	"github.com/CeresDB/ceresmeta/server/coordinator"
+	"github.com/CeresDB/ceresmeta/server/member"
 	"github.com/CeresDB/ceresmeta/server/storage"
 	"go.uber.org/zap"
 )
@@ -42,7 +42,7 @@ func NewService(opTimeout time.Duration, h Handler) *Service {
 // Handler is needed by grpc service to process the requests.
 type Handler interface {
 	GetClusterManager() cluster.Manager
-	GetLeader(ctx context.Context) (*metastoragepb.Member, bool, error)
+	GetLeader(ctx context.Context) (member.GetLeaderAddrResp, error)
 	// TODO: define the methods for handling other grpc requests.
 }
 

--- a/server/service/grpc/service.go
+++ b/server/service/grpc/service.go
@@ -12,12 +12,12 @@ import (
 	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
 	"github.com/CeresDB/ceresdbproto/golang/pkg/commonpb"
 	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metastoragepb"
 	"github.com/CeresDB/ceresmeta/pkg/coderr"
 	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/cluster"
 	"github.com/CeresDB/ceresmeta/server/cluster/metadata"
 	"github.com/CeresDB/ceresmeta/server/coordinator"
-	"github.com/CeresDB/ceresmeta/server/member"
 	"github.com/CeresDB/ceresmeta/server/storage"
 	"go.uber.org/zap"
 )
@@ -42,7 +42,7 @@ func NewService(opTimeout time.Duration, h Handler) *Service {
 // Handler is needed by grpc service to process the requests.
 type Handler interface {
 	GetClusterManager() cluster.Manager
-	GetLeader(ctx context.Context) (*member.GetLeaderResp, error)
+	GetLeader(ctx context.Context) (*metastoragepb.Member, bool, error)
 	// TODO: define the methods for handling other grpc requests.
 }
 

--- a/server/service/http/forward.go
+++ b/server/service/http/forward.go
@@ -46,14 +46,14 @@ func getForwardedHTTPClient() *http.Client {
 }
 
 func (s *ForwardClient) getForwardedAddr(ctx context.Context) (string, bool, error) {
-	member, err := s.member.GetLeader(ctx)
+	member, isLocal, err := s.member.GetLeader(ctx)
 	if err != nil {
 		return "", false, errors.WithMessage(err, "get forwarded addr")
 	}
-	if member.IsLocal {
+	if isLocal {
 		return "", true, nil
 	}
-	httpAddr, err := formatHTTPAddr(member.Leader.Endpoint, s.port)
+	httpAddr, err := formatHTTPAddr(member.Endpoint, s.port)
 	if err != nil {
 		return "", false, errors.WithMessage(err, "format http addr")
 	}

--- a/server/service/http/forward.go
+++ b/server/service/http/forward.go
@@ -46,14 +46,14 @@ func getForwardedHTTPClient() *http.Client {
 }
 
 func (s *ForwardClient) getForwardedAddr(ctx context.Context) (string, bool, error) {
-	member, isLocal, err := s.member.GetLeader(ctx)
+	resp, err := s.member.GetLeaderAddr(ctx)
 	if err != nil {
 		return "", false, errors.WithMessage(err, "get forwarded addr")
 	}
-	if isLocal {
+	if resp.IsLocal {
 		return "", true, nil
 	}
-	httpAddr, err := formatHTTPAddr(member.Endpoint, s.port)
+	httpAddr, err := formatHTTPAddr(resp.LeaderEndpoint, s.port)
 	if err != nil {
 		return "", false, errors.WithMessage(err, "format http addr")
 	}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #181 

# Rationale for this change
As mentioned in the issue, fix the performance problem of `routeTable`.

# What changes are included in this PR?
* Add leader memory cache in member.
* Correct the `GetLeader` method, get the leader endpoint through the cache when forwarding GRPC request.

# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests and integration tests.