### PR TITLE
refactor: compatible with topology persistence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
-	github.com/CeresDB/ceresdbproto/golang v0.0.0-20230515021908-1b3a3eae3d60
+	github.com/CeresDB/ceresdbproto/golang v0.0.0-20230531074927-f60b148b3a5c
 	github.com/axw/gocov v1.1.0
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CeresDB/ceresdbproto/golang v0.0.0-20230515021908-1b3a3eae3d60 h1:+/bcJ6M6SnXWjhA80c5Qq6u+LASrPGxoDCMIZoJcmaQ=
 github.com/CeresDB/ceresdbproto/golang v0.0.0-20230515021908-1b3a3eae3d60/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20230531074927-f60b148b3a5c h1:Z/FkMasq2ZTcsKsFuiUaLi26mLyx23mxwlbt1NC/eRY=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20230531074927-f60b148b3a5c/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -346,7 +346,7 @@ func (m *managerImpl) Start(ctx context.Context) error {
 			if err := m.storage.UpdateCluster(ctx, req); err != nil {
 				return errors.WithMessagef(err, "update cluster topology type failed, clusterName:%s", clusterMetadata.Name())
 			}
-			log.Info("update cluster topology type", zap.String("request", fmt.Sprintf("%v", req)))
+			log.Info("update cluster topology type successfully", zap.String("request", fmt.Sprintf("%v", req)))
 			if err := clusterMetadata.LoadMetadata(ctx); err != nil {
 				log.Error("fail to load cluster", zap.String("clusterName", clusterMetadata.Name()), zap.Error(err))
 				return err

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -329,7 +329,7 @@ func (m *managerImpl) Start(ctx context.Context) error {
 		}
 
 		// TODO: topologyType is used to be compatible with cluster data changes and needs to be deleted later
-		if m.topologyType != clusterMetadata.GetStorageMetadata().TopologyType {
+		if clusterMetadata.GetStorageMetadata().TopologyType == storage.TopologyTypeUnknown {
 			if err := m.storage.UpdateCluster(ctx, storage.UpdateClusterRequest{
 				Cluster: storage.Cluster{
 					ID:             metadataStorage.ID,

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -330,6 +330,7 @@ func (m *managerImpl) Start(ctx context.Context) error {
 
 		// TODO: topologyType is used to be compatible with cluster data changes and needs to be deleted later
 		if clusterMetadata.GetStorageMetadata().TopologyType == storage.TopologyTypeUnknown {
+			log.Info("update cluster topology type", zap.String("NewTopologyType", string(m.topologyType)))
 			if err := m.storage.UpdateCluster(ctx, storage.UpdateClusterRequest{
 				Cluster: storage.Cluster{
 					ID:             metadataStorage.ID,

--- a/server/cluster/manager_test.go
+++ b/server/cluster/manager_test.go
@@ -42,7 +42,7 @@ func newTestStorage(t *testing.T) (storage.Storage, clientv3.KV, *clientv3.Clien
 }
 
 func newClusterManagerWithStorage(storage storage.Storage, kv clientv3.KV, client *clientv3.Client) (cluster.Manager, error) {
-	return cluster.NewManagerImpl(storage, kv, client, testRootPath, defaultIDAllocatorStep)
+	return cluster.NewManagerImpl(storage, kv, client, testRootPath, defaultIDAllocatorStep, defaultTopologyType)
 }
 
 func TestClusterManager(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -163,7 +163,7 @@ func (srv *Server) startServer(_ context.Context) error {
 
 	topologyType, err := metadata.ParseTopologyType(srv.cfg.TopologyType)
 	if err != nil {
-		return metadata.ErrParseTopologyType
+		return err
 	}
 
 	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.etcdCli, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep, topologyType)

--- a/server/server.go
+++ b/server/server.go
@@ -161,7 +161,12 @@ func (srv *Server) startServer(_ context.Context) error {
 		MaxScanLimit: srv.cfg.MaxScanLimit, MinScanLimit: srv.cfg.MinScanLimit,
 	})
 
-	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.etcdCli, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep)
+	topologyType, err := metadata.ParseTopologyType(srv.cfg.TopologyType)
+	if err != nil {
+		return metadata.ErrParseTopologyType
+	}
+
+	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.etcdCli, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep, topologyType)
 	if err != nil {
 		return errors.WithMessage(err, "start server")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -168,7 +168,7 @@ func (srv *Server) startServer(_ context.Context) error {
 
 	manager, err := cluster.NewManagerImpl(storage, srv.etcdCli, srv.etcdCli, srv.cfg.StorageRootPath, srv.cfg.IDAllocatorStep, topologyType)
 	if err != nil {
-		return errors.WithMessage(err, "start server")
+		return err
 	}
 	srv.clusterManager = manager
 	srv.flowLimiter = limiter.NewFlowLimiter(srv.cfg.FlowLimiter)

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -24,6 +24,7 @@ const (
 	ClusterStateStable
 	ClusterStatePrepare
 
+	TopologyTypeUnknown = "unknown"
 	TopologyTypeStatic  = "static"
 	TopologyTypeDynamic = "dynamic"
 )
@@ -283,6 +284,8 @@ func convertClusterToPB(cluster Cluster) clusterpb.Cluster {
 
 func convertTopologyTypeToPB(topologyType TopologyType) clusterpb.Cluster_TopologyType {
 	switch topologyType {
+	case TopologyTypeUnknown:
+		return clusterpb.Cluster_UNKNOWN
 	case TopologyTypeStatic:
 		return clusterpb.Cluster_STATIC
 	case TopologyTypeDynamic:
@@ -293,6 +296,8 @@ func convertTopologyTypeToPB(topologyType TopologyType) clusterpb.Cluster_Topolo
 
 func convertTopologyTypePB(topologyType clusterpb.Cluster_TopologyType) TopologyType {
 	switch topologyType {
+	case clusterpb.Cluster_UNKNOWN:
+		return TopologyTypeUnknown
 	case clusterpb.Cluster_STATIC:
 		return TopologyTypeStatic
 	case clusterpb.Cluster_DYNAMIC:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
We modified the persistent data `TopologyType` in the previous pull request. In order to avoid the user from manually operating the interface, we need to add compatible code

# What changes are included in this PR?
* Add compatible code for `TopologyType`

# Are there any user-facing changes?
Avoid users manually operating the interface to be compatible with version changes

# How does this change test
An old version of the persistent data was used for testing in the local environment.