### PR TITLE
fix: add cluster state check

### DIFF
--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -136,6 +136,10 @@ func (c *ClusterMetadata) GetShardTables(shardIDs []storage.ShardID) map[storage
 func (c *ClusterMetadata) DropTable(ctx context.Context, schemaName, tableName string) (DropTableResult, error) {
 	c.logger.Info("drop table start", zap.String("cluster", c.Name()), zap.String("schemaName", schemaName), zap.String("tableName", tableName))
 
+	if c.GetClusterState() != storage.ClusterStateStable {
+		return DropTableResult{}, errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
+	}
+
 	table, ok, err := c.tableManager.GetTable(schemaName, tableName)
 	if err != nil {
 		return DropTableResult{}, errors.WithMessage(err, "get table")
@@ -169,6 +173,10 @@ func (c *ClusterMetadata) DropTable(ctx context.Context, schemaName, tableName s
 // The mapping relationship between table and shard will be modified.
 func (c *ClusterMetadata) MigrateTable(ctx context.Context, request MigrateTableRequest) error {
 	c.logger.Info("migrate table", zap.String("request", fmt.Sprintf("%v", request)))
+
+	if c.GetClusterState() != storage.ClusterStateStable {
+		return errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
+	}
 
 	tables := make([]storage.Table, 0, len(request.TableNames))
 	tableIDs := make([]storage.TableID, 0, len(request.TableNames))
@@ -216,6 +224,10 @@ func (c *ClusterMetadata) GetTable(schemaName, tableName string) (storage.Table,
 func (c *ClusterMetadata) CreateTableMetadata(ctx context.Context, request CreateTableMetadataRequest) (CreateTableMetadataResult, error) {
 	c.logger.Info("create table start", zap.String("cluster", c.Name()), zap.String("schemaName", request.SchemaName), zap.String("tableName", request.TableName))
 
+	if c.GetClusterState() != storage.ClusterStateStable {
+		return CreateTableMetadataResult{}, errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
+	}
+
 	_, exists, err := c.tableManager.GetTable(request.SchemaName, request.TableName)
 	if err != nil {
 		return CreateTableMetadataResult{}, err
@@ -242,6 +254,10 @@ func (c *ClusterMetadata) CreateTableMetadata(ctx context.Context, request Creat
 func (c *ClusterMetadata) AddTableTopology(ctx context.Context, shardID storage.ShardID, table storage.Table) (CreateTableResult, error) {
 	c.logger.Info("add table topology start", zap.String("cluster", c.Name()), zap.String("tableName", table.Name))
 
+	if c.GetClusterState() != storage.ClusterStateStable {
+		return CreateTableResult{}, errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
+	}
+
 	// Add table to topology manager.
 	result, err := c.topologyManager.AddTable(ctx, shardID, []storage.Table{table})
 	if err != nil {
@@ -258,6 +274,10 @@ func (c *ClusterMetadata) AddTableTopology(ctx context.Context, shardID storage.
 
 func (c *ClusterMetadata) DropTableMetadata(ctx context.Context, schemaName, tableName string) (DropTableMetadataResult, error) {
 	c.logger.Info("drop table start", zap.String("cluster", c.Name()), zap.String("schemaName", schemaName), zap.String("tableName", tableName))
+
+	if c.GetClusterState() != storage.ClusterStateStable {
+		return DropTableMetadataResult{}, errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
+	}
 
 	table, ok, err := c.tableManager.GetTable(schemaName, tableName)
 	if err != nil {
@@ -280,6 +300,10 @@ func (c *ClusterMetadata) DropTableMetadata(ctx context.Context, schemaName, tab
 
 func (c *ClusterMetadata) CreateTable(ctx context.Context, request CreateTableRequest) (CreateTableResult, error) {
 	c.logger.Info("create table start", zap.String("cluster", c.Name()), zap.String("schemaName", request.SchemaName), zap.String("tableName", request.TableName))
+
+	if c.GetClusterState() != storage.ClusterStateStable {
+		return CreateTableResult{}, errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
+	}
 
 	_, exists, err := c.tableManager.GetTable(request.SchemaName, request.TableName)
 	if err != nil {

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -136,7 +136,7 @@ func (c *ClusterMetadata) GetShardTables(shardIDs []storage.ShardID) map[storage
 func (c *ClusterMetadata) DropTable(ctx context.Context, schemaName, tableName string) (DropTableResult, error) {
 	c.logger.Info("drop table start", zap.String("cluster", c.Name()), zap.String("schemaName", schemaName), zap.String("tableName", tableName))
 
-	if c.GetClusterState() != storage.ClusterStateStable {
+	if !c.ensureClusterStable() {
 		return DropTableResult{}, errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
 	}
 
@@ -174,7 +174,7 @@ func (c *ClusterMetadata) DropTable(ctx context.Context, schemaName, tableName s
 func (c *ClusterMetadata) MigrateTable(ctx context.Context, request MigrateTableRequest) error {
 	c.logger.Info("migrate table", zap.String("request", fmt.Sprintf("%v", request)))
 
-	if c.GetClusterState() != storage.ClusterStateStable {
+	if !c.ensureClusterStable() {
 		return errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
 	}
 
@@ -224,7 +224,7 @@ func (c *ClusterMetadata) GetTable(schemaName, tableName string) (storage.Table,
 func (c *ClusterMetadata) CreateTableMetadata(ctx context.Context, request CreateTableMetadataRequest) (CreateTableMetadataResult, error) {
 	c.logger.Info("create table start", zap.String("cluster", c.Name()), zap.String("schemaName", request.SchemaName), zap.String("tableName", request.TableName))
 
-	if c.GetClusterState() != storage.ClusterStateStable {
+	if !c.ensureClusterStable() {
 		return CreateTableMetadataResult{}, errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
 	}
 
@@ -254,7 +254,7 @@ func (c *ClusterMetadata) CreateTableMetadata(ctx context.Context, request Creat
 func (c *ClusterMetadata) AddTableTopology(ctx context.Context, shardID storage.ShardID, table storage.Table) (CreateTableResult, error) {
 	c.logger.Info("add table topology start", zap.String("cluster", c.Name()), zap.String("tableName", table.Name))
 
-	if c.GetClusterState() != storage.ClusterStateStable {
+	if !c.ensureClusterStable() {
 		return CreateTableResult{}, errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
 	}
 
@@ -275,7 +275,7 @@ func (c *ClusterMetadata) AddTableTopology(ctx context.Context, shardID storage.
 func (c *ClusterMetadata) DropTableMetadata(ctx context.Context, schemaName, tableName string) (DropTableMetadataResult, error) {
 	c.logger.Info("drop table start", zap.String("cluster", c.Name()), zap.String("schemaName", schemaName), zap.String("tableName", tableName))
 
-	if c.GetClusterState() != storage.ClusterStateStable {
+	if !c.ensureClusterStable() {
 		return DropTableMetadataResult{}, errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
 	}
 
@@ -301,7 +301,7 @@ func (c *ClusterMetadata) DropTableMetadata(ctx context.Context, schemaName, tab
 func (c *ClusterMetadata) CreateTable(ctx context.Context, request CreateTableRequest) (CreateTableResult, error) {
 	c.logger.Info("create table start", zap.String("cluster", c.Name()), zap.String("schemaName", request.SchemaName), zap.String("tableName", request.TableName))
 
-	if c.GetClusterState() != storage.ClusterStateStable {
+	if !c.ensureClusterStable() {
 		return CreateTableResult{}, errors.WithMessage(ErrClusterStateInvalid, "invalid cluster state, cluster state must be stable")
 	}
 
@@ -619,6 +619,10 @@ func (c *ClusterMetadata) GetClusterState() storage.ClusterState {
 	defer c.lock.RUnlock()
 
 	return c.topologyManager.GetClusterState()
+}
+
+func (c *ClusterMetadata) ensureClusterStable() bool {
+	return c.GetClusterState() == storage.ClusterStateStable
 }
 
 func (c *ClusterMetadata) GetClusterView() storage.ClusterView {

--- a/server/coordinator/scheduler/scheduler_manager.go
+++ b/server/coordinator/scheduler/scheduler_manager.go
@@ -135,6 +135,7 @@ func (m *ManagerImpl) Start(ctx context.Context) error {
 				continue
 			}
 			if clusterSnapshot.Topology.IsPrepareFinished() {
+				m.logger.Info("try to update cluster state to stable")
 				if err := m.clusterMetadata.UpdateClusterView(ctx, storage.ClusterStateStable, clusterSnapshot.Topology.ClusterView.ShardNodes); err != nil {
 					m.logger.Error("update cluster view failed", zap.Error(err))
 				}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Before the cluster state is stable, it is not allowed to create and delete tables to avoid uneven distribution of tables.

# What changes are included in this PR?
* Add cluster state check when create table & drop table.

# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests and integration test.