### PR TITLE
fix: remove gprc header error stack

### DIFF
--- a/server/service/grpc/service.go
+++ b/server/service/grpc/service.go
@@ -409,10 +409,10 @@ func responseHeader(err error, msg string) *commonpb.ResponseHeader {
 
 	code, ok := coderr.GetCauseCode(err)
 	if ok {
-		return &commonpb.ResponseHeader{Code: uint32(code), Error: msg + err.Error()}
+		return &commonpb.ResponseHeader{Code: uint32(code), Error: msg}
 	}
 
-	return &commonpb.ResponseHeader{Code: coderr.Internal, Error: msg + err.Error()}
+	return &commonpb.ResponseHeader{Code: coderr.Internal, Error: msg}
 }
 
 func (s *Service) allow() (bool, error) {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #221 

# Rationale for this change
As mentioned in issue, reduce the pressure of route requests on cpu.

# What changes are included in this PR?
* Remove error stack in gprc response header.


# Are there any user-facing changes?
None.

# How does this change test
No need.