### PR TITLE
feat: add least table shard picker

### DIFF
--- a/server/coordinator/factory.go
+++ b/server/coordinator/factory.go
@@ -91,7 +91,7 @@ func NewFactory(allocator id.Allocator, dispatch eventdispatch.Dispatch, storage
 		idAllocator: allocator,
 		dispatch:    dispatch,
 		storage:     storage,
-		shardPicker: NewRandomBalancedShardPicker(),
+		shardPicker: NewLeastTableShardPicker(),
 	}
 }
 

--- a/server/coordinator/procedure/ddl/createpartitiontable/create_partition_table_test.go
+++ b/server/coordinator/procedure/ddl/createpartitiontable/create_partition_table_test.go
@@ -35,7 +35,7 @@ func TestCreatePartitionTable(t *testing.T) {
 		Name:       test.TestTableName0,
 	}
 
-	shardPicker := coordinator.NewRandomBalancedShardPicker()
+	shardPicker := coordinator.NewLeastTableShardPicker()
 	subTableShards, err := shardPicker.PickShards(ctx, c.GetMetadata().GetClusterSnapshot(), len(request.GetPartitionTableInfo().SubTableNames))
 
 	shardNodesWithVersion := make([]metadata.ShardNodeWithVersion, 0, len(subTableShards))

