### PR TITLE
chore: refactor some code

### DIFF
--- a/server/member/watch_leader.go
+++ b/server/member/watch_leader.go
@@ -93,7 +93,7 @@ func NewLeaderWatcher(ctx WatchContext, self *Member, leaseTTLSec int64, embedEt
 	}
 }
 
-// watchWithCheckEtcdLeader watches the leader changes:
+// Watch watches the leader changes:
 //  1. Check whether the leader is valid if leader exists.
 //     - Leader is valid: wait for the leader changes.
 //     - Leader is not valid: reset the leader by the current leader.

--- a/server/server.go
+++ b/server/server.go
@@ -168,11 +168,11 @@ func (srv *Server) initEtcdClient() error {
 	}
 	srv.etcdCli = client
 
-	endpoint := fmt.Sprintf("%s:%d", srv.cfg.Addr, srv.cfg.GrpcPort)
 	if srv.etcdSrv != nil {
 		etcdLeaderGetter := &etcdutil.LeaderGetterWrapper{Server: srv.etcdSrv.Server}
 		srv.member = member.NewMember(srv.cfg.StorageRootPath, uint64(srv.etcdSrv.Server.ID()), srv.cfg.NodeName, srv.etcdCfg.ACUrls[0].String(), client, etcdLeaderGetter, srv.cfg.EtcdCallTimeout())
 	} else {
+		endpoint := fmt.Sprintf("http://%s:%d", srv.cfg.Addr, srv.cfg.GrpcPort)
 		srv.member = member.NewMember(srv.cfg.StorageRootPath, 0, srv.cfg.NodeName, endpoint, client, nil, srv.cfg.EtcdCallTimeout())
 	}
 	return nil


### PR DESCRIPTION
## Rationale
The endpoint of the leader persisted in the etcd is wrong.

## Detailed Changes
Save the correct endpoint of the ceresmeta leader in the etcd.

## Test Plan
Manual tests.