### PR TITLE
ci: catchup and simplify integrate test runner

### DIFF
--- a/scripts/run_integration_test.sh
+++ b/scripts/run_integration_test.sh
@@ -2,26 +2,13 @@
 
 set -exo
 
-INTEGRATION_TEST_PATH=/tmp/ceresmeta_integration_test
-CERESDB_INTEGRATION_PATH=${INTEGRATION_TEST_PATH}"/ceresdb/integration_tests"
-CERESMETA_INTEGRATION_TEST_PATH=${CERESDB_INTEGRATION_PATH}"/ceresmeta"
-CERESMETA_DIR_PATH=$(pwd)
+CERESMETA_BIN_PATH="$(pwd)/bin/ceresmeta-server"
+INTEGRATION_TEST_PATH=$(mktemp -d)
 
-rm -rf $INTEGRATION_TEST_PATH
-
-mkdir -p $INTEGRATION_TEST_PATH
-
-# Download CeresDB Code.
+# Download CeresDB Code
 cd $INTEGRATION_TEST_PATH
 git clone --depth 1 https://github.com/ceresdb/ceresdb.git --branch main
 
-# Make Build Meta Script Blank.
-echo > $CERESDB_INTEGRATION_PATH/build_meta.sh
-
-# Copy Meta Binary to CeresDB Execution Directory.
-cd $CERESDB_INTEGRATION_PATH
-mkdir ceresmeta
-cp $CERESMETA_DIR_PATH/bin/ceresmeta-server $CERESMETA_INTEGRATION_TEST_PATH/ceresmeta
-
-# Run integration_test.
-make run-cluster
+# Run integration_test
+cd ceresdb/integration_tests
+BIN_PATH=${CERESMETA_BIN_PATH} make run-cluster


### PR DESCRIPTION
This follows up https://github.com/CeresDB/ceresdb/pull/1287 and https://github.com/CeresDB/ceresmeta/pull/265.