### PR TITLE
feat: add deploy mode

### DIFF
--- a/server/coordinator/scheduler/error.go
+++ b/server/coordinator/scheduler/error.go
@@ -1,0 +1,9 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+package scheduler
+
+import "github.com/CeresDB/ceresmeta/pkg/coderr"
+
+var (
+	ErrInvalidTopologyType = coderr.NewCodeError(coderr.Internal, "invalid topology type")
+)

--- a/server/coordinator/scheduler/error.go
+++ b/server/coordinator/scheduler/error.go
@@ -4,6 +4,4 @@ package scheduler
 
 import "github.com/CeresDB/ceresmeta/pkg/coderr"
 
-var (
-	ErrInvalidTopologyType = coderr.NewCodeError(coderr.Internal, "invalid topology type")
-)
+var ErrInvalidTopologyType = coderr.NewCodeError(coderr.Internal, "invalid topology type")

--- a/server/coordinator/scheduler/reopen_shard_scheduler.go
+++ b/server/coordinator/scheduler/reopen_shard_scheduler.go
@@ -27,6 +27,10 @@ func NewReopenShardScheduler(factory *coordinator.Factory, procedureExecutingBat
 	}
 }
 
+func (r ReopenShardScheduler) UpdateDeployMode(_ context.Context, _ bool) {
+	// ReopenShardScheduler do not need deployMode.
+}
+
 func (r ReopenShardScheduler) Schedule(ctx context.Context, clusterSnapshot metadata.Snapshot) (ScheduleResult, error) {
 	// ReopenShardScheduler can only be scheduled when the cluster is stable.
 	if !clusterSnapshot.Topology.IsStable() {

--- a/server/coordinator/scheduler/scheduler.go
+++ b/server/coordinator/scheduler/scheduler.go
@@ -18,4 +18,8 @@ type ScheduleResult struct {
 type Scheduler interface {
 	// Schedule will generate procedure based on current cluster snapshot, which will be submitted to ProcedureManager, and whether it is actually executed depends on the current state of ProcedureManager.
 	Schedule(ctx context.Context, clusterSnapshot metadata.Snapshot) (ScheduleResult, error)
+
+	// UpdateDeployMode is used to update deployMode for scheduler,
+	// DeployMode means that the cluster topology is locked and the mapping between shards and nodes cannot be changed.
+	UpdateDeployMode(ctx context.Context, enable bool)
 }

--- a/server/coordinator/scheduler/scheduler_manager.go
+++ b/server/coordinator/scheduler/scheduler_manager.go
@@ -30,8 +30,6 @@ const (
 type Manager interface {
 	ListScheduler() []Scheduler
 
-	GetScheduler() Scheduler
-
 	Start(ctx context.Context) error
 
 	Stop(ctx context.Context) error
@@ -222,11 +220,6 @@ func (m *ManagerImpl) ListScheduler() []Scheduler {
 	defer m.lock.RUnlock()
 
 	return m.registerSchedulers
-}
-
-func (m *ManagerImpl) GetScheduler() Scheduler {
-	//TODO implement me
-	panic("implement me")
 }
 
 func (m *ManagerImpl) Scheduler(ctx context.Context, clusterSnapshot metadata.Snapshot) []ScheduleResult {

--- a/server/coordinator/scheduler/static_topology_shard_scheduler.go
+++ b/server/coordinator/scheduler/static_topology_shard_scheduler.go
@@ -25,6 +25,10 @@ func NewStaticTopologyShardScheduler(factory *coordinator.Factory, nodePicker co
 	return StaticTopologyShardScheduler{factory: factory, nodePicker: nodePicker, procedureExecutingBatchSize: procedureExecutingBatchSize}
 }
 
+func (s StaticTopologyShardScheduler) UpdateDeployMode(_ context.Context, _ bool) {
+	// StaticTopologyShardScheduler do not need deployMode.
+}
+
 func (s StaticTopologyShardScheduler) Schedule(ctx context.Context, clusterSnapshot metadata.Snapshot) (ScheduleResult, error) {
 	var procedures []procedure.Procedure
 	var reasons strings.Builder

--- a/server/service/http/error.go
+++ b/server/service/http/error.go
@@ -18,6 +18,8 @@ var (
 	ErrHealthCheck       = coderr.NewCodeError(coderr.Internal, "server health check")
 	ErrParseTopology     = coderr.NewCodeError(coderr.Internal, "parse topology type")
 	ErrUpdateFlowLimiter = coderr.NewCodeError(coderr.Internal, "update flow limiter")
+	ErrGetDeployMode     = coderr.NewCodeError(coderr.Internal, "get deploy mode")
+	ErrUpdateDeployMode  = coderr.NewCodeError(coderr.Internal, "update deploy mode")
 	ErrAddLearner        = coderr.NewCodeError(coderr.Internal, "add member as learner")
 	ErrListMembers       = coderr.NewCodeError(coderr.Internal, "get member list")
 	ErrRemoveMembers     = coderr.NewCodeError(coderr.Internal, "remove member")

--- a/server/service/http/types.go
+++ b/server/service/http/types.go
@@ -137,3 +137,7 @@ type UpdateFlowLimiterRequest struct {
 	Burst  int  `json:"burst"`
 	Enable bool `json:"enable"`
 }
+
+type UpdateDeployModeRequest struct {
+	Enable bool `json:"enable"`
+}


### PR DESCRIPTION
## Rationale
In the current implementation, every time the CeresDB node changes, it will cause large-scale scheduling in the cluster. However, in the actual situation, we hope to control the affected range of the cluster when deploy and debug. Therefore, we need to add a deploy mode switch to control cluster scheduling.

## Detailed Changes
* Add `DeployMode` switch in `RebalancedShardScheduler`, shard topology will be locked when deploy mode is true.
* Add some API to control `DeployMode`.

## Test Plan
Pass all unit tests and test `DeployMode` take effect locally.