### PR TITLE
feat: add diagnose/shards api

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -50,22 +50,6 @@ func NewCluster(logger *zap.Logger, metadata *metadata.ClusterMetadata, client *
 	}, nil
 }
 
-func (c *Cluster) GetMetadata() *metadata.ClusterMetadata {
-	return c.metadata
-}
-
-func (c *Cluster) GetProcedureManager() procedure.Manager {
-	return c.procedureManager
-}
-
-func (c *Cluster) GetProcedureFactory() *coordinator.Factory {
-	return c.procedureFactory
-}
-
-func (c *Cluster) GetSchedulerManager() scheduler.Manager {
-	return c.schedulerManager
-}
-
 func (c *Cluster) Start(ctx context.Context) error {
 	if err := c.procedureManager.Start(ctx); err != nil {
 		return errors.WithMessage(err, "start procedure manager")
@@ -84,4 +68,24 @@ func (c *Cluster) Stop(ctx context.Context) error {
 		return errors.WithMessage(err, "stop scheduler manager")
 	}
 	return nil
+}
+
+func (c *Cluster) GetMetadata() *metadata.ClusterMetadata {
+	return c.metadata
+}
+
+func (c *Cluster) GetProcedureManager() procedure.Manager {
+	return c.procedureManager
+}
+
+func (c *Cluster) GetProcedureFactory() *coordinator.Factory {
+	return c.procedureFactory
+}
+
+func (c *Cluster) GetSchedulerManager() scheduler.Manager {
+	return c.schedulerManager
+}
+
+func (c *Cluster) GetShardNodes() metadata.GetShardNodesResult {
+	return c.metadata.GetShardNodes()
 }

--- a/server/cluster/metadata/topology_manager.go
+++ b/server/cluster/metadata/topology_manager.go
@@ -66,8 +66,8 @@ type GetShardNodesByTableIDsResult struct {
 }
 
 type GetShardNodesResult struct {
-	shardNodes []storage.ShardNode
-	versions   map[storage.ShardID]uint64
+	ShardNodes []storage.ShardNode
+	Versions   map[storage.ShardID]uint64
 }
 
 type CreateShardView struct {
@@ -412,8 +412,8 @@ func (m *TopologyManagerImpl) GetShardNodes() GetShardNodesResult {
 	}
 
 	return GetShardNodesResult{
-		shardNodes: shardNodes,
-		versions:   shardViewVersions,
+		ShardNodes: shardNodes,
+		Versions:   shardViewVersions,
 	}
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -47,7 +47,7 @@ const (
 	defaultMinScanLimit    int  = 20
 	defaultIDAllocatorStep uint = 20
 
-	defaultClusterName              = "defaultCluster"
+	DefaultClusterName              = "defaultCluster"
 	defaultClusterNodeCount         = 2
 	defaultClusterReplicationFactor = 1
 	defaultClusterShardTotal        = 8
@@ -299,7 +299,7 @@ func MakeConfigParser() (*Parser, error) {
 		MinScanLimit:            defaultMinScanLimit,
 		IDAllocatorStep:         defaultIDAllocatorStep,
 
-		DefaultClusterName:              defaultClusterName,
+		DefaultClusterName:              DefaultClusterName,
 		DefaultClusterNodeCount:         defaultClusterNodeCount,
 		DefaultClusterReplicationFactor: defaultClusterReplicationFactor,
 		DefaultClusterShardTotal:        defaultClusterShardTotal,

--- a/server/coordinator/scheduler/reopen_shard_scheduler.go
+++ b/server/coordinator/scheduler/reopen_shard_scheduler.go
@@ -83,5 +83,5 @@ func (r ReopenShardScheduler) Schedule(ctx context.Context, clusterSnapshot meta
 }
 
 func needReopen(shardInfo metadata.ShardInfo) bool {
-	return shardInfo.Status == storage.ShardStatusPartitionOpen
+	return shardInfo.Status == storage.ShardStatusPartialOpen
 }

--- a/server/coordinator/scheduler/reopen_shard_scheduler_test.go
+++ b/server/coordinator/scheduler/reopen_shard_scheduler_test.go
@@ -46,7 +46,7 @@ func TestReopenShardScheduler(t *testing.T) {
 		ID:      1,
 		Role:    storage.ShardRoleLeader,
 		Version: 0,
-		Status:  storage.ShardStatusPartitionOpen,
+		Status:  storage.ShardStatusPartialOpen,
 	})
 	result, err = s.Schedule(ctx, snapshot)
 	re.NoError(err)

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -120,7 +120,7 @@ func (a *API) NewAPIRouter() *Router {
 	router.Get("/debug/pprof/block", a.pprofBlock)
 	router.Get("/debug/pprof/goroutine", a.pprofGoroutine)
 	router.Get("/debug/pprof/threadCreate", a.pprofThreadcreate)
-	router.Get("/debug/diagnose/shards/:"+clusterNameParam, wrap(a.diagnoseShards, true, a.forwardClient))
+	router.Get("/debug/diagnose/:"+clusterNameParam+"/shards", wrap(a.diagnoseShards, true, a.forwardClient))
 
 	// Register ETCD API.
 	router.Post("/etcd/promoteLearner", wrap(a.etcdAPI.promoteLearner, false, a.forwardClient))
@@ -620,7 +620,7 @@ func (a *API) diagnoseShards(req *http.Request) apiFuncResult {
 
 	expectedShardNodes := c.GetShardNodes()
 	// shardName -> shardInfo
-	registerNodesMap := make(map[string][]metadata.ShardInfo)
+	registerNodesMap := make(map[string][]metadata.ShardInfo, len(registerNodes))
 	for _, node := range registerNodes {
 		registerNodesMap[node.Node.Name] = node.ShardInfos
 	}

--- a/server/storage/types.go
+++ b/server/storage/types.go
@@ -34,9 +34,11 @@ const (
 const (
 	ShardRoleLeader ShardRole = iota + 1
 	ShardRoleFollower
+)
 
-	ShardStatusPartitionOpen ShardStatus = iota + 1
-	ShardStatusReady
+const (
+	ShardStatusReady ShardStatus = iota + 1
+	ShardStatusPartialOpen
 )
 
 const (
@@ -354,7 +356,7 @@ func ConvertShardStatusPB(status *metaservicepb.ShardInfo_Status) ShardStatus {
 	}
 	switch *status {
 	case metaservicepb.ShardInfo_PartialOpen:
-		return ShardStatusPartitionOpen
+		return ShardStatusPartialOpen
 	case metaservicepb.ShardInfo_Ready:
 		return ShardStatusReady
 	}
@@ -363,7 +365,7 @@ func ConvertShardStatusPB(status *metaservicepb.ShardInfo_Status) ShardStatus {
 
 func ConvertShardStatusToPB(status ShardStatus) metaservicepb.ShardInfo_Status {
 	switch status {
-	case ShardStatusPartitionOpen:
+	case ShardStatusPartialOpen:
 		return metaservicepb.ShardInfo_PartialOpen
 	case ShardStatusReady:
 		return metaservicepb.ShardInfo_Ready
@@ -533,4 +535,14 @@ func convertNodePB(node *clusterpb.Node) Node {
 		LastTouchTime: node.LastTouchTime,
 		State:         convertNodeStatePB(node.State),
 	}
+}
+
+func ConvertShardStatusToString(status ShardStatus) string {
+	switch status {
+	case ShardStatusReady:
+		return "ready"
+	case ShardStatusPartialOpen:
+		return "partialOpen"
+	}
+	return "unknown"
 }


### PR DESCRIPTION
## Rationale
Provides `disgnose/shards` api  to check cluster shards status.

## Detailed Changes
* Refactor some code.
* Add `disgnose/shards` api.
```
curl 0:8080/api/v1/diagnose/defaultCluster/shards
{
    "status": "success",
    "data":
    {
        "shard_not_register":
        {
            "0": "127.0.0.1:8832",
            "1": "127.0.0.1:8832",
            "5": "127.0.0.1:8832",
            "6": "127.0.0.1:8832"
        },
        "shard_not_ready":
        {}
    }
}
```

## Test Plan
Manual test and CI.