### PR TITLE
fix: allow rebalance scheduler to run on the unstable cluster

### DIFF
--- a/server/coordinator/scheduler/rebalanced_shard_scheduler.go
+++ b/server/coordinator/scheduler/rebalanced_shard_scheduler.go
@@ -32,8 +32,8 @@ func NewRebalancedShardScheduler(logger *zap.Logger, factory *coordinator.Factor
 }
 
 func (r RebalancedShardScheduler) Schedule(ctx context.Context, clusterSnapshot metadata.Snapshot) (ScheduleResult, error) {
-	// RebalancedShardScheduler can only be scheduled when the cluster is stable.
-	if !clusterSnapshot.Topology.IsStable() {
+	// RebalancedShardScheduler can only be scheduled when the cluster is not empty.
+	if clusterSnapshot.Topology.ClusterView.State == storage.ClusterStateEmpty {
 		return ScheduleResult{}, nil
 	}
 

--- a/server/coordinator/scheduler/rebalanced_shard_scheduler_test.go
+++ b/server/coordinator/scheduler/rebalanced_shard_scheduler_test.go
@@ -29,9 +29,8 @@ func TestRebalancedScheduler(t *testing.T) {
 
 	// PrepareCluster would be scheduled an empty procedure.
 	prepareCluster := test.InitPrepareCluster(ctx, t)
-	result, err = s.Schedule(ctx, prepareCluster.GetMetadata().GetClusterSnapshot())
+	_, err = s.Schedule(ctx, prepareCluster.GetMetadata().GetClusterSnapshot())
 	re.NoError(err)
-	re.Empty(result)
 
 	// StableCluster with all shards assigned would be scheduled a load balance procedure.
 	stableCluster := test.InitStableCluster(ctx, t)


### PR DESCRIPTION
## Rationale
Currently, the cluster state can't be stable after `AssignShardScheduler` is removed in #236. And this results from that the `RebalancedShardScheduler` won't schedule if the cluster state is not stable.

## Detailed Changes
Allow the `RabalancedShardScheduler` to run on the unstable cluster.

## Test Plan
Manual test.