--- a/server/coordinator/procedure/ddl/droppartitiontable/create_drop_partition_table_test.go
+++ b/server/coordinator/procedure/ddl/droppartitiontable/create_drop_partition_table_test.go
@@ -30,7 +30,7 @@ func TestCreateAndDropPartitionTable(t *testing.T) {
 
 	shardNode := c.GetMetadata().GetClusterSnapshot().Topology.ClusterView.ShardNodes[0]
 
-	shardPicker := coordinator.NewRandomBalancedShardPicker()
+	shardPicker := coordinator.NewLeastTableShardPicker()
 
 	testTableNum := 8
 	testSubTableNum := 4

--- a/server/coordinator/shard_picker.go
+++ b/server/coordinator/shard_picker.go
@@ -4,8 +4,6 @@ package coordinator
 
 import (
 	"context"
-	"crypto/rand"
-	"math/big"
 	"sort"
 
 	"github.com/CeresDB/ceresmeta/server/cluster/metadata"
@@ -20,96 +18,15 @@ type ShardPicker interface {
 	PickShards(ctx context.Context, snapshot metadata.Snapshot, expectShardNum int) ([]storage.ShardNode, error)
 }
 
-// RandomBalancedShardPicker randomly pick up shards that are not on the same node in the current cluster.
-type RandomBalancedShardPicker struct{}
-
-func NewRandomBalancedShardPicker() ShardPicker {
-	return &RandomBalancedShardPicker{}
-}
-
-// PickShards will pick a specified number of shards as expectShardNum.
-func (p *RandomBalancedShardPicker) PickShards(_ context.Context, snapshot metadata.Snapshot, expectShardNum int) ([]storage.ShardNode, error) {
-	if len(snapshot.Topology.ClusterView.ShardNodes) == 0 {
-		return nil, errors.WithMessage(ErrNodeNumberNotEnough, "no shard is assigned")
-	}
-
-	shardNodes := snapshot.Topology.ClusterView.ShardNodes
-
-	nodeShardsMapping := make(map[string][]storage.ShardNode, 0)
-	for _, shardNode := range shardNodes {
-		_, exists := nodeShardsMapping[shardNode.NodeName]
-		if !exists {
-			nodeShardsMapping[shardNode.NodeName] = []storage.ShardNode{}
-		}
-		nodeShardsMapping[shardNode.NodeName] = append(nodeShardsMapping[shardNode.NodeName], shardNode)
-	}
-
-	// Try to make shards on different nodes.
-	result := make([]storage.ShardNode, 0, expectShardNum)
-	nodeNames := make([]string, 0, len(nodeShardsMapping))
-	tempNodeShardMapping := copyNodeShardMapping(nodeShardsMapping)
-
-	for i := 0; i < expectShardNum; i++ {
-		// Initialize nodeNames.
-		if len(nodeNames) == 0 {
-			for nodeName := range nodeShardsMapping {
-				nodeNames = append(nodeNames, nodeName)
-			}
-		}
-
-		// Get random node.
-		selectNodeIndex, err := rand.Int(rand.Reader, big.NewInt(int64(len(nodeNames))))
-		if err != nil {
-			return nil, errors.WithMessage(err, "generate random node index")
-		}
-		nodeShards := tempNodeShardMapping[nodeNames[selectNodeIndex.Int64()]]
-
-		// When node shards is empty, copy from nodeShardsMapping and get shards again.
-		if len(nodeShards) == 0 {
-			tempNodeShardMapping = copyNodeShardMapping(nodeShardsMapping)
-
-			nodeShards = tempNodeShardMapping[nodeNames[selectNodeIndex.Int64()]]
-		}
-
-		// Get random shard.
-		selectNodeShardsIndex, err := rand.Int(rand.Reader, big.NewInt(int64(len(nodeShards))))
-		if err != nil {
-			return nil, errors.WithMessage(err, "generate random node shard index")
-		}
-
-		result = append(result, nodeShards[selectNodeShardsIndex.Int64()])
-
-		// Remove select shard.
-		nodeShards[selectNodeShardsIndex.Int64()] = nodeShards[len(nodeShards)-1]
-		tempNodeShardMapping[nodeNames[selectNodeIndex.Int64()]] = nodeShards[:len(nodeShards)-1]
-
-		// Remove select node.
-		nodeNames[selectNodeIndex.Int64()] = nodeNames[len(nodeNames)-1]
-		nodeNames = nodeNames[:len(nodeNames)-1]
-	}
-
-	return result, nil
-}
-
-func copyNodeShardMapping(nodeShardsMapping map[string][]storage.ShardNode) map[string][]storage.ShardNode {
-	tempNodeShardMapping := make(map[string][]storage.ShardNode, len(nodeShardsMapping))
-	for nodeName, shardNode := range nodeShardsMapping {
-		tempShardNode := make([]storage.ShardNode, len(shardNode))
-		copy(tempShardNode, shardNode)
-		tempNodeShardMapping[nodeName] = tempShardNode
-	}
-	return tempNodeShardMapping
-}
-
 // LeastTableShardPicker selects shards based on the number of tables on the current shard,
 // and always selects the shard with the smallest number of current tables.
-type LeastTableShardPicker struct{}
+type leastTableShardPicker struct{}
 
 func NewLeastTableShardPicker() ShardPicker {
-	return &LeastTableShardPicker{}
+	return &leastTableShardPicker{}
 }
 
-func (l LeastTableShardPicker) PickShards(_ context.Context, snapshot metadata.Snapshot, expectShardNum int) ([]storage.ShardNode, error) {
+func (l leastTableShardPicker) PickShards(_ context.Context, snapshot metadata.Snapshot, expectShardNum int) ([]storage.ShardNode, error) {
 	shardNodeMapping := make(map[storage.ShardID]storage.ShardNode, len(snapshot.Topology.ShardViewsMapping))
 	for _, shardNode := range snapshot.Topology.ClusterView.ShardNodes {
 		shardNodeMapping[shardNode.ID] = shardNode
@@ -121,42 +38,21 @@ func (l LeastTableShardPicker) PickShards(_ context.Context, snapshot metadata.S
 
 	result := make([]storage.ShardNode, 0, expectShardNum)
 
-	shardTableNumberMapping := make(map[storage.ShardID]int, len(snapshot.Topology.ShardViewsMapping))
-	for shardID, shardView := range snapshot.Topology.ShardViewsMapping {
-		shardTableNumberMapping[shardID] = len(shardView.TableIDs)
+	ShardIDs := make([]storage.ShardID, 0, len(snapshot.Topology.ShardViewsMapping))
+	for shardID := range snapshot.Topology.ShardViewsMapping {
+		ShardIDs = append(ShardIDs, shardID)
 	}
 
-	var sortedMapping []Pair
+	// sort shard by table number,
+	// the shard with the smallest number of tables is at the front of the array.
+	sort.SliceStable(ShardIDs, func(i, j int) bool {
+		return len(snapshot.Topology.ShardViewsMapping[storage.ShardID(i)].TableIDs) < len(snapshot.Topology.ShardViewsMapping[storage.ShardID(j)].TableIDs)
+	})
+
 	for i := 0; i < expectShardNum; i++ {
-		if i%len(shardTableNumberMapping) == 0 {
-			sortedMapping = sortByTableNumber(shardTableNumberMapping)
-		}
-
-		selectShard := sortedMapping[i%len(shardTableNumberMapping)]
-		shardTableNumberMapping[selectShard.shardID]++
-
-		result = append(result, shardNodeMapping[selectShard.shardID])
+		selectShardID := ShardIDs[i%len(ShardIDs)]
+		result = append(result, shardNodeMapping[selectShardID])
 	}
 
 	return result, nil
-}
-
-type Pair struct {
-	shardID     storage.ShardID
-	tableNumber int
-}
-
-// sortByTableNumber sort shard by table number,
-// the shard with the smallest number of tables is at the front of the array.
-func sortByTableNumber(shardTableNumberMapping map[storage.ShardID]int) []Pair {
-	vec := make([]Pair, 0, len(shardTableNumberMapping))
-	for shardID, tableNumber := range shardTableNumberMapping {
-		vec = append(vec, Pair{shardID: shardID, tableNumber: tableNumber})
-	}
-
-	sort.Slice(vec, func(i, j int) bool {
-		return vec[i].tableNumber < vec[j].tableNumber
-	})
-
-	return vec
 }

--- a/server/coordinator/shard_picker.go
+++ b/server/coordinator/shard_picker.go
@@ -46,7 +46,7 @@ func (l leastTableShardPicker) PickShards(_ context.Context, snapshot metadata.S
 	// sort shard by table number,
 	// the shard with the smallest number of tables is at the front of the array.
 	sort.SliceStable(ShardIDs, func(i, j int) bool {
-		return len(snapshot.Topology.ShardViewsMapping[storage.ShardID(i)].TableIDs) < len(snapshot.Topology.ShardViewsMapping[storage.ShardID(j)].TableIDs)
+		return len(snapshot.Topology.ShardViewsMapping[ShardIDs[i]].TableIDs) < len(snapshot.Topology.ShardViewsMapping[ShardIDs[j]].TableIDs)
 	})
 
 	for i := 0; i < expectShardNum; i++ {

--- a/server/coordinator/shard_picker_test.go
+++ b/server/coordinator/shard_picker_test.go
@@ -58,4 +58,17 @@ func TestLeastTableShardPicker(t *testing.T) {
 	for _, shardNode := range shardNodes {
 		re.NotEqual(shardNode.ID, 0)
 	}
+
+	// drop shard node 1, shard 1 should not be picked.
+	for _, shardNode := range snapshot.Topology.ClusterView.ShardNodes {
+		if shardNode.ID == 1 {
+			err = c.GetMetadata().DropShardNode(ctx, []storage.ShardNode{shardNode})
+			re.NoError(err)
+		}
+	}
+	shardNodes, err = shardPicker.PickShards(ctx, snapshot, 8)
+	re.NoError(err)
+	for _, shardNode := range shardNodes {
+		re.NotEqual(shardNode.ID, 1)
+	}
 }

--- a/server/coordinator/shard_picker_test.go
+++ b/server/coordinator/shard_picker_test.go
@@ -13,31 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRandomShardPicker(t *testing.T) {
-	re := require.New(t)
-	ctx := context.Background()
-
-	c := test.InitStableCluster(ctx, t)
-	snapshot := c.GetMetadata().GetClusterSnapshot()
-
-	shardPicker := coordinator.NewRandomBalancedShardPicker()
-
-	shardNodes, err := shardPicker.PickShards(ctx, snapshot, 3)
-	re.NoError(err)
-	re.Equal(len(shardNodes), 3)
-	shardNodes, err = shardPicker.PickShards(ctx, snapshot, 4)
-	re.NoError(err)
-	re.Equal(len(shardNodes), 4)
-	// ExpectShardNum is bigger than shard number.
-	shardNodes, err = shardPicker.PickShards(ctx, snapshot, 5)
-	re.NoError(err)
-	re.Equal(len(shardNodes), 5)
-	// TODO: Ensure that the shardNodes is average distributed on nodes and shards.
-	shardNodes, err = shardPicker.PickShards(ctx, snapshot, 9)
-	re.NoError(err)
-	re.Equal(len(shardNodes), 9)
-}
-
 func TestLeastTableShardPicker(t *testing.T) {
 	re := require.New(t)
 	ctx := context.Background()

--- a/server/coordinator/shard_picker_test.go
+++ b/server/coordinator/shard_picker_test.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/CeresDB/ceresmeta/server/cluster/metadata"
 	"github.com/CeresDB/ceresmeta/server/coordinator"
 	"github.com/CeresDB/ceresmeta/server/coordinator/procedure/test"
+	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,4 +36,51 @@ func TestRandomShardPicker(t *testing.T) {
 	shardNodes, err = shardPicker.PickShards(ctx, snapshot, 9)
 	re.NoError(err)
 	re.Equal(len(shardNodes), 9)
+}
+
+func TestLeastTableShardPicker(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+
+	c := test.InitStableCluster(ctx, t)
+	snapshot := c.GetMetadata().GetClusterSnapshot()
+
+	shardPicker := coordinator.NewLeastTableShardPicker()
+
+	shardNodes, err := shardPicker.PickShards(ctx, snapshot, 4)
+	re.NoError(err)
+	re.Equal(len(shardNodes), 4)
+	// Each shardNode should be different shard.
+	shardIDs := map[storage.ShardID]struct{}{}
+	for _, shardNode := range shardNodes {
+		shardIDs[shardNode.ID] = struct{}{}
+	}
+	re.Equal(len(shardIDs), 4)
+
+	shardNodes, err = shardPicker.PickShards(ctx, snapshot, 7)
+	re.NoError(err)
+	re.Equal(len(shardNodes), 7)
+	// Each shardNode should be different shard.
+	shardIDs = map[storage.ShardID]struct{}{}
+	for _, shardNode := range shardNodes {
+		shardIDs[shardNode.ID] = struct{}{}
+	}
+	re.Equal(len(shardIDs), 4)
+
+	// Create table on shard 0.
+	_, err = c.GetMetadata().CreateTable(ctx, metadata.CreateTableRequest{
+		ShardID:       0,
+		SchemaName:    test.TestSchemaName,
+		TableName:     "test",
+		PartitionInfo: storage.PartitionInfo{},
+	})
+	re.NoError(err)
+
+	// shard 0 should not exist in pick result.
+	shardNodes, err = shardPicker.PickShards(ctx, snapshot, 3)
+	re.NoError(err)
+	re.Equal(len(shardNodes), 3)
+	for _, shardNode := range shardNodes {
+		re.NotEqual(shardNode.ID, 0)
+	}
 }


### PR DESCRIPTION
## Rationale
Currently, we use a completely random method to select shards for tables, which will lead to uneven distribution of tables in the cluster when the number of tables is small. In order to solve this problem, a new shardPicker is implemented, which selects the shard with the smallest number of current tables each time to create a table.

## Detailed Changes
* Add `NewLeastTableShardPicker`, which selects the shard with the smallest number of current tables each time to create a table.


## Test Plan
* Pass all unit tests and manually create tables for verification in the local environment.