### PR TITLE
feat: add reopen shard scheduler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
-	github.com/CeresDB/ceresdbproto/golang v0.0.0-20230707021308-fba75ce6409c
+	github.com/CeresDB/ceresdbproto/golang v0.0.0-20230718090326-c8106d1700c6
 	github.com/axw/gocov v1.1.0
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CeresDB/ceresdbproto/golang v0.0.0-20230707021308-fba75ce6409c h1:7gmSQsGua+Y1g6ygsC/K75T/zK2ki7y5R5BkrN1/Ymc=
-github.com/CeresDB/ceresdbproto/golang v0.0.0-20230707021308-fba75ce6409c/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20230718090326-c8106d1700c6 h1:Nk07ueHmoB8ykYfoPy4V+dYkrvZYy+sAwta+mfMupag=
+github.com/CeresDB/ceresdbproto/golang v0.0.0-20230718090326-c8106d1700c6/go.mod h1:qLTh6jtSu2ZLIFsU3iiDIKvkrQvyY/Csg6Mk0Ub0QZ4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/server/cluster/metadata/types.go
+++ b/server/cluster/metadata/types.go
@@ -39,6 +39,8 @@ type ShardInfo struct {
 	Role storage.ShardRole
 	// ShardViewVersion
 	Version uint64
+	// The open state of the shard, which is used to determine whether the shard needs to be opened again.
+	Status storage.ShardStatus
 }
 
 type ShardNodeWithVersion struct {
@@ -152,10 +154,12 @@ func (n RegisteredNode) IsExpired(now time.Time) bool {
 }
 
 func ConvertShardsInfoToPB(shard ShardInfo) *metaservicepb.ShardInfo {
+	status := storage.ConvertShardStatusToPB(shard.Status)
 	return &metaservicepb.ShardInfo{
 		Id:      uint32(shard.ID),
 		Role:    storage.ConvertShardRoleToPB(shard.Role),
 		Version: shard.Version,
+		Status:  &status,
 	}
 }
 
@@ -164,6 +168,7 @@ func ConvertShardsInfoPB(shard *metaservicepb.ShardInfo) ShardInfo {
 		ID:      storage.ShardID(shard.Id),
 		Role:    storage.ConvertShardRolePB(shard.Role),
 		Version: shard.Version,
+		Status:  storage.ConvertShardStatusPB(shard.Status),
 	}
 }
 

--- a/server/coordinator/scheduler/reopen_shard_scheduler.go
+++ b/server/coordinator/scheduler/reopen_shard_scheduler.go
@@ -1,0 +1,87 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/CeresDB/ceresmeta/server/cluster/metadata"
+	"github.com/CeresDB/ceresmeta/server/coordinator"
+	"github.com/CeresDB/ceresmeta/server/coordinator/procedure"
+	"github.com/CeresDB/ceresmeta/server/storage"
+)
+
+// ReopenShardScheduler used to reopen shards in status PartitionOpen.
+type ReopenShardScheduler struct {
+	factory                     *coordinator.Factory
+	procedureExecutingBatchSize uint32
+}
+
+func NewReopenShardScheduler(factory *coordinator.Factory, procedureExecutingBatchSize uint32) ReopenShardScheduler {
+	return ReopenShardScheduler{
+		factory:                     factory,
+		procedureExecutingBatchSize: procedureExecutingBatchSize,
+	}
+}
+
+func (r ReopenShardScheduler) Schedule(ctx context.Context, clusterSnapshot metadata.Snapshot) (ScheduleResult, error) {
+	// ReopenShardScheduler can only be scheduled when the cluster is stable.
+	if !clusterSnapshot.Topology.IsStable() {
+		return ScheduleResult{}, nil
+	}
+	now := time.Now()
+
+	var procedures []procedure.Procedure
+	var reasons strings.Builder
+
+	for _, registeredNode := range clusterSnapshot.RegisteredNodes {
+		if registeredNode.IsExpired(now) {
+			continue
+		}
+
+		for _, shardInfo := range registeredNode.ShardInfos {
+			if !needReopen(shardInfo) {
+				continue
+			}
+			p, err := r.factory.CreateTransferLeaderProcedure(ctx, coordinator.TransferLeaderRequest{
+				Snapshot:          clusterSnapshot,
+				ShardID:           shardInfo.ID,
+				OldLeaderNodeName: "",
+				NewLeaderNodeName: registeredNode.Node.Name,
+			})
+			if err != nil {
+				return ScheduleResult{}, err
+			}
+
+			procedures = append(procedures, p)
+			reasons.WriteString(fmt.Sprintf("the shard needs to be reopen , shardID:%d, shardStatus:%d, node:%s.", shardInfo.ID, shardInfo.Status, registeredNode.Node.Name))
+			if len(procedures) >= int(r.procedureExecutingBatchSize) {
+				break
+			}
+		}
+	}
+
+	if len(procedures) == 0 {
+		return ScheduleResult{}, nil
+	}
+
+	batchProcedure, err := r.factory.CreateBatchTransferLeaderProcedure(ctx, coordinator.BatchRequest{
+		Batch:     procedures,
+		BatchType: procedure.TransferLeader,
+	})
+	if err != nil {
+		return ScheduleResult{}, err
+	}
+
+	return ScheduleResult{
+		batchProcedure,
+		reasons.String(),
+	}, nil
+}
+
+func needReopen(shardInfo metadata.ShardInfo) bool {
+	return shardInfo.Status == storage.ShardStatusPartitionOpen
+}

