### PR TITLE
feat: support drop partition table parallelly

### DIFF
--- a/server/cluster/metadata/types.go
+++ b/server/cluster/metadata/types.go
@@ -11,9 +11,8 @@ import (
 )
 
 const (
-	expiredThreshold                     = time.Second * 10
-	MinShardID                           = 0
-	HeartbeatKeepAliveIntervalSec uint64 = 15
+	expiredThreshold = time.Second * 10
+	MinShardID       = 0
 )
 
 type Snapshot struct {

--- a/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
+++ b/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
@@ -285,7 +285,7 @@ func dropDataTablesCallback(event *fsm.Event) {
 	g, _ := errgroup.WithContext(req.ctx)
 
 	// shardID -> tableNames
-	splitedTableNames := make(map[storage.ShardID][]string)
+	shardTables := make(map[storage.ShardID][]string)
 	for _, tableName := range params.SourceReq.PartitionTableInfo.GetSubTableNames() {
 		table, err := ddl.GetTableMetadata(params.ClusterMetadata, req.schemaName(), tableName)
 		if err != nil {
@@ -310,10 +310,10 @@ func dropDataTablesCallback(event *fsm.Event) {
 			continue
 		}
 
-		splitedTableNames[shardVersionUpdate.ShardID] = append(splitedTableNames[shardVersionUpdate.ShardID], tableName)
+		shardTables[shardVersionUpdate.ShardID] = append(shardTables[shardVersionUpdate.ShardID], tableName)
 	}
 
-	for shardID, tableNames := range splitedTableNames {
+	for shardID, tableNames := range shardTables {
 		shardID := shardID
 		tableNames := tableNames
 		shardVersion := shardVersions[shardID]

--- a/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
+++ b/server/coordinator/procedure/ddl/droppartitiontable/drop_partition_table.go
@@ -18,6 +18,7 @@ import (
 	"github.com/looplab/fsm"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 // fsm state change:
@@ -281,7 +282,11 @@ func dropDataTablesCallback(event *fsm.Event) {
 	}
 
 	shardVersions := req.p.relatedVersionInfo.ShardWithVersion
-	for _, tableName := range params.SourceReq.PartitionTableInfo.SubTableNames {
+	g, _ := errgroup.WithContext(req.ctx)
+
+	// shardID -> tableNames
+	splitedTableNames := make(map[storage.ShardID][]string)
+	for _, tableName := range params.SourceReq.PartitionTableInfo.GetSubTableNames() {
 		table, err := ddl.GetTableMetadata(params.ClusterMetadata, req.schemaName(), tableName)
 		if err != nil {
 			log.Warn("get table metadata failed", zap.String("tableName", tableName))
@@ -305,18 +310,22 @@ func dropDataTablesCallback(event *fsm.Event) {
 			continue
 		}
 
-		if err := ddl.DispatchDropTable(req.ctx, params.ClusterMetadata, params.Dispatch, params.SourceReq.GetSchemaName(), table, shardVersionUpdate); err != nil {
-			procedure.CancelEventWithLog(event, err, fmt.Sprintf("drop table, table:%s", tableName))
-			return
-		}
+		splitedTableNames[shardVersionUpdate.ShardID] = append(splitedTableNames[shardVersionUpdate.ShardID], tableName)
+	}
 
-		_, err = params.ClusterMetadata.DropTable(req.ctx, req.schemaName(), tableName)
-		if err != nil {
-			procedure.CancelEventWithLog(event, err, "drop table metadata", zap.String("tableName", tableName))
-			return
-		}
+	for shardID, tableNames := range splitedTableNames {
+		shardID := shardID
+		tableNames := tableNames
+		shardVersion := shardVersions[shardID]
+		g.Go(func() error {
+			return dispatchDropDataTable(req, params.Dispatch, params.ClusterMetadata, shardID, params.SourceReq.GetSchemaName(), tableNames, shardVersion)
+		})
+	}
 
-		shardVersions[shardVersionUpdate.ShardID]++
+	err = g.Wait()
+	if err != nil {
+		procedure.CancelEventWithLog(event, err, "")
+		return
 	}
 }
 
@@ -356,4 +365,31 @@ func finishCallback(event *fsm.Event) {
 		procedure.CancelEventWithLog(event, err, "drop partition table on succeeded")
 		return
 	}
+}
+
+func dispatchDropDataTable(req *callbackRequest, dispatch eventdispatch.Dispatch, clusterMetadata *metadata.ClusterMetadata, shardID storage.ShardID, schema string, tableNames []string, shardVersion uint64) error {
+	for _, tableName := range tableNames {
+		table, err := ddl.GetTableMetadata(clusterMetadata, req.schemaName(), tableName)
+		if err != nil {
+			return errors.WithMessagef(err, "get table metadata, table:%s", tableName)
+		}
+
+		shardVersionUpdate := metadata.ShardVersionUpdate{
+			ShardID:     shardID,
+			CurrVersion: shardVersion + 1,
+			PrevVersion: shardVersion,
+		}
+
+		if err := ddl.DispatchDropTable(req.ctx, clusterMetadata, dispatch, schema, table, shardVersionUpdate); err != nil {
+			return errors.WithMessagef(err, "drop table, table:%s", tableName)
+		}
+
+		_, err = clusterMetadata.DropTable(req.ctx, req.schemaName(), tableName)
+		if err != nil {
+			return errors.WithMessagef(err, "drop table, table:%s", tableName)
+		}
+
+		shardVersion++
+	}
+	return nil
 }


### PR DESCRIPTION
## Rationale
Support concurrent deletion of partition subtables at the shard level.

## Detailed Changes
* Dispatch drop partition sub table concurrently.

## Test Plan
Manual test and CI.
```
CREATE TABLE `demo1`(
    `name`string TAG,
    `id` int TAG,
    `value` double NOT NULL,
    `t` timestamp NOT NULL,
    TIMESTAMP KEY(t)
    ) PARTITION BY KEY(name) PARTITIONS 400 ENGINE = Analytic
```
It takes 4 seconds to drop this partition table `demo1` which contains 400 sub-tables.

