### PR TITLE
feat: support MaxOpsPerTxn for operate etcd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.0
 	gotest.tools/gotestsum v1.8.1
+	go.etcd.io/etcd/client/pkg/v3 v3.5.4
 )
 
 require (
@@ -74,7 +75,6 @@ require (
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
-	go.etcd.io/etcd/client/pkg/v3 v3.5.4 // indirect
 	go.etcd.io/etcd/client/v2 v2.305.4 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.5.4 // indirect
 	go.etcd.io/etcd/raft/v3 v3.5.4 // indirect

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -231,7 +231,7 @@ func (c *ClusterMetadata) MigrateTable(ctx context.Context, request MigrateTable
 
 		if !exists {
 			c.logger.Error("the table to be closed does not exist", zap.String("schemaName", request.SchemaName), zap.String("tableName", tableName))
-			return errors.WithMessagef(ErrTableNotFound, "table not exists, shcemaName:%s,tableName:%s", request.SchemaName, tableName)
+			return errors.WithMessagef(ErrTableNotFound, "table not exists, schemaName:%s, tableName:%s", request.SchemaName, tableName)
 		}
 
 		tables = append(tables, table)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -29,7 +29,7 @@ const (
 	defaultEnableLimiter          bool  = false
 	defaultEtcdStartTimeoutMs     int64 = 60 * 1000
 	defaultCallTimeoutMs                = 5 * 1000
-	defaultMaxTxnOps                    = 128
+	defaultEtcdMaxTxnOps                = 128
 	defaultEtcdLeaseTTLSec              = 10
 
 	defaultGrpcHandleTimeoutMs int = 60 * 1000
@@ -58,6 +58,7 @@ const (
 
 	defaultMaxScanLimit    int  = 100
 	defaultMinScanLimit    int  = 20
+	defaultMaxOpsPerTxn    int  = 32
 	defaultIDAllocatorStep uint = 20
 
 	DefaultClusterName              = "defaultCluster"
@@ -140,6 +141,7 @@ type Config struct {
 	MaxRequestBytes         uint   `toml:"max-request-bytes" env:"MAX_REQUEST_BYTES"`
 	MaxScanLimit            int    `toml:"max-scan-limit" env:"MAX_SCAN_LIMIT"`
 	MinScanLimit            int    `toml:"min-scan-limit" env:"MIN_SCAN_LIMIT"`
+	MaxOpsPerTxn            int    `toml:"max-ops-per-txn" env:"MAX_OPS_PER_TXN"`
 	IDAllocatorStep         uint   `toml:"id-allocator-step" env:"ID_ALLOCATOR_STEP"`
 
 	// Following fields are the settings for the default cluster.
@@ -292,7 +294,7 @@ func MakeConfigParser() (*Parser, error) {
 
 		EtcdStartTimeoutMs: defaultEtcdStartTimeoutMs,
 		EtcdCallTimeoutMs:  defaultCallTimeoutMs,
-		EtcdMaxTxnOps:      defaultMaxTxnOps,
+		EtcdMaxTxnOps:      defaultEtcdMaxTxnOps,
 
 		GrpcHandleTimeoutMs:                    defaultGrpcHandleTimeoutMs,
 		GrpcServiceMaxSendMsgSize:              defaultGrpcServiceMaxSendMsgSize,
@@ -324,6 +326,7 @@ func MakeConfigParser() (*Parser, error) {
 		MaxRequestBytes:         defaultMaxRequestBytes,
 		MaxScanLimit:            defaultMaxScanLimit,
 		MinScanLimit:            defaultMinScanLimit,
+		MaxOpsPerTxn:            defaultMaxOpsPerTxn,
 		IDAllocatorStep:         defaultIDAllocatorStep,
 
 		DefaultClusterName:              DefaultClusterName,


### PR DESCRIPTION
## Rationale
The external etcd server may have a limit on the number of operations in a transaction. However, CeresMeta don't impose such a limit when operating etcd, and it will lead to error.

## Detailed Changes
Introduce such a limit on the number of operations in a transaction.

## Test Plan
Existing tests.