### PR TITLE
fix: fix panic when shard is not assigned

### DIFF
--- a/server/coordinator/shard_picker.go
+++ b/server/coordinator/shard_picker.go
@@ -28,6 +28,10 @@ func NewRandomBalancedShardPicker() ShardPicker {
 
 // PickShards will pick a specified number of shards as expectShardNum.
 func (p *RandomBalancedShardPicker) PickShards(_ context.Context, snapshot metadata.Snapshot, expectShardNum int) ([]storage.ShardNode, error) {
+	if len(snapshot.Topology.ClusterView.ShardNodes) == 0 {
+		return nil, errors.WithMessage(ErrNodeNumberNotEnough, "no shard is assigned")
+	}
+
 	shardNodes := snapshot.Topology.ClusterView.ShardNodes
 
 	nodeShardsMapping := make(map[string][]storage.ShardNode, 0)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Fix server panic when shard is not assigned.

# What changes are included in this PR?
* Add shardNodes check in `shard_picker.go`

# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests and integration test.