--- a/server/coordinator/scheduler/reopen_shard_scheduler_test.go
+++ b/server/coordinator/scheduler/reopen_shard_scheduler_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package scheduler_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CeresDB/ceresmeta/server/cluster/metadata"
+	"github.com/CeresDB/ceresmeta/server/coordinator"
+	"github.com/CeresDB/ceresmeta/server/coordinator/procedure/test"
+	"github.com/CeresDB/ceresmeta/server/coordinator/scheduler"
+	"github.com/CeresDB/ceresmeta/server/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReopenShardScheduler(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+
+	procedureFactory := coordinator.NewFactory(test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t))
+
+	s := scheduler.NewReopenShardScheduler(procedureFactory, 1)
+
+	emptyCluster := test.InitEmptyCluster(ctx, t)
+	// ReopenShardScheduler should not schedule when cluster is not stable.
+	result, err := s.Schedule(ctx, emptyCluster.GetMetadata().GetClusterSnapshot())
+	re.NoError(err)
+	re.Nil(result.Procedure)
+
+	stableCluster := test.InitStableCluster(ctx, t)
+	snapshot := stableCluster.GetMetadata().GetClusterSnapshot()
+
+	// Add shard with ready status.
+	snapshot.RegisteredNodes[0].ShardInfos = append(snapshot.RegisteredNodes[0].ShardInfos, metadata.ShardInfo{
+		ID:      0,
+		Role:    storage.ShardRoleLeader,
+		Version: 0,
+		Status:  storage.ShardStatusReady,
+	})
+	re.NoError(err)
+	re.Nil(result.Procedure)
+
+	// Add shard with partitionOpen status.
+	snapshot.RegisteredNodes[0].ShardInfos = append(snapshot.RegisteredNodes[0].ShardInfos, metadata.ShardInfo{
+		ID:      1,
+		Role:    storage.ShardRoleLeader,
+		Version: 0,
+		Status:  storage.ShardStatusPartitionOpen,
+	})
+	result, err = s.Schedule(ctx, snapshot)
+	re.NoError(err)
+	re.NotNil(result.Procedure)
+}

