### PR TITLE
feat: add ETCD member API

### DIFF
--- a/server/member/member.go
+++ b/server/member/member.go
@@ -159,12 +159,13 @@ func (m *Member) CampaignAndKeepLeader(ctx context.Context, leaseTTLSec int64, c
 	closeLeaseOnce := sync.Once{}
 	closeLeaseWg := sync.WaitGroup{}
 	closeLease := func() {
-		closeLeaseWg.Wait()
+		log.Debug("try to close lease")
 		ctx1, cancel := context.WithTimeout(context.Background(), m.rpcTimeout)
 		defer cancel()
 		if err := newLease.Close(ctx1); err != nil {
 			m.logger.Error("close lease failed", zap.Error(err))
 		}
+		log.Debug("try to close lease finish")
 	}
 	defer closeLeaseOnce.Do(closeLease)
 
@@ -227,7 +228,7 @@ func (m *Member) CampaignAndKeepLeader(ctx context.Context, leaseTTLSec int64, c
 			}
 			etcdLeader := m.etcdLeaderGetter.EtcdLeaderID()
 			if etcdLeader != m.ID {
-				m.logger.Info("etcd leader changed and should re-assign the leadership", zap.String("old-leader", m.Name))
+				m.logger.Info("etcd leader changed and should re-assign the leadership", zap.String("old-leader", m.Name), zap.Uint64("new-leader", etcdLeader))
 				return nil
 			}
 		case <-ctx.Done():

--- a/server/server.go
+++ b/server/server.go
@@ -173,7 +173,7 @@ func (srv *Server) startServer(_ context.Context) error {
 	srv.clusterManager = manager
 	srv.flowLimiter = limiter.NewFlowLimiter(srv.cfg.FlowLimiter)
 
-	api := http.NewAPI(manager, srv.status, http.NewForwardClient(srv.member, srv.cfg.HTTPPort), srv.flowLimiter)
+	api := http.NewAPI(manager, srv.status, http.NewForwardClient(srv.member, srv.cfg.HTTPPort), srv.flowLimiter, srv.etcdCli)
 	httpService := http.NewHTTPService(srv.cfg.HTTPPort, time.Second*10, time.Second*10, api.NewAPIRouter())
 	go func() {
 		err := httpService.Start()

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -18,4 +18,8 @@ var (
 	ErrHealthCheck       = coderr.NewCodeError(coderr.Internal, "server health check")
 	ErrParseTopology     = coderr.NewCodeError(coderr.Internal, "parse topology type")
 	ErrUpdateFlowLimiter = coderr.NewCodeError(coderr.Internal, "update flow limiter")
+	ErrAddLearner        = coderr.NewCodeError(coderr.Internal, "add member as learner")
+	ErrListMembers       = coderr.NewCodeError(coderr.Internal, "get member list")
+	ErrRemoveMembers     = coderr.NewCodeError(coderr.Internal, "remove member")
+	ErrGetMember         = coderr.NewCodeError(coderr.Internal, "get member")
 )

--- a/server/service/http/etcd_api.go
+++ b/server/service/http/etcd_api.go
@@ -25,7 +25,7 @@ func NewEtcdAPI(etcdClient *clientv3.Client, forwardClient *ForwardClient) EtcdA
 }
 
 type AddMemberRequest struct {
-	MembersAddr []string `json:"membersAddr"`
+	MemberAddrs []string `json:"memberAddrs"`
 }
 
 func (a *EtcdAPI) addMember(writer http.ResponseWriter, req *http.Request) {
@@ -37,7 +37,7 @@ func (a *EtcdAPI) addMember(writer http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	resp, err := a.etcdClient.MemberAdd(req.Context(), addMemberRequest.MembersAddr)
+	resp, err := a.etcdClient.MemberAdd(req.Context(), addMemberRequest.MemberAddrs)
 	if err != nil {
 		log.Error("member add as learner failed", zap.Error(err))
 		respondError(writer, ErrAddLearner, fmt.Sprintf("err: %s", err.Error()))
@@ -91,6 +91,8 @@ func (a *EtcdAPI) updateMember(writer http.ResponseWriter, req *http.Request) {
 			return
 		}
 	}
+
+	respondError(writer, ErrGetMember, fmt.Sprintf("member not found, member name: %s", updateMemberRequest.OldMemberName))
 }
 
 type RemoveMemberRequest struct {

--- a/server/service/http/etcd_api.go
+++ b/server/service/http/etcd_api.go
@@ -1,0 +1,215 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/CeresDB/ceresmeta/pkg/log"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+)
+
+type EtcdAPI struct {
+	etcdClient    *clientv3.Client
+	forwardClient *ForwardClient
+}
+
+func NewEtcdAPI(etcdClient *clientv3.Client, forwardClient *ForwardClient) EtcdAPI {
+	return EtcdAPI{
+		etcdClient:    etcdClient,
+		forwardClient: forwardClient,
+	}
+}
+
+type AddMemberRequest struct {
+	MembersAddr []string `json:"membersAddr"`
+}
+
+func (a *EtcdAPI) addMember(writer http.ResponseWriter, req *http.Request) {
+	var addMemberRequest AddMemberRequest
+	err := json.NewDecoder(req.Body).Decode(&addMemberRequest)
+	if err != nil {
+		log.Error("decode request body failed", zap.Error(err))
+		respondError(writer, ErrParseRequest, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	resp, err := a.etcdClient.MemberAdd(req.Context(), addMemberRequest.MembersAddr)
+	if err != nil {
+		log.Error("member add as learner failed", zap.Error(err))
+		respondError(writer, ErrAddLearner, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	respond(writer, resp)
+}
+
+func (a *EtcdAPI) getMember(writer http.ResponseWriter, req *http.Request) {
+	resp, err := a.etcdClient.MemberList(req.Context())
+	if err != nil {
+		log.Error("list member failed", zap.Error(err))
+		respondError(writer, ErrListMembers, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	respond(writer, resp)
+}
+
+type UpdateMemberRequest struct {
+	OldMemberName string   `json:"oldMemberName"`
+	NewMemberAddr []string `json:"newMemberAddr"`
+}
+
+func (a *EtcdAPI) updateMember(writer http.ResponseWriter, req *http.Request) {
+	var updateMemberRequest UpdateMemberRequest
+	err := json.NewDecoder(req.Body).Decode(&updateMemberRequest)
+	if err != nil {
+		log.Error("decode request body failed", zap.Error(err))
+		respondError(writer, ErrParseRequest, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	memberListResp, err := a.etcdClient.MemberList(req.Context())
+	if err != nil {
+		log.Error("list members failed", zap.Error(err))
+		respondError(writer, ErrListMembers, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	for _, member := range memberListResp.Members {
+		if member.Name == updateMemberRequest.OldMemberName {
+			_, err := a.etcdClient.MemberUpdate(req.Context(), member.ID, updateMemberRequest.NewMemberAddr)
+			if err != nil {
+				log.Error("remove learner failed", zap.Error(err))
+				respondError(writer, ErrRemoveMembers, fmt.Sprintf("err: %s", err.Error()))
+				return
+			}
+			respond(writer, "ok")
+			return
+		}
+	}
+}
+
+type RemoveMemberRequest struct {
+	MemberName string `json:"memberName"`
+}
+
+func (a *EtcdAPI) removeMember(writer http.ResponseWriter, req *http.Request) {
+	var removeMemberRequest RemoveMemberRequest
+	err := json.NewDecoder(req.Body).Decode(&removeMemberRequest)
+	if err != nil {
+		log.Error("decode request body failed", zap.Error(err))
+		respondError(writer, ErrParseRequest, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	memberListResp, err := a.etcdClient.MemberList(req.Context())
+	if err != nil {
+		log.Error("list members failed", zap.Error(err))
+		respondError(writer, ErrListMembers, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	for _, member := range memberListResp.Members {
+		if member.Name == removeMemberRequest.MemberName {
+			_, err := a.etcdClient.MemberRemove(req.Context(), member.ID)
+			if err != nil {
+				log.Error("remove learner failed", zap.Error(err))
+				respondError(writer, ErrRemoveMembers, fmt.Sprintf("err: %s", err.Error()))
+				return
+			}
+			respond(writer, "ok")
+			return
+		}
+	}
+
+	respondError(writer, ErrGetMember, fmt.Sprintf("member not found, member name: %s", removeMemberRequest.MemberName))
+}
+
+type PromoteLearnerRequest struct {
+	LearnerName string `json:"learnerName"`
+}
+
+func (a *EtcdAPI) promoteLearner(writer http.ResponseWriter, req *http.Request) {
+	var promoteLearnerRequest PromoteLearnerRequest
+	err := json.NewDecoder(req.Body).Decode(&promoteLearnerRequest)
+	if err != nil {
+		log.Error("decode request body failed", zap.Error(err))
+		respondError(writer, ErrParseRequest, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	memberListResp, err := a.etcdClient.MemberList(req.Context())
+	if err != nil {
+		log.Error("list members failed", zap.Error(err))
+		respondError(writer, ErrListMembers, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	for _, member := range memberListResp.Members {
+		if member.Name == promoteLearnerRequest.LearnerName {
+			_, err := a.etcdClient.MemberPromote(req.Context(), member.ID)
+			if err != nil {
+				log.Error("remove learner failed", zap.Error(err))
+				respondError(writer, ErrRemoveMembers, fmt.Sprintf("err: %s", err.Error()))
+				return
+			}
+			respond(writer, "ok")
+			return
+		}
+	}
+
+	respondError(writer, ErrGetMember, fmt.Sprintf("learner not found, learner name: %s", promoteLearnerRequest.LearnerName))
+}
+
+type MoveLeaderRequest struct {
+	MemberName string `json:"memberName"`
+}
+
+func (a *EtcdAPI) moveLeader(writer http.ResponseWriter, req *http.Request) {
+	resp, isLeader, err := a.forwardClient.forwardToLeader(req)
+	if err != nil {
+		log.Error("forward to leader failed", zap.Error(err))
+		respondError(writer, ErrForwardToLeader, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	if !isLeader {
+		respondForward(writer, resp)
+		return
+	}
+
+	var moveLeaderRequest MoveLeaderRequest
+	err = json.NewDecoder(req.Body).Decode(&moveLeaderRequest)
+	if err != nil {
+		log.Error("decode request body failed", zap.Error(err))
+		respondError(writer, ErrParseRequest, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	memberListResp, err := a.etcdClient.MemberList(req.Context())
+	if err != nil {
+		log.Error("list members failed", zap.Error(err))
+		respondError(writer, ErrListMembers, fmt.Sprintf("err: %s", err.Error()))
+		return
+	}
+
+	for _, member := range memberListResp.Members {
+		if member.Name == moveLeaderRequest.MemberName {
+			moveLeaderResp, err := a.etcdClient.MoveLeader(req.Context(), member.ID)
+			if err != nil {
+				log.Error("remove learner failed", zap.Error(err))
+				respondError(writer, ErrRemoveMembers, fmt.Sprintf("err: %s", err.Error()))
+				return
+			}
+			log.Info("move leader", zap.String("moveLeaderResp", fmt.Sprintf("%v", moveLeaderResp)))
+			respond(writer, "ok")
+			return
+		}
+	}
+
+	respondError(writer, ErrGetMember, fmt.Sprintf("member not found, member name: %s", moveLeaderRequest.MemberName))
+}

--- a/server/service/http/forward.go
+++ b/server/service/http/forward.go
@@ -62,10 +62,12 @@ func (s *ForwardClient) getForwardedAddr(ctx context.Context) (string, bool, err
 	if resp.IsLocal {
 		return "", true, nil
 	}
+	// TODO: In the current implementation, if the HTTP port of each node of CeresMeta is inconsistent, the forwarding address will be wrong
 	httpAddr, err := formatHTTPAddr(resp.LeaderEndpoint, s.port)
 	if err != nil {
 		return "", false, errors.WithMessage(err, "format http addr")
 	}
+	log.Info("getForwardedAddr", zap.String("leaderAddr", httpAddr), zap.Int("port", s.port))
 	return httpAddr, false, nil
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #209 

# Rationale for this change
At present, the peers IP of CeresMeta cannot be adjusted after the cluster initialization is completed, and the capacity cannot be expanded or contracted. If there is a node replacement or expansion or contraction, it needs to be manually operated through `etcdutil`. We need to add a management interface to solve this problem.

# What changes are included in this PR?
* Add ETCD member API. 

# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests and integration tests.