### PR TITLE
fix: logger panic

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -38,7 +38,7 @@ func NewCluster(logger *zap.Logger, metadata *metadata.ClusterMetadata, client *
 		return nil, errors.WithMessage(err, "create procedure manager")
 	}
 	dispatch := eventdispatch.NewDispatchImpl()
-	procedureFactory := coordinator.NewFactory(id.NewAllocatorImpl(logger, client, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage)
+	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage)
 
 	schedulerManager := manager.NewManager(logger, procedureManager, procedureFactory, metadata, client, rootPath, metadata.GetEnableSchedule(), metadata.GetTopologyType(), metadata.GetProcedureExecutingBatchSize())
 

--- a/server/coordinator/factory.go
+++ b/server/coordinator/factory.go
@@ -22,7 +22,7 @@ import (
 )
 
 type Factory struct {
-	logger      zap.Logger
+	logger      *zap.Logger
 	idAllocator id.Allocator
 	dispatch    eventdispatch.Dispatch
 	storage     procedure.Storage
@@ -86,11 +86,12 @@ type BatchRequest struct {
 	BatchType procedure.Typ
 }
 
-func NewFactory(allocator id.Allocator, dispatch eventdispatch.Dispatch, storage procedure.Storage) *Factory {
+func NewFactory(logger *zap.Logger, allocator id.Allocator, dispatch eventdispatch.Dispatch, storage procedure.Storage) *Factory {
 	return &Factory{
 		idAllocator: allocator,
 		dispatch:    dispatch,
 		storage:     storage,
+		logger:      logger,
 		shardPicker: NewLeastTableShardPicker(),
 	}
 }

--- a/server/coordinator/factory_test.go
+++ b/server/coordinator/factory_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/CeresDB/ceresmeta/server/coordinator/procedure"
 	"github.com/CeresDB/ceresmeta/server/coordinator/procedure/test"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func setupFactory(t *testing.T) (*coordinator.Factory, *metadata.ClusterMetadata) {
@@ -21,7 +22,7 @@ func setupFactory(t *testing.T) (*coordinator.Factory, *metadata.ClusterMetadata
 	dispatch := test.MockDispatch{}
 	allocator := test.MockIDAllocator{}
 	storage := test.NewTestStorage(t)
-	f := coordinator.NewFactory(allocator, dispatch, storage)
+	f := coordinator.NewFactory(zap.NewNop(), allocator, dispatch, storage)
 
 	return f, c.GetMetadata()
 }

--- a/server/coordinator/scheduler/manager/scheduler_manager_test.go
+++ b/server/coordinator/scheduler/manager/scheduler_manager_test.go
@@ -27,7 +27,7 @@ func TestSchedulerManager(t *testing.T) {
 	dispatch := test.MockDispatch{}
 	allocator := test.MockIDAllocator{}
 	s := test.NewTestStorage(t)
-	f := coordinator.NewFactory(allocator, dispatch, s)
+	f := coordinator.NewFactory(zap.NewNop(), allocator, dispatch, s)
 	_, client, _ := etcdutil.PrepareEtcdServerAndClient(t)
 
 	// Create scheduler manager with enableScheduler equal to false.

--- a/server/coordinator/scheduler/rebalanced/scheduler_test.go
+++ b/server/coordinator/scheduler/rebalanced/scheduler_test.go
@@ -18,7 +18,7 @@ func TestRebalancedScheduler(t *testing.T) {
 	re := require.New(t)
 	ctx := context.Background()
 
-	procedureFactory := coordinator.NewFactory(test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t))
+	procedureFactory := coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t))
 
 	s := rebalanced.NewShardScheduler(zap.NewNop(), procedureFactory, nodepicker.NewConsistentUniformHashNodePicker(zap.NewNop()), 1)
 

--- a/server/coordinator/scheduler/reopen/scheduler_test.go
+++ b/server/coordinator/scheduler/reopen/scheduler_test.go
@@ -12,13 +12,14 @@ import (
 	"github.com/CeresDB/ceresmeta/server/coordinator/scheduler/reopen"
 	"github.com/CeresDB/ceresmeta/server/storage"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestReopenShardScheduler(t *testing.T) {
 	re := require.New(t)
 	ctx := context.Background()
 
-	procedureFactory := coordinator.NewFactory(test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t))
+	procedureFactory := coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t))
 
 	s := reopen.NewShardScheduler(procedureFactory, 1)
 

--- a/server/coordinator/scheduler/static/scheduler_test.go
+++ b/server/coordinator/scheduler/static/scheduler_test.go
@@ -18,7 +18,7 @@ func TestStaticTopologyScheduler(t *testing.T) {
 	re := require.New(t)
 	ctx := context.Background()
 
-	procedureFactory := coordinator.NewFactory(test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t))
+	procedureFactory := coordinator.NewFactory(zap.NewNop(), test.MockIDAllocator{}, test.MockDispatch{}, test.NewTestStorage(t))
 
 	s := static.NewShardScheduler(procedureFactory, nodepicker.NewConsistentUniformHashNodePicker(zap.NewNop()), 1)
 


### PR DESCRIPTION
## Rationale
Fix panic caused by missing logger.

## Detailed Changes
* Add `logger` in NewFactory.

## Test Plan
Pass all unit tests and integration test.