--- a/server/coordinator/scheduler/scheduler_manager.go
+++ b/server/coordinator/scheduler/scheduler_manager.go
@@ -192,13 +192,15 @@ func (m *ManagerImpl) initRegister() {
 
 func (m *ManagerImpl) createStaticTopologySchedulers() []Scheduler {
 	staticTopologyShardScheduler := NewStaticTopologyShardScheduler(m.factory, m.nodePicker, m.procedureExecutingBatchSize)
-	return []Scheduler{staticTopologyShardScheduler}
+	reopenShardScheduler := NewReopenShardScheduler(m.factory, m.procedureExecutingBatchSize)
+	return []Scheduler{staticTopologyShardScheduler, reopenShardScheduler}
 }
 
 func (m *ManagerImpl) createDynamicTopologySchedulers() []Scheduler {
 	assignShardScheduler := NewAssignShardScheduler(m.factory, m.nodePicker, m.procedureExecutingBatchSize)
 	rebalancedShardScheduler := NewRebalancedShardScheduler(m.logger, m.factory, m.nodePicker, m.procedureExecutingBatchSize)
-	return []Scheduler{assignShardScheduler, rebalancedShardScheduler}
+	reopenShardScheduler := NewReopenShardScheduler(m.factory, m.procedureExecutingBatchSize)
+	return []Scheduler{assignShardScheduler, rebalancedShardScheduler, reopenShardScheduler}
 }
 
 func (m *ManagerImpl) registerScheduler(scheduler Scheduler) {

--- a/server/coordinator/scheduler/scheduler_manager_test.go
+++ b/server/coordinator/scheduler/scheduler_manager_test.go
@@ -42,7 +42,7 @@ func TestSchedulerManager(t *testing.T) {
 	err = schedulerManager.Start(ctx)
 	re.NoError(err)
 	schedulers := schedulerManager.ListScheduler()
-	re.Equal(1, len(schedulers))
+	re.Equal(2, len(schedulers))
 	err = schedulerManager.Stop(ctx)
 	re.NoError(err)
 
@@ -51,7 +51,7 @@ func TestSchedulerManager(t *testing.T) {
 	err = schedulerManager.Start(ctx)
 	re.NoError(err)
 	schedulers = schedulerManager.ListScheduler()
-	re.Equal(2, len(schedulers))
+	re.Equal(3, len(schedulers))
 	err = schedulerManager.Stop(ctx)
 	re.NoError(err)
 }

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
+	"github.com/CeresDB/ceresdbproto/golang/pkg/metaservicepb"
 )
 
 type (
@@ -15,6 +16,7 @@ type (
 	TableID      uint64
 	ClusterState int
 	ShardRole    int
+	ShardStatus  int
 	NodeState    int
 	TopologyType string
 )
@@ -32,6 +34,9 @@ const (
 const (
 	ShardRoleLeader ShardRole = iota + 1
 	ShardRoleFollower
+
+	ShardStatusPartitionOpen ShardStatus = iota + 1
+	ShardStatusReady
 )
 
 const (
@@ -341,6 +346,29 @@ func ConvertShardRoleToPB(role ShardRole) clusterpb.ShardRole {
 		return clusterpb.ShardRole_FOLLOWER
 	}
 	return clusterpb.ShardRole_FOLLOWER
+}
+
+func ConvertShardStatusPB(status *metaservicepb.ShardInfo_Status) ShardStatus {
+	if status == nil {
+		return ShardStatusReady
+	}
+	switch *status {
+	case metaservicepb.ShardInfo_PartialOpen:
+		return ShardStatusPartitionOpen
+	case metaservicepb.ShardInfo_Ready:
+		return ShardStatusReady
+	}
+	return ShardStatusReady
+}
+
+func ConvertShardStatusToPB(status ShardStatus) metaservicepb.ShardInfo_Status {
+	switch status {
+	case ShardStatusPartitionOpen:
+		return metaservicepb.ShardInfo_PartialOpen
+	case ShardStatusReady:
+		return metaservicepb.ShardInfo_Ready
+	}
+	return metaservicepb.ShardInfo_Ready
 }
 
 func convertShardNodeToPB(shardNode ShardNode) clusterpb.ShardNode {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
At present, our implementation of shard opening is relatively simple. When some tables in a shard fail to open, it is impossible to retry and recover without restarting the CeresDB node. We need to solve this problem so that shards that fail to open some tables Can be recovered by retrying.

# What changes are included in this PR?
* Introduce the latest proto and add the definition of shard status.
* Add the implementation of `ReopenShardScheduler` for retrying partially opened shards.

# Are there any user-facing changes?
None.

# How does this change test
* Pass all unit tests and integration tests.