### PR TITLE
fix: support idempotent drop partition table

### DIFF
--- a/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
+++ b/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
@@ -101,11 +101,11 @@ func buildRelatedVersionInfo(params ProcedureParams) (procedure.RelatedVersionIn
 			return procedure.RelatedVersionInfo{}, errors.WithMessagef(err, "get sub table, tableName:%s", subTableName)
 		}
 		if !exists {
-			return procedure.RelatedVersionInfo{}, errors.WithMessagef(procedure.ErrTableNotExists, "get sub table, tableName:%s", subTableName)
+			continue
 		}
 		shardID, exists := tableShardMapping[table.ID]
 		if !exists {
-			return procedure.RelatedVersionInfo{}, errors.WithMessagef(metadata.ErrShardNotFound, "get shard of sub table, tableID:%d", table.ID)
+			continue
 		}
 		shardView, exists := params.ClusterSnapshot.Topology.ShardViewsMapping[shardID]
 		if !exists {
@@ -280,8 +280,8 @@ func dropDataTablesCallback(event *fsm.Event) {
 	for _, tableName := range params.SourceReq.PartitionTableInfo.SubTableNames {
 		table, shardVersionUpdate, err := ddl.GetShardVersionByTableName(params.ClusterMetadata, req.schemaName(), tableName, shardVersions)
 		if err != nil {
-			procedure.CancelEventWithLog(event, err, fmt.Sprintf("get shard version by table, table:%s", tableName))
-			return
+			log.Warn(fmt.Sprintf("get shard version by table, table:%s", tableName))
+			continue
 		}
 
 		if err := ddl.DispatchDropTable(req.ctx, params.ClusterMetadata, params.Dispatch, params.SourceReq.GetSchemaName(), table, shardVersionUpdate); err != nil {

--- a/server/coordinator/scheduler/static_topology_shard_scheduler.go
+++ b/server/coordinator/scheduler/static_topology_shard_scheduler.go
@@ -68,7 +68,7 @@ func (s *StaticTopologyShardScheduler) Schedule(ctx context.Context, clusterSnap
 			shardNode := clusterSnapshot.Topology.ClusterView.ShardNodes[i]
 			node, err := findOnlineNodeByName(shardNode.NodeName, clusterSnapshot.RegisteredNodes)
 			if err != nil {
-				return ScheduleResult{}, err
+				continue
 			}
 			if !contains(shardNode.ID, node.ShardInfos) {
 				// Shard need to be reopened
@@ -82,7 +82,7 @@ func (s *StaticTopologyShardScheduler) Schedule(ctx context.Context, clusterSnap
 					return ScheduleResult{}, err
 				}
 				procedures = append(procedures, p)
-				reasons.WriteString(fmt.Sprintf("Cluster initialization, assign shard to node, shardID:%d, nodeName:%s. ", shardNode.ID, node.Node.Name))
+				reasons.WriteString(fmt.Sprintf("Cluster recover, assign shard to node, shardID:%d, nodeName:%s. ", shardNode.ID, node.Node.Name))
 				if len(procedures) >= int(s.procedureExecutingBatchSize) {
 					break
 				}

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -7,6 +7,7 @@ import "github.com/CeresDB/ceresmeta/pkg/coderr"
 var (
 	ErrParseRequest      = coderr.NewCodeError(coderr.BadRequest, "parse request params")
 	ErrDropTable         = coderr.NewCodeError(coderr.Internal, "drop table")
+	ErrGetTable          = coderr.NewCodeError(coderr.Internal, "get table")
 	ErrRouteTable        = coderr.NewCodeError(coderr.Internal, "route table")
 	ErrGetNodeShards     = coderr.NewCodeError(coderr.Internal, "get node shards")
 	ErrCreateProcedure   = coderr.NewCodeError(coderr.Internal, "create procedure")


### PR DESCRIPTION
## Rationale
Since the sub tables of the partition table are distributed on different nodes, some sub tables often fail to be deleted when deleting the partition table. We need to ensure that the deletion of the partition table is idempotent and can be deleted in extreme cases. Partition Table.

## Detailed Changes
Ignore the verification of each sub-table when deleting the partition table, try to delete each sub table.

## Test Plan
Pass all unit tests and integration test.