### PR TITLE
feat: add http API

### DIFF
--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -362,6 +362,7 @@ func (c *ClusterMetadata) RegisterNode(ctx context.Context, registeredNode Regis
 	}
 
 	if err := c.UpdateClusterViewByNode(ctx, shardNodes); err != nil {
+		c.logger.Error("update cluster view by node", zap.Error(err), zap.String("nodeName", registeredNode.Node.Name))
 		return errors.WithMessage(err, "update cluster view failed")
 	}
 

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -9,6 +9,7 @@ var (
 	ErrDropTable         = coderr.NewCodeError(coderr.Internal, "drop table")
 	ErrRouteTable        = coderr.NewCodeError(coderr.Internal, "route table")
 	ErrGetNodeShards     = coderr.NewCodeError(coderr.Internal, "get node shards")
+	ErrDropShardNodes    = coderr.NewCodeError(coderr.Internal, "drop shard nodes")
 	ErrCreateProcedure   = coderr.NewCodeError(coderr.Internal, "create procedure")
 	ErrSubmitProcedure   = coderr.NewCodeError(coderr.Internal, "submit procedure")
 	ErrGetCluster        = coderr.NewCodeError(coderr.Internal, "get cluster")


### PR DESCRIPTION
## Rationale
Add a new API for deleting node shards and get register nodes

## Detailed Changes
* Add `DropNodeShards` API.
* Modify `GetNodeShards` interface to make it conform to the style of Restful API.
* Add `GetNode` API.

## Test Plan
Pass all unit tests and integration test.