### PR TITLE
refactor: correct shard version

### DIFF
--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -422,6 +422,8 @@ func (c *ClusterMetadata) RegisterNode(ctx context.Context, registeredNode Regis
 		return nil
 	}
 	if exists && !needUpdate(oldCache, registeredNode) {
+		// Check whether the shard versions need to be corrected.
+		c.maybeCorrectShardVersion(ctx, registeredNode)
 		return nil
 	}
 
@@ -751,4 +753,21 @@ L1:
 	}
 
 	return true
+}
+
+func (c *ClusterMetadata) maybeCorrectShardVersion(ctx context.Context, node RegisteredNode) {
+	topology := c.topologyManager.GetTopology()
+	for _, shardInfo := range node.ShardInfos {
+		oldShardView := topology.ShardViewsMapping[shardInfo.ID]
+		if oldShardView.Version != shardInfo.Version {
+			// Shard version in ceresMeta not equal to ceresDB, it is needed to be corrected.
+			// TODO: Maybe we need to consider whether the version is larger or smaller.
+			c.logger.Warn("shard version mismatch", zap.Uint32("shardID", uint32(shardInfo.ID)), zap.Uint64("", oldShardView.Version), zap.Uint64("nodeVersion", shardInfo.Version))
+			// Update with expect value.
+			if err := c.topologyManager.UpdateShardVersionWithExpect(ctx, shardInfo.ID, shardInfo.Version, oldShardView.Version); err != nil {
+				c.logger.Warn("update shard version with expect failed", zap.Uint32("shardID", uint32(shardInfo.ID)), zap.Uint64("expectVersion", oldShardView.Version), zap.Uint64("newVersion", shardInfo.Version))
+			}
+			// TODO: Maybe we need do some thing to ensure ceresDB status after update shard version.
+		}
+	}
 }

--- a/server/cluster/metadata/topology_manager.go
+++ b/server/cluster/metadata/topology_manager.go
@@ -577,6 +577,8 @@ func (m *TopologyManagerImpl) UpdateShardVersionWithExpect(ctx context.Context, 
 		return errors.WithMessage(err, "storage update shard view")
 	}
 
+	m.updateShardView(shardID, newShardView)
+
 	return nil
 }
 

--- a/server/cluster/metadata/topology_manager.go
+++ b/server/cluster/metadata/topology_manager.go
@@ -49,8 +49,8 @@ type TopologyManager interface {
 	GetClusterView() storage.ClusterView
 	// CreateShardViews create shardViews.
 	CreateShardViews(ctx context.Context, shardViews []CreateShardView) error
-	// UpdateShardVersion update shard version.
-	UpdateShardVersion(ctx context.Context, shardID storage.ShardID, version uint64) error
+	// UpdateShardVersionWithExpect update shard version when pre version is same as expect version.
+	UpdateShardVersionWithExpect(ctx context.Context, shardID storage.ShardID, version uint64, expect uint64) error
 	// GetTopology get current topology snapshot.
 	GetTopology() Topology
 }
@@ -559,7 +559,7 @@ func (m *TopologyManagerImpl) CreateShardViews(ctx context.Context, createShardV
 	return nil
 }
 
-func (m *TopologyManagerImpl) UpdateShardVersion(ctx context.Context, shardID storage.ShardID, version uint64) error {
+func (m *TopologyManagerImpl) UpdateShardVersionWithExpect(ctx context.Context, shardID storage.ShardID, version uint64, expect uint64) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -572,7 +572,7 @@ func (m *TopologyManagerImpl) UpdateShardVersion(ctx context.Context, shardID st
 	if err := m.storage.UpdateShardView(ctx, storage.UpdateShardViewRequest{
 		ClusterID:     m.clusterID,
 		ShardView:     newShardView,
-		LatestVersion: shardView.Version,
+		LatestVersion: expect,
 	}); err != nil {
 		return errors.WithMessage(err, "storage update shard view")
 	}

--- a/server/coordinator/procedure/operation/transferleader/batch_transfer_leader.go
+++ b/server/coordinator/procedure/operation/transferleader/batch_transfer_leader.go
@@ -97,7 +97,7 @@ func (p *BatchTransferLeaderProcedure) Start(ctx context.Context) error {
 		g.Go(func() error {
 			err := p.Start(ctx)
 			if err != nil {
-				log.Error("procedure start failed", zap.Error(err), zap.String("procedure", fmt.Sprintf("%v", p)), zap.Error(err))
+				log.Error("procedure start failed", zap.Error(err), zap.Uint64("procedureID", p.ID()), zap.Error(err))
 			}
 			return err
 		})


### PR DESCRIPTION
## Rationale
For detail, see: https://github.com/CeresDB/ceresmeta/issues/263
In this pr, add the checksum repair logic of shard version.

## Detailed Changes
* Add `MayCorrectShardVersion` in `RegisterNode`, it will correct shard version when it is inconsistent in ceresmeta and ceresdb.

## Test Plan
I created some local shard version inconsistent scenarios to verify its repair ability.