### PR TITLE
refactor: remove useless topology data

### DIFF
--- a/server/coordinator/procedure/operation/transferleader/transfer_leader.go
+++ b/server/coordinator/procedure/operation/transferleader/transfer_leader.go
@@ -247,7 +247,7 @@ func closeOldLeaderCallback(event *fsm.Event) {
 		return
 	}
 
-	log.Info("try to close shard", zap.Uint64("procedureID", req.p.ID()), zap.Uint64("shardID", req.p.params.ID), zap.String("oldLeader", req.p.params.OldLeaderNodeName))
+	log.Info("try to close shard", zap.Uint64("procedureID", req.p.ID()), zap.Uint64("shardID", uint64(req.p.params.ShardID)), zap.String("oldLeader", req.p.params.OldLeaderNodeName))
 
 	closeShardRequest := eventdispatch.CloseShardRequest{
 		ShardID: uint32(req.p.params.ShardID),

--- a/server/storage/storage_impl.go
+++ b/server/storage/storage_impl.go
@@ -480,8 +480,6 @@ func (s *metaStorageImpl) UpdateShardView(ctx context.Context, req UpdateShardVi
 	latestVersionEquals := clientv3.Compare(clientv3.Value(latestVersionKey), "=", fmtID(req.LatestVersion))
 	opPutLatestVersion := clientv3.OpPut(latestVersionKey, fmtID(shardViewPB.Version))
 	opPutShardTopology := clientv3.OpPut(key, string(value))
-	// Delete expired shard view.
-	opDelShardTopology := clientv3.OpDelete(oldTopologyKey)
 
 	resp, err := s.client.Txn(ctx).
 		If(latestVersionEquals).
@@ -495,8 +493,9 @@ func (s *metaStorageImpl) UpdateShardView(ctx context.Context, req UpdateShardVi
 	}
 
 	// Try to remove expired shard view.
+	opDelShardTopology := clientv3.OpDelete(oldTopologyKey)
 	if _, err := s.client.Do(ctx, opDelShardTopology); err != nil {
-		log.Warn("remove expired shard view failed", zap.Error(err))
+		log.Warn("remove expired shard view failed", zap.Error(err), zap.String("oldTopologyKey", oldTopologyKey))
 	}
 
 	return nil

--- a/server/storage/storage_impl.go
+++ b/server/storage/storage_impl.go
@@ -4,17 +4,17 @@ package storage
 
 import (
 	"context"
-	"github.com/CeresDB/ceresmeta/pkg/log"
-	"go.uber.org/zap"
 	"math"
 	"strconv"
 	"strings"
 
 	"github.com/CeresDB/ceresdbproto/golang/pkg/clusterpb"
+	"github.com/CeresDB/ceresmeta/pkg/log"
 	"github.com/CeresDB/ceresmeta/server/etcdutil"
 	"github.com/pkg/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/clientv3util"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 )
 


### PR DESCRIPTION
## Rationale
In the current implementation, a copy of the topology is stored every time the cluster topology is updated, but expired topology data has no effect and will cause a waste of ETCD storage space.

## Detailed Changes
* Remove expired topology data when update cluster view.


## Test Plan
Pass all unit tests and integration test.