### PR TITLE
fix: procedure id path

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -53,7 +53,7 @@ func NewCluster(logger *zap.Logger, metadata *metadata.ClusterMetadata, client *
 		return nil, errors.WithMessage(err, "create procedure manager")
 	}
 	dispatch := eventdispatch.NewDispatchImpl()
-	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, getProcedureIDPath(rootPath), defaultAllocStep), dispatch, procedureStorage)
+	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, makeProcedureIDPath(rootPath), defaultAllocStep), dispatch, procedureStorage)
 
 	schedulerManager := manager.NewManager(logger, procedureManager, procedureFactory, metadata, client, rootPath, metadata.GetEnableSchedule(), metadata.GetTopologyType(), metadata.GetProcedureExecutingBatchSize())
 
@@ -110,6 +110,6 @@ func (c *Cluster) GetShardNodes() metadata.GetShardNodesResult {
 	return c.metadata.GetShardNodes()
 }
 
-func getProcedureIDPath(rootPath string) string {
+func makeProcedureIDPath(rootPath string) string {
 	return path.Join(rootPath, defaultProcedurePrefixKey)
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"context"
+	"path"
 
 	"github.com/CeresDB/ceresmeta/server/cluster/metadata"
 	"github.com/CeresDB/ceresmeta/server/coordinator"
@@ -52,7 +53,7 @@ func NewCluster(logger *zap.Logger, metadata *metadata.ClusterMetadata, client *
 		return nil, errors.WithMessage(err, "create procedure manager")
 	}
 	dispatch := eventdispatch.NewDispatchImpl()
-	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, defaultProcedurePrefixKey, defaultAllocStep), dispatch, procedureStorage)
+	procedureFactory := coordinator.NewFactory(logger, id.NewAllocatorImpl(logger, client, getProcedureIDPath(rootPath), defaultAllocStep), dispatch, procedureStorage)
 
 	schedulerManager := manager.NewManager(logger, procedureManager, procedureFactory, metadata, client, rootPath, metadata.GetEnableSchedule(), metadata.GetTopologyType(), metadata.GetProcedureExecutingBatchSize())
 
