### PR TITLE
refactor: diagnose shards api

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/CeresDB/ceresmeta/server/coordinator/procedure"
 	"github.com/CeresDB/ceresmeta/server/coordinator/scheduler"
 	"github.com/CeresDB/ceresmeta/server/id"
+	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/pkg/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -84,6 +85,10 @@ func (c *Cluster) GetProcedureFactory() *coordinator.Factory {
 
 func (c *Cluster) GetSchedulerManager() scheduler.Manager {
 	return c.schedulerManager
+}
+
+func (c *Cluster) GetShards() []storage.ShardID {
+	return c.metadata.GetShards()
 }
 
 func (c *Cluster) GetShardNodes() metadata.GetShardNodesResult {

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -44,7 +44,7 @@ type Manager interface {
 
 	RegisterNode(ctx context.Context, clusterName string, registeredNode metadata.RegisteredNode) error
 	GetRegisteredNode(ctx context.Context, clusterName string, node string) (metadata.RegisteredNode, error)
-	ListRegisterNodes(ctx context.Context, clusterName string) ([]metadata.RegisteredNode, error)
+	ListRegisteredNodes(ctx context.Context, clusterName string) ([]metadata.RegisteredNode, error)
 }
 
 type managerImpl struct {
@@ -322,7 +322,7 @@ func (m *managerImpl) GetRegisteredNode(_ context.Context, clusterName string, n
 	return registeredNode, nil
 }
 
-func (m *managerImpl) ListRegisterNodes(_ context.Context, clusterName string) ([]metadata.RegisteredNode, error) {
+func (m *managerImpl) ListRegisteredNodes(_ context.Context, clusterName string) ([]metadata.RegisteredNode, error) {
 	cluster, err := m.getCluster(clusterName)
 	if err != nil {
 		return []metadata.RegisteredNode{}, errors.WithMessage(err, "get cluster")

--- a/server/cluster/manager_test.go
+++ b/server/cluster/manager_test.go
@@ -91,7 +91,7 @@ func testGetNodeAndShard(ctx context.Context, re *require.Assertions, manager cl
 	c, err := manager.GetCluster(ctx, clusterName)
 	re.NoError(err)
 
-	nodes, err := manager.ListRegisterNodes(ctx, cluster1)
+	nodes, err := manager.ListRegisteredNodes(ctx, cluster1)
 	re.NoError(err)
 	re.Equal(2, len(nodes))
 

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -375,6 +375,10 @@ func (c *ClusterMetadata) CreateTable(ctx context.Context, request CreateTableRe
 	return ret, nil
 }
 
+func (c *ClusterMetadata) GetShards() []storage.ShardID {
+	return c.topologyManager.GetShards()
+}
+
 func (c *ClusterMetadata) GetShardNodesByShardID(id storage.ShardID) ([]storage.ShardNode, error) {
 	return c.topologyManager.GetShardNodesByID(id)
 }

--- a/server/cluster/metadata/topology_manager.go
+++ b/server/cluster/metadata/topology_manager.go
@@ -29,6 +29,8 @@ type TopologyManager interface {
 	RemoveTable(ctx context.Context, shardID storage.ShardID, tableIDs []storage.TableID) (ShardVersionUpdate, error)
 	// EvictTable evict table from cluster topology.
 	EvictTable(ctx context.Context, tableID storage.TableID) ([]ShardVersionUpdate, error)
+	// GetShards get all shards in cluster topology.
+	GetShards() []storage.ShardID
 	// GetShardNodesByID get shardNodes with shardID.
 	GetShardNodesByID(shardID storage.ShardID) ([]storage.ShardNode, error)
 	// GetShardNodesByTableIDs get shardNodes with tableIDs.
@@ -343,6 +345,18 @@ func (m *TopologyManagerImpl) EvictTable(ctx context.Context, tableID storage.Ta
 	}
 
 	return result, nil
+}
+
+func (m *TopologyManagerImpl) GetShards() []storage.ShardID {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	shards := make([]storage.ShardID, 0, len(m.shardViews))
+	for _, shardView := range m.shardViews {
+		shards = append(shards, shardView.ShardID)
+	}
+
+	return shards
 }
 
 func (m *TopologyManagerImpl) GetShardNodesByID(shardID storage.ShardID) ([]storage.ShardNode, error) {

--- a/server/service/http/types.go
+++ b/server/service/http/types.go
@@ -69,7 +69,7 @@ type DiagnoseShardStatus struct {
 
 type DiagnoseShardResult struct {
 	// shardID -> nodeName
-	UnregisteredShards map[storage.ShardID]string              `json:"unregistered_shards"`
+	UnregisteredShards []storage.ShardID                       `json:"unregistered_shards"`
 	UnreadyShards      map[storage.ShardID]DiagnoseShardStatus `json:"unready_shards"`
 }
 


### PR DESCRIPTION
## Rationale
When a shard is not open on a node, the diagnose api returns incorrect information.

## Detailed Changes
Modify the method of obtaining shards to no longer retrieve all shard information from the `nodeshards`.

## Test Plan
Manual test and CI.