### PR TITLE
fix: fix update shard view

### DIFF
--- a/server/cluster/metadata/topology_manager.go
+++ b/server/cluster/metadata/topology_manager.go
@@ -508,7 +508,8 @@ func (m *TopologyManagerImpl) UpdateShardVersionWithExpect(ctx context.Context, 
 		return errors.WithMessage(err, "storage update shard view")
 	}
 
-	m.shardTablesMapping[shardID] = shardView
+	// Update shard view into memory.
+	m.shardTablesMapping[shardID] = &newShardView
 
 	return nil
 }


### PR DESCRIPTION
## Rationale
Fix the problem of updating `shardview` in memory that existed in the previous pr https://github.com/CeresDB/ceresmeta/pull/268.

## Detailed Changes
* Update `shardTableMapping` in memory.

## Test Plan
Pass all unit tests and integration test.