@@ -107,4 +108,8 @@ func (c *Cluster) GetShards() []storage.ShardID {
 
 func (c *Cluster) GetShardNodes() metadata.GetShardNodesResult {
 	return c.metadata.GetShardNodes()
+}
+
+func getProcedureIDPath(rootPath string) string {
+	return path.Join(rootPath, defaultProcedurePrefixKey)
 }

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	AllocClusterIDPrefix = "ClusterID"
+	allocClusterIDPrefix = "ClusterID"
 )
 
 type Manager interface {
@@ -79,7 +79,7 @@ type managerImpl struct {
 }
 
 func NewManagerImpl(storage storage.Storage, kv clientv3.KV, client *clientv3.Client, rootPath string, idAllocatorStep uint, topologyType storage.TopologyType) (Manager, error) {
-	alloc := id.NewAllocatorImpl(log.GetLogger(), kv, path.Join(rootPath, AllocClusterIDPrefix), idAllocatorStep)
+	alloc := id.NewAllocatorImpl(log.GetLogger(), kv, getClusterIDPath(rootPath), idAllocatorStep)
 
 	manager := &managerImpl{
 		lock:     sync.RWMutex{},
@@ -514,4 +514,8 @@ func (m *managerImpl) GetNodeShards(ctx context.Context, clusterName string) (me
 	}
 
 	return ret, nil
+}
+
+func getClusterIDPath(rootPath string) string {
+	return path.Join(rootPath, allocClusterIDPrefix)
 }

--- a/server/cluster/manager.go
+++ b/server/cluster/manager.go
@@ -79,7 +79,7 @@ type managerImpl struct {
 }
 
 func NewManagerImpl(storage storage.Storage, kv clientv3.KV, client *clientv3.Client, rootPath string, idAllocatorStep uint, topologyType storage.TopologyType) (Manager, error) {
-	alloc := id.NewAllocatorImpl(log.GetLogger(), kv, getClusterIDPath(rootPath), idAllocatorStep)
+	alloc := id.NewAllocatorImpl(log.GetLogger(), kv, makeClusterIDPath(rootPath), idAllocatorStep)
 
 	manager := &managerImpl{
 		lock:     sync.RWMutex{},
@@ -516,6 +516,6 @@ func (m *managerImpl) GetNodeShards(ctx context.Context, clusterName string) (me
 	return ret, nil
 }
 
-func getClusterIDPath(rootPath string) string {
+func makeClusterIDPath(rootPath string) string {
 	return path.Join(rootPath, allocClusterIDPrefix)
 }

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -58,8 +58,8 @@ type ClusterMetadata struct {
 }
 
 func NewClusterMetadata(logger *zap.Logger, meta storage.Cluster, storage storage.Storage, kv clientv3.KV, rootPath string, idAllocatorStep uint) *ClusterMetadata {
-	schemaIDAlloc := id.NewAllocatorImpl(logger, kv, getSchemaIDPath(rootPath, meta.Name), idAllocatorStep)
-	tableIDAlloc := id.NewAllocatorImpl(logger, kv, getTableIDPath(rootPath, meta.Name), idAllocatorStep)
+	schemaIDAlloc := id.NewAllocatorImpl(logger, kv, makeSchemaIDPath(rootPath, meta.Name), idAllocatorStep)
+	tableIDAlloc := id.NewAllocatorImpl(logger, kv, makeTableIDPath(rootPath, meta.Name), idAllocatorStep)
 	// FIXME: Load ShardTopology when cluster create, pass exist ShardID to allocator.
 	shardIDAlloc := id.NewReusableAllocatorImpl([]uint64{}, MinShardID)
 
@@ -787,10 +787,10 @@ func (c *ClusterMetadata) maybeCorrectShardVersion(ctx context.Context, node Reg
 	}
 }
 
-func getSchemaIDPath(rootPath, clusterName string) string {
-	return path.Join(rootPath, allocSchemaIDPrefix)
+func makeSchemaIDPath(rootPath, clusterName string) string {
+	return path.Join(rootPath, clusterName, allocSchemaIDPrefix)
 }
 
-func getTableIDPath(rootPath, clusterName string) string {
-	return path.Join(rootPath, allocTableIDPrefix)
+func makeTableIDPath(rootPath, clusterName string) string {
+	return path.Join(rootPath, clusterName, allocTableIDPrefix)
 }

--- a/server/cluster/metadata/cluster_metadata.go
+++ b/server/cluster/metadata/cluster_metadata.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	AllocSchemaIDPrefix = "SchemaID"
-	AllocTableIDPrefix  = "TableID"
+	allocSchemaIDPrefix = "SchemaID"
+	allocTableIDPrefix  = "TableID"
 )
 
 type ClusterMetadata struct {
@@ -58,8 +58,8 @@ type ClusterMetadata struct {
 }
 
 func NewClusterMetadata(logger *zap.Logger, meta storage.Cluster, storage storage.Storage, kv clientv3.KV, rootPath string, idAllocatorStep uint) *ClusterMetadata {
-	schemaIDAlloc := id.NewAllocatorImpl(logger, kv, path.Join(rootPath, meta.Name, AllocSchemaIDPrefix), idAllocatorStep)
-	tableIDAlloc := id.NewAllocatorImpl(logger, kv, path.Join(rootPath, meta.Name, AllocTableIDPrefix), idAllocatorStep)
+	schemaIDAlloc := id.NewAllocatorImpl(logger, kv, getSchemaIDPath(rootPath, meta.Name), idAllocatorStep)
+	tableIDAlloc := id.NewAllocatorImpl(logger, kv, getTableIDPath(rootPath, meta.Name), idAllocatorStep)
 	// FIXME: Load ShardTopology when cluster create, pass exist ShardID to allocator.
 	shardIDAlloc := id.NewReusableAllocatorImpl([]uint64{}, MinShardID)
 
@@ -785,4 +785,12 @@ func (c *ClusterMetadata) maybeCorrectShardVersion(ctx context.Context, node Reg
 			// TODO: Maybe we need do some thing to ensure ceresDB status after update shard version.
 		}
 	}
+}
+
+func getSchemaIDPath(rootPath, clusterName string) string {
+	return path.Join(rootPath, allocSchemaIDPrefix)
+}
+
+func getTableIDPath(rootPath, clusterName string) string {
+	return path.Join(rootPath, allocTableIDPrefix)
 }


### PR DESCRIPTION
## Rationale
The procedure ID path does not include the Ceresmeta prefix.

## Detailed Changes
Add the Ceresmeta prefix to the procedure ID path.

## Test Plan
CI.