### PR TITLE
chore: use clusters in api endpoint

### DIFF
--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -60,8 +60,6 @@ func (a *API) NewAPIRouter() *Router {
 	router.Post(fmt.Sprintf("/clusters/:%s/shardAffinities", clusterNameParam), wrap(a.addShardAffinities, true, a.forwardClient))
 	router.Del(fmt.Sprintf("/clusters/:%s/shardAffinities", clusterNameParam), wrap(a.removeShardAffinities, true, a.forwardClient))
 	router.Post("/table/query", wrap(a.queryTable, true, a.forwardClient))
-	router.Get(fmt.Sprintf("/clusters/:%s/deployMode", clusterNameParam), wrap(a.getDeployMode, true, a.forwardClient))
-	router.Put(fmt.Sprintf("/clusters/:%s/deployMode", clusterNameParam), wrap(a.updateDeployMode, true, a.forwardClient))
 
 	// Register debug API.
 	router.GetWithoutPrefix("/debug/pprof/profile", pprof.Profile)
@@ -74,6 +72,8 @@ func (a *API) NewAPIRouter() *Router {
 	router.GetWithoutPrefix("/debug/pprof/threadCreate", a.pprofThreadcreate)
 	router.GetWithoutPrefix(fmt.Sprintf("/debug/diagnose/:%s/shards", clusterNameParam), wrap(a.diagnoseShards, true, a.forwardClient))
 	router.GetWithoutPrefix("/debug/leader", wrap(a.getLeader, false, a.forwardClient))
+	router.GetWithoutPrefix(fmt.Sprintf("/clusters/:%s/deployMode", clusterNameParam), wrap(a.getDeployMode, true, a.forwardClient))
+	router.PutWithoutPrefix(fmt.Sprintf("/clusters/:%s/deployMode", clusterNameParam), wrap(a.updateDeployMode, true, a.forwardClient))
 
 	// Register ETCD API.
 	router.Post("/etcd/promoteLearner", wrap(a.etcdAPI.promoteLearner, false, a.forwardClient))

--- a/server/service/http/api.go
+++ b/server/service/http/api.go
@@ -53,15 +53,15 @@ func (a *API) NewAPIRouter() *Router {
 
 	// Register cluster API.
 	router.Get("/clusters", wrap(a.listClusters, true, a.forwardClient))
-	router.Post("/cluster", wrap(a.createCluster, true, a.forwardClient))
-	router.Put(fmt.Sprintf("/cluster/:%s", clusterNameParam), wrap(a.updateCluster, true, a.forwardClient))
-	router.Get(fmt.Sprintf("/cluster/:%s/procedure", clusterNameParam), wrap(a.listProcedures, true, a.forwardClient))
-	router.Get(fmt.Sprintf("/cluster/:%s/shardAffinities", clusterNameParam), wrap(a.listShardAffinities, true, a.forwardClient))
-	router.Post(fmt.Sprintf("/cluster/:%s/shardAffinities", clusterNameParam), wrap(a.addShardAffinities, true, a.forwardClient))
-	router.Del(fmt.Sprintf("/cluster/:%s/shardAffinities", clusterNameParam), wrap(a.removeShardAffinities, true, a.forwardClient))
+	router.Post("/clusters", wrap(a.createCluster, true, a.forwardClient))
+	router.Put(fmt.Sprintf("/clusters/:%s", clusterNameParam), wrap(a.updateCluster, true, a.forwardClient))
+	router.Get(fmt.Sprintf("/clusters/:%s/procedure", clusterNameParam), wrap(a.listProcedures, true, a.forwardClient))
+	router.Get(fmt.Sprintf("/clusters/:%s/shardAffinities", clusterNameParam), wrap(a.listShardAffinities, true, a.forwardClient))
+	router.Post(fmt.Sprintf("/clusters/:%s/shardAffinities", clusterNameParam), wrap(a.addShardAffinities, true, a.forwardClient))
+	router.Del(fmt.Sprintf("/clusters/:%s/shardAffinities", clusterNameParam), wrap(a.removeShardAffinities, true, a.forwardClient))
 	router.Post("/table/query", wrap(a.queryTable, true, a.forwardClient))
-	router.Get(fmt.Sprintf("/cluster/:%s/deployMode", clusterNameParam), wrap(a.getDeployMode, true, a.forwardClient))
-	router.Put(fmt.Sprintf("/cluster/:%s/deployMode", clusterNameParam), wrap(a.updateDeployMode, true, a.forwardClient))
+	router.Get(fmt.Sprintf("/clusters/:%s/deployMode", clusterNameParam), wrap(a.getDeployMode, true, a.forwardClient))
+	router.Put(fmt.Sprintf("/clusters/:%s/deployMode", clusterNameParam), wrap(a.updateDeployMode, true, a.forwardClient))
 
 	// Register debug API.
 	router.GetWithoutPrefix("/debug/pprof/profile", pprof.Profile)

--- a/server/service/http/route.go
+++ b/server/service/http/route.go
@@ -73,6 +73,11 @@ func (r *Router) Put(path string, h http.HandlerFunc) {
 	r.rtr.PUT(r.prefix+path, r.handle(path, h))
 }
 
+// PutWithoutPrefix registers a new PUT route without prefix.
+func (r *Router) PutWithoutPrefix(path string, h http.HandlerFunc) {
+	r.rtr.PUT(path, r.handle(path, h))
+}
+
 // Post registers a new POST route.
 func (r *Router) Post(path string, h http.HandlerFunc) {
 	r.rtr.POST(r.prefix+path, r.handle(path, h))


### PR DESCRIPTION
## Rationale

> There’s no rule on keeping the resource nouns singular or plural, though it is advisable to keep collections plural.

- https://swagger.io/resources/articles/best-practices-in-api-design/

## Detailed Changes


## Test Plan
